### PR TITLE
`mfix` needs to give the monad structure to the body.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ Makefile.coq
 Makefile.coq.conf
 _CoqProject
 _CoqPath
+lib/

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -1,0 +1,14 @@
+# Coq Conventions
+
+## Naming conventions:
+
+- [python_case] for definitions
+- [CamelCase] for constructors and classes
+
+Variables:
+- [E E1 E2 F F1 F2 : Type -> Type] effect types
+- [X Y Z : Type] effect output types
+- [e : E X] effects
+- [R S : Type] return/result types ([Ret : R -> itree E R])
+- [t u : itree E R] itrees
+- [k h : R -> itree E S] itree continuations (iforests?)

--- a/lib/README.md
+++ b/lib/README.md
@@ -1,6 +1,0 @@
-# Library Dependencies
-
-This lib directory should be used for 3rd-party dependencies, each of
-which can be installed independently of Vellvm:
-
-*  lib/paco  - paco-1.2.8 [available here](http://plv.mpi-sws.org/paco/)

--- a/setup.sh
+++ b/setup.sh
@@ -1,9 +1,15 @@
 #!/usr/bin/env sh
 
-cd InteractionTrees/lib/
+cd lib/
+
+# Set up paco
 git clone https://github.com/coq-contribs/paco.git
+(cd paco; make)
+
+# Set up ExtLib
+git clone https://github.com/coq-ext-lib/coq-ext-lib.git
+(cd coq-ext-lib; make)
+
 cd ../ # at /
 
-cd src && make
-cd ../ # at /
-
+make -C src

--- a/theories/Equivalence.v
+++ b/theories/Equivalence.v
@@ -1,4 +1,5 @@
 Require Import Coq.Classes.RelationClasses.
+Require Import Coq.Setoids.Setoid.
 Require Import Coq.Relations.Relations.
 
 Require Import Paco.paco.
@@ -146,14 +147,17 @@ Hint Resolve monotone_eutt_0 : paco.
 Hint Resolve monotone_eutt_ : paco.
 Infix "~" := (@eutt _ _) (at level 80).
 
-Lemma bind_tau : forall {E R S} (t : itree E R) (f : R -> itree E S) , bind (Tau t) f = Tau (bind t f).
+
+Lemma bind_tau : forall {E R S} (t : itree E R) (f : R -> itree E S) ,
+    bind (Tau t) f = Tau (bind t f).
 Proof.
   intros E R S t f.
-  rewrite bind_def.
-  simpl. reflexivity.
+  rewrite match_itree at 1.
+  reflexivity.
 Qed.
 
 
+(*
 Lemma finite_taus_bind_inv1 : forall {E R S} (t : itree E R) (f : R -> itree E S),
     finite_taus (bind t f) -> finite_taus t.
 Proof.
@@ -175,6 +179,7 @@ Proof.
     + exists (Vis e k). split. simpl; auto. apply NoTau.
     + inversion I1.
 Qed.
+*)
 
 Lemma finite_taus_tau1: forall (E : Type -> Type) (R : Type) (t : itree E R),
     finite_taus t -> finite_taus (Tau t).
@@ -269,6 +274,7 @@ Proof.
     + inversion I.
 Qed.
 
+(*
 Lemma finite_taus_bind : forall E R S (t1 t2 : itree E R) (f : R -> itree E S),
     t1 ~ t2 -> finite_taus (bind t1 f) -> finite_taus (bind t2 f).
 Proof.
@@ -285,3 +291,4 @@ Lemma eutt_bind_hom1 : forall {E R S} (t1 t2 : itree E R) (f : R -> itree E S),
     t1 ~ t2 -> (bind t1 f) ~ (bind t2 f).
 Proof.
 Admitted.
+*)

--- a/theories/Equivalence.v
+++ b/theories/Equivalence.v
@@ -1,7 +1,8 @@
 Require Import Coq.Classes.RelationClasses.
 Require Import Coq.Relations.Relations.
-(* Require Import Eqdep. *)
+
 Require Import Paco.paco.
+Require Import ExtLib.Structures.Monad.
 
 Require Import ITree.ITree.
 

--- a/theories/Fix.v
+++ b/theories/Fix.v
@@ -7,6 +7,8 @@
 Require Import ITree.ITree.
 Require Import ITree.Effect.
 
+Require Import ExtLib.Structures.Monad.
+
 Module Type FixSig.
   Section Fix.
     (* the ambient effects *)
@@ -16,14 +18,15 @@ Module Type FixSig.
     Variable codom : dom -> Type.
 
     Definition fix_body : Type :=
-      forall m, (forall t, itree E t -> m t) ->
+      forall m, Monad m ->
+           (forall t, itree E t -> m t) ->
            (forall x : dom, m (codom x)) ->
            forall x : dom, m (codom x).
 
     Parameter mfix : fix_body -> forall x : dom, itree E (codom x).
 
     Axiom mfix_unfold : forall (body : fix_body) (x : dom),
-        mfix body x = body (itree E) (fun t => id) (mfix body) x.
+        mfix body x = body (itree E) _ (fun t => id) (mfix body) x.
 
   End Fix.
 End FixSig.
@@ -89,7 +92,8 @@ Module FixImpl : FixSig.
        * complex, though one could argue that it is a more abstract encoding.
        *)
       Definition fix_body : Type :=
-        forall m, (forall t, itree E t -> m t) ->
+        forall m, Monad m ->
+             (forall t, itree E t -> m t) ->
              (forall x : dom, m (codom x)) ->
              forall x : dom, m (codom x).
 
@@ -98,11 +102,11 @@ Module FixImpl : FixSig.
       Definition mfix
       : forall x : dom, itree E (codom x) :=
         _mfix
-          (body (itree (E +' fixpoint)) (fun t : Type => hoist (fun X : Type => inl))
+          (body (itree (E +' fixpoint)) _ (fun t : Type => hoist (fun X : Type => inl))
                 (fun x0 : dom => Vis (inr (call x0)) Ret)).
 
       Theorem mfix_unfold : forall x,
-          mfix x = body (itree E) (fun t => id) mfix x.
+          mfix x = body (itree E) _ (fun t => id) mfix x.
       Proof. Admitted.
     End mfixP.
   End Fix.

--- a/theories/Fix.v
+++ b/theories/Fix.v
@@ -5,9 +5,8 @@
  *   https://gmalecha.github.io/reflections/2018/compositional-coinductive-recursion-in-coq
  *)
 Require Import ITree.ITree.
+Require Import ITree.Morphisms.
 Require Import ITree.Effect.
-
-Require Import ExtLib.Structures.Monad.
 
 Module Type FixSig.
   Section Fix.
@@ -57,7 +56,7 @@ Module FixImpl : FixSig.
         | Vis (inr e) k =>
           match e in fixpoint X return (X -> _) -> _ with
           | call x => fun k =>
-                       Tau (homFix (bind (f x) k))
+                       Tau (homFix (Core.bind (f x) k))
           end k
         | Tau x => Tau (homFix x)
         end.
@@ -74,9 +73,10 @@ Module FixImpl : FixSig.
           end
         end.
 
-      Theorem homFix_is_hom : forall {T} (c : itree _ T),
-          homFix c = hom eval_fixpoint c.
-      Proof. Admitted.
+      Theorem homFix_is_interp : forall {T} (c : itree _ T),
+          homFix c = interp eval_fixpoint c.
+      Proof.
+      Admitted.
 
       Theorem _mfix_unroll : forall x, _mfix x = homFix (f x).
       Proof. reflexivity. Qed.
@@ -103,7 +103,7 @@ Module FixImpl : FixSig.
       : forall x : dom, itree E (codom x) :=
         _mfix
           (body (E +' fixpoint)
-                (fun t : Type => hoist (fun X : Type => inl))
+                (fun t => @interp _ _ (fun _ e => do e) _)
                 (fun x0 : dom => Vis (inr (call x0)) Ret)).
 
       Theorem mfix_unfold : forall x,

--- a/theories/Fix.v
+++ b/theories/Fix.v
@@ -18,15 +18,15 @@ Module Type FixSig.
     Variable codom : dom -> Type.
 
     Definition fix_body : Type :=
-      forall m, Monad m ->
-           (forall t, itree E t -> m t) ->
-           (forall x : dom, m (codom x)) ->
-           forall x : dom, m (codom x).
+      forall E',
+        (forall t, itree E t -> itree E' t) ->
+        (forall x : dom, itree E' (codom x)) ->
+        forall x : dom, itree E' (codom x).
 
     Parameter mfix : fix_body -> forall x : dom, itree E (codom x).
 
     Axiom mfix_unfold : forall (body : fix_body) (x : dom),
-        mfix body x = body (itree E) _ (fun t => id) (mfix body) x.
+        mfix body x = body E (fun t => id) (mfix body) x.
 
   End Fix.
 End FixSig.
@@ -92,21 +92,22 @@ Module FixImpl : FixSig.
        * complex, though one could argue that it is a more abstract encoding.
        *)
       Definition fix_body : Type :=
-        forall m, Monad m ->
-             (forall t, itree E t -> m t) ->
-             (forall x : dom, m (codom x)) ->
-             forall x : dom, m (codom x).
+        forall E',
+          (forall t, itree E t -> itree E' t) ->
+          (forall x : dom, itree E' (codom x)) ->
+          forall x : dom, itree E' (codom x).
 
       Variable body : fix_body.
 
       Definition mfix
       : forall x : dom, itree E (codom x) :=
         _mfix
-          (body (itree (E +' fixpoint)) _ (fun t : Type => hoist (fun X : Type => inl))
+          (body (E +' fixpoint)
+                (fun t : Type => hoist (fun X : Type => inl))
                 (fun x0 : dom => Vis (inr (call x0)) Ret)).
 
       Theorem mfix_unfold : forall x,
-          mfix x = body (itree E) _ (fun t => id) mfix x.
+          mfix x = body E (fun t => id) mfix x.
       Proof. Admitted.
     End mfixP.
   End Fix.

--- a/theories/ITree.v
+++ b/theories/ITree.v
@@ -1,20 +1,9 @@
+Require Import ExtLib.Structures.Functor.
+Require Import ExtLib.Structures.Applicative.
 Require Import ExtLib.Structures.Monad.
 
 Set Implicit Arguments.
 Set Contextual Implicit.
-
-(* Naming conventions:
-   - [python_case] definitions
-   - [CamelCase] constructors and classes
-
-   Variables:
-   - [E E1 E2 F F1 F2 : Type -> Type] effect types
-   - [X Y Z : Type] effect output types
-   - [e : E X] effects
-   - [R S : Type] return/result types ([Ret : R -> itree E R])
-   - [t u : itree E R] itrees
-   - [k h : R -> itree E S] itree continuations (iforests?)
- *)
 
 (** An [itree E R] is the denotation of a program as coinductive
     (possibly infinite) tree where the leaves [Ret] are labeled with
@@ -45,74 +34,48 @@ Proof. destruct t; auto. Qed.
 
 Arguments match_itree {E R} t.
 
-(* [itree] is a monad, with the monadic [Core.bind] defined
-   by substitution of [Ret] leaves. However, many generic
-   recursive constructions fail the productivity checker,
-   hence we will wrap [Core.bind] to work around those issues. *)
 Module Core.
-(** [itree E] forms a [Monad] *)
-Definition bind_body {E R S}
-           (t : itree E R)
-           (go : itree E R -> itree E S)
-           (k : R -> itree E S) : itree E S :=
-  match t with
-  | Ret r => k r
-  | Vis e h => Vis e (fun x => go (h x))
-  | Tau t => Tau (go t)
-  end.
 
-Definition bind {E R S} (t : itree E R) (k : R -> itree E S) :
-  itree E S :=
-  (cofix bind_ (t : itree E R) :=
-      bind_body t bind_ k) t.
+  Section bind.
+    Context {E : Type -> Type} {T U : Type}.
+    Variable k : T -> itree E U.
 
-Lemma bind_def_core : forall {E R S} t (k : R -> itree E S),
-    bind t k = bind_body t (fun t' => bind t' k) k.
-Proof.
-  intros.
-  rewrite (match_itree (bind _ _)).
-  destruct t; auto.
-  simpl.
-  rewrite <- (match_itree (k r)).
-  reflexivity.
-Qed.
+    CoFixpoint bind' (c : itree E T) : itree E U :=
+      match c with
+      | Ret r => k r
+      | Vis e k' => Vis e (fun x => bind' (k' x))
+      | Tau t => Tau (bind' t)
+      end.
+  End bind.
+
+  Definition bind {E T U}
+             (c : itree E T) (k : T -> itree E U)
+  : itree E U :=
+    bind' k c.
+
+  Definition bindTau {E T U}
+             (c : itree E T) (k : T -> itree E U)
+  : itree E U :=
+    match c with
+    | Ret r => Tau (k r)
+    | Vis e k' => Vis e (fun x => bind (k' x) k)
+    | Tau x => Tau (bind x k)
+    end.
 
 End Core.
 
-(** Monadic bind *)
-(* We insert a [Tau] in the [Ret] case to make programs/specifications
-   neater. This makes [itree] no longer a monad structurally,
-   but it remains one in a looser sense as long as [Tau] is
-   interpreted as the identity. *)
-Definition bind' {E R S}
-           (t : itree E R) (k : R -> itree E S) : itree E S :=
-  Core.bind t (fun r => Tau (k r)).
-
-Global Instance Monad_itree {E} : Monad (itree E) :=
-{ ret := @Ret E
-; bind := @bind' E
-}.
-
-(* A lemma to unfold [bind]. *)
-Lemma bind_def E R S :
-  forall t (k : R -> itree E S),
-    bind t k =
-    Core.bind_body t (fun t' => bind t' k) (fun r => Tau (k r)).
-Proof.
-  simpl bind; unfold bind'.
-  intros s k.
-  rewrite Core.bind_def_core.
-  reflexivity.
-Qed.
+(* note(gmm): There needs to be generic automation for monads to simplify
+ * using the monad laws up to a setoid.
+ * this would be *really* useful to a lot of projects.
+ *
+ * this will be especially important for this project because coinductives
+ * don't simplify very nicely.
+ *)
 
 
-Definition liftE (E : Type -> Type) (X : Type)
+Definition liftE {E : Type -> Type} {X : Type}
            (e : E X) : itree E X :=
   Vis e Ret.
-
-Definition sequ {E R S}
-           (t : itree E R) (u : itree E S) : itree E S :=
-  bind t (fun _ => u).
 
 (** Functorial map ([fmap]) *)
 Definition map {E R S} (f : R -> S) : itree E R -> itree E S :=
@@ -123,6 +86,20 @@ Definition map {E R S} (f : R -> S) : itree E R -> itree E S :=
     | Tau t => Tau (go t)
     end.
 
+Instance Functor_itree {E} : Functor (itree E) :=
+{ fmap := @map E }.
+
+Instance Applicative_itree {E} : Applicative (itree E) :=
+{ pure := @Ret E
+; ap _ _ f x := Core.bind f (fun f => Core.bind x (fun x => Ret (f x)))
+}.
+
+Global Instance Monad_itree {E} : Monad (itree E) :=
+{ ret  := @Ret E
+; bind := @Core.bind E
+}.
+
+
 (** Ignore the result of a tree. *)
 Definition ignore {E R} : itree E R -> itree E unit :=
   map (fun _ => tt).
@@ -131,55 +108,12 @@ Definition ignore {E R} : itree E R -> itree E unit :=
 CoFixpoint spin {E R} : itree E R := Tau spin.
 
 Definition forever {E R S} (t : itree E R) : itree E S :=
-  cofix forever_t := sequ t forever_t.
+  cofix forever_t := Core.bindTau t (fun _ => forever_t).
 
-(* Homomorphisms between effects *)
-Definition eff_hom (E E' : Type -> Type) : Type :=
-  forall t, E t -> itree E' t.
 
-(* Stateful homomorphisms between effects *)
-Definition eff_hom_s (s : Type) (E E' : Type -> Type) : Type :=
-  forall t, E t -> s -> itree E' (s * t).
-
-(** If we can interpret the effects of a tree as computations in
-    another, we can extend that interpretation to the whole tree. *)
-Definition hom {E F : Type -> Type}
-           (f : eff_hom E F) (R : Type)
-: itree E R -> itree F R :=
-  cofix hom_f t :=
-    match t with
-    | Ret r => Ret r
-    | Vis e k => bind' (f _ e) (fun x => hom_f (k x))
-    | Tau t => Tau (hom_f t)
-    end.
-Arguments hom {E F} _ [R] _.
-
-(* todo: We should probably export this using a state transformer.
+(* this definition exists in ExtLib (or should because it is
+ * generic to Monads)
  *)
-Definition hom_state {E F : Type -> Type} {S : Type}
-           (f : eff_hom_s S E F) (R : Type)
-: itree E R -> S -> itree F (S * R) :=
-  cofix homState_f t s :=
-    match t with
-    | Ret r => Ret (s, r)
-    | Vis e k => bind' (f _ e s) (fun '(s',x) => homState_f (k x) s')
-    | Tau t => Tau (homState_f t s)
-    end.
-Arguments hom_state {_ _} _ [_] _.
-
-(** With a mapping from one effect to one single other effect,
-    a more economical mapping is possible, using [Vis] instead
-    of [bind]. *)
-Definition hoist {E F R}
-           (f : forall X, E X -> F X) :
-  itree E R -> itree F R :=
-  cofix hoist_f m :=
-    match m with
-    | Ret r => Ret r
-    | Vis e k => Vis (f _ e) (fun x => hoist_f (k x))
-    | Tau n => Tau (hoist_f n)
-    end.
-
 Definition when {E}
            (b : bool) (body : itree E unit) : itree E unit :=
   if b then body else ret tt.

--- a/theories/Morphisms.v
+++ b/theories/Morphisms.v
@@ -1,0 +1,148 @@
+(* Effects form a category where the arrows are effect morphisms.
+ *
+ * These morphisms can be used to transport itrees from one effect
+ * to another.
+ *
+ * Some morphisms interpret effects using additional structure.
+ * In general, this additional structure is monadic in nature.
+ *)
+Require Import ITree.ITree.
+Require Import ExtLib.Structures.Functor.
+
+(* * Homomorphisms between effects *)
+Definition eff_hom (E E' : Type -> Type) : Type :=
+  forall t, E t -> itree E' t.
+
+(* An `eff_hom` can be used to transport itrees between different effects.
+ *)
+Definition interp {E F : Type -> Type}
+           (f : eff_hom E F) (R : Type)
+: itree E R -> itree F R :=
+  cofix hom_f t :=
+    match t with
+    | Ret r => Ret r
+    | Vis e k => Core.bindTau (f _ e) (fun x => hom_f (k x))
+    | Tau t => Tau (hom_f t)
+    end.
+Arguments interp {E F} _ [R] _.
+
+(* * Effects form a category
+ * The objects are effects: i.e. `Type -> Type`
+ * The morphisms from `a` to `b` are `eff_hom a b`
+ *)
+
+(* todo(gmm): it would be good to have notation for this.
+ * - if there was a "category" class like in Haskell, then we could
+ *   get composition from something like that.
+ *)
+Definition eh_compose {A B C} (g : eff_hom B C) (f : eff_hom A B)
+: eff_hom A C :=
+  fun _ e =>
+    interp g (f _ e).
+
+Definition eh_id {A} : eff_hom A A :=
+  fun _ e => Vis e Ret.
+
+Section eff_hom_state.
+  Variable s : Type.
+  Variable E E' : Type -> Type.
+
+  (* * Stateful homomorphisms between effects *)
+  Definition eff_hom_s : Type :=
+    forall t, E t -> s -> itree E' (s * t).
+
+  (* question(gmm): Should we export this using `stateT`? That is,
+   *
+   * interp_state {E F S} (f : eff_hom_s S E F) (R : Type)
+   *   itree E R -> stateT S (itree F) R.
+   *
+   * a nice benefit of this is that it makes the structure a bit more
+   * explicit (and hints at the generalization to arbitary monads).
+   *)
+  Variable f : eff_hom_s.
+  CoFixpoint interp_state (R : Type) (t : itree E R) (st : s)
+  : itree E' (s * R) :=
+    match t with
+    | Ret r => Ret (st, r)
+    | Vis e k => Core.bindTau (f _ e st) (fun '(s',x) => interp_state _ (k x) s')
+    | Tau t => Tau (interp_state _ t st)
+    end.
+End eff_hom_state.
+Arguments interp_state {_ _ _} _ [_] _ _.
+
+(* * Reader homomorphisms between effects *)
+Section eff_hom_reader.
+  Variable s : Type.
+  Variable E E' : Type -> Type.
+
+  Definition eff_hom_r : Type :=
+    forall t, E t -> s -> itree E' t.
+
+  Variable f : eff_hom_r.
+  CoFixpoint interp_reader (R : Type) (t : itree E R) (st : s) : itree E' R :=
+    match t with
+    | Ret r => Ret r
+    | Vis e k => Core.bindTau (f _ e st) (fun x => interp_reader _ (k x) st)
+    | Tau t => Tau (interp_reader _ t st)
+    end.
+
+End eff_hom_reader.
+
+Arguments interp_reader {_ _ _} _ [_] _ _.
+
+Require Import ExtLib.Structures.Monoid.
+
+(* * Writer homomorphisms between effects *)
+Section eff_hom_writer.
+  Variable s : Type.
+  Variable E E' : Type -> Type.
+
+  Definition eff_hom_w : Type :=
+    forall t, E t -> itree E' (s * t).
+
+  Context {Monoid_s : Monoid s}.
+  Variable f : eff_hom_w.
+
+  (* Note that we have to give an intepretation in terms of state in order
+   * to pass the productivity checker. This definition is equivalent to:
+   *
+   * CoFixpoint interp_reader (R : Type) (t : itree E R) (st : s) : itree E' R :=
+   *   match t with
+   *   | Ret r => Ret r
+   *   | Vis e k => Core.bindTau (f _ e st)
+   *     (fun x => fmap (fun '(s',x) => (monoid_plus Monoid_s s s', x))
+   *                    (interp_writer _ (k x) st))
+   *   | Tau t => Tau (interp_writer _ t st)
+   *   end.
+   *)
+  Definition interp_writer (R : Type) (t : itree E R) : itree E' (s * R) :=
+    interp_state
+      (fun _ e s => fmap (fun '(s',x) => (monoid_plus Monoid_s s s', x)) (f _ e))
+      t (monoid_unit Monoid_s).
+
+End eff_hom_writer.
+
+Arguments interp_writer {_ _ _ _} _ [_] _.
+
+(* A propositional "interpreter"
+ * This can be useful for non-determinism.
+ *)
+Section interp_prop.
+  Context {E F : Type -> Type}.
+
+  Definition eff_hom_prop : Type :=
+    forall t, E t -> itree F t -> Prop.
+
+  CoInductive interp_prop (f : eff_hom_prop) (R : Type)
+  : itree E R -> itree F R -> Prop :=
+  | ipRet : forall x, interp_prop f R (Ret x) (Ret x)
+  | ipVis : forall {T} {e : E T} {e' : itree F T}
+              (k : _ -> itree E R) (k' : T -> itree F R),
+      f _ e e' ->
+      (forall x, interp_prop f R (k x) (k' x)) ->
+      interp_prop f R (Vis e k) (Core.bind e' k')
+  | ipDelay : forall a b, interp_prop f R a b ->
+                     interp_prop f R (Tau a) (Tau b).
+
+End interp_prop.
+Arguments eff_hom_prop _ _ : clear implicits.


### PR DESCRIPTION
When trying to use the definition of `mfix`, I noticed that I forgot to give the body access to a monad instance for `m`, which prevents it from using both `inj` and `rec`.

I am using the `ExtLib` definition of `Monad`, though in #6 we decided that it might be better to pull out a separate library. We can do that before merging this if we want.