### PR TITLE
simplify the definition of bind to avoid unnecessary taus

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -1,0 +1,14 @@
+# Coq Conventions
+
+## Naming conventions:
+
+- [python_case] for definitions
+- [CamelCase] for constructors and classes
+
+Variables:
+- [E E1 E2 F F1 F2 : Type -> Type] effect types
+- [X Y Z : Type] effect output types
+- [e : E X] effects
+- [R S : Type] return/result types ([Ret : R -> itree E R])
+- [t u : itree E R] itrees
+- [k h : R -> itree E S] itree continuations (iforests?)

--- a/theories/Effect.v
+++ b/theories/Effect.v
@@ -12,9 +12,10 @@ Require Import String.
 Require Import ITree.ITree.
 Require Import ITree.Morphisms.
 
-Inductive void : Type := .
+Require Import ExtLib.Structures.Functor.
+Require Import ExtLib.Structures.Monoid.
 
-Section Extensible.
+Inductive void : Type := .
 
 (** Sums for extensible event types. *)
 
@@ -41,6 +42,46 @@ Definition bimap_sum1 {A B C D : Type -> Type} {X Y : Type}
   | inr b => inr (g b)
   end.
 
+Notation "E1 +' E2" := (sum1 E1 E2)
+(at level 50, left associativity) : type_scope.
+
+Section into.
+  Context {E F : Type -> Type}.
+
+  Definition into (h : eff_hom E F) : eff_hom (E +' F) F :=
+    fun _ e =>
+      match e with
+      | inl e => h _ e
+      | inr e => Vis e Ret
+      end.
+
+  Definition into_state {s} (h : eff_hom_s s E F) : eff_hom_s s (E +' F) F :=
+    fun _ e s =>
+      match e with
+      | inl e => h _ e s
+      | inr e => Vis e (fun x => Ret (s, x))
+      end.
+
+  Definition into_reader {s} (h : eff_hom_r s E F) : eff_hom_r s (E +' F) F :=
+    fun _ e s =>
+      match e with
+      | inl e => h _ e s
+      | inr e => Vis e Ret
+      end.
+
+  Definition into_writer {s} `{Monoid_s : Monoid s} (h : eff_hom_w s E F)
+  : eff_hom_w s (E +' F) F :=
+    fun _ e =>
+      match e with
+      | inl e => h _ e
+      | inr e => Vis e (fun x => Ret (monoid_unit Monoid_s, x))
+      end.
+
+  (* todo(gmm): is the a corresponding definition for `eff_hom_p`? *)
+
+End into.
+
+
 (* Automatic application of commutativity and associativity for sums.
    TODO: This is still quite fragile and prone to
    infinite instance resolution loops.
@@ -55,7 +96,7 @@ Global Instance fluid_id A : Convertible A A | 0 :=
 
 (* Destructure sums. *)
 Global Instance fluid_sum A B C `{Convertible A C} `{Convertible B C}
-  : Convertible (sum1 A B) C | 7 :=
+: Convertible (sum1 A B) C | 7 :=
   { convert X ab :=
       match ab with
       | inl a => convert a
@@ -64,21 +105,16 @@ Global Instance fluid_sum A B C `{Convertible A C} `{Convertible B C}
 
 (* Lean right by default for no reason. *)
 Global Instance fluid_left A B `{Convertible A B} C
-  : Convertible A (sum1 B C) | 9 :=
+: Convertible A (sum1 B C) | 9 :=
   { convert X a := inl (convert a) }.
 
 (* Very incoherent instances. *)
 Global Instance fluid_right A C `{Convertible A C} B
-  : Convertible A (sum1 B C) | 8 :=
+: Convertible A (sum1 B C) | 8 :=
   { convert X a := inr (convert a) }.
 
 Global Instance fluid_empty A : Convertible emptyE A :=
   { convert X v := match v with end }.
-
-End Extensible.
-
-Notation "E1 +' E2" := (sum1 E1 E2)
-(at level 50, left associativity) : type_scope.
 
 Notation "EE ++' E" := (List.fold_right sum1 EE E)
 (at level 50, left associativity) : type_scope.
@@ -144,16 +180,6 @@ Definition do {E F X} `{F -< E}
   Vis (convert e) Ret.
 
 
-Definition run {E F} (run_ : eff_hom E F)
-: forall X, itree (E +' F) X -> itree F X :=
-  let run' Y (e : (E +' F) Y) :=
-      match e with
-      | (| f' ) => liftE f'
-      | ( e' |) => run_ _ e'
-      end
-  in interp run'.
-Arguments run {_ _} _ [_] _.
-
 Section Failure.
 
 Inductive failureE : Type -> Type :=
@@ -203,49 +229,52 @@ End NonDeterminism.
 
 Section Reader.
 
-Variable (env : Type).
+  Variable (env : Type).
 
-Inductive readerE : Type -> Type :=
-| Ask : readerE env.
+  Inductive readerE : Type -> Type :=
+  | Ask : readerE env.
 
-Definition ask {E} `{Convertible readerE E} : itree E env :=
-  liftE (convert Ask).
+  Definition ask {E} `{Convertible readerE E} : itree E env :=
+    liftE (convert Ask).
 
-CoFixpoint run_reader {E R} (v : env) (t : itree (readerE +' E) R)
+  Definition eval_reader {E} : eff_hom_r env readerE E :=
+    fun _ e r =>
+      match e with
+      | Ask => Ret r
+      end.
+
+  Definition run_reader {E} R (v : env) (t : itree (readerE +' E) R)
   : itree E R :=
-  match t with
-  | Ret r => Ret r
-  | Vis ( e |) k =>
-    match e in readerE X return (X -> _) -> _ with
-    | Ask => fun k => Tau (run_reader v (k v))
-    end k
-  | Vis (| e ) k => Vis e (fun x => run_reader v (k x))
-  | Tau t => Tau (run_reader v t)
-  end.
+    interp_reader (into_reader eval_reader) t v.
 
 End Reader.
 
 Arguments ask {env E _}.
+Arguments run_reader {_ _} [_] _ _.
 
 Section State.
 
-Variable (S : Type).
+  Variable (S : Type).
 
-Inductive stateE : Type -> Type :=
-| Get : stateE S
-| Put : S -> stateE unit.
+  Inductive stateE : Type -> Type :=
+  | Get : stateE S
+  | Put : S -> stateE unit.
 
-Definition get {E} `{stateE -< E} : itree E S := do Get.
-Definition put {E} `{stateE -< E} (s : S) : itree E unit :=
-  do (Put s).
+  Definition get {E} `{stateE -< E} : itree E S := do Get.
+  Definition put {E} `{stateE -< E} (s : S) : itree E unit :=
+    do (Put s).
 
 
-Definition eval_state : eff_hom_s S stateE emptyE :=
-  fun _ e s =>
-    match e with
-    | Get => Ret (s, s)
-    | Put s' => Ret (s', tt)
-    end.
+  Definition eval_state {E} : eff_hom_s S stateE E :=
+    fun _ e s =>
+      match e with
+      | Get => Ret (s, s)
+      | Put s' => Ret (s', tt)
+      end.
+
+  Definition run_state {E R} (v : S) (t : itree (stateE +' E) R)
+  : itree E (S * R) :=
+    interp_state (into_state eval_state) t v.
 
 (*
 Definition run_state {E F : Type -> Type}
@@ -268,65 +297,62 @@ End State.
 
 Arguments get {S E _}.
 Arguments put {S E _}.
+Arguments run_state {_ _} [_] _ _.
+
+Section Tagged.
+  Variable E : Type -> Type.
+
+  Record Tagged (tag : Set) (t : Type) : Type := mkTagged
+  { unTag : E t }.
+
+  Definition atTag (tag : Set) {t} (e : E t) : Tagged tag t :=
+  {| unTag := e |}.
+
+  Definition eval_tagged {tag} : eff_hom (Tagged tag) E :=
+    fun _ e => Vis e.(unTag) Ret.
+
+End Tagged.
+
 
 Section Counter.
 
-Class Countable (N : Type) := { zero : N; succ : N -> N }.
+  Class Countable (N : Type) := { zero : N; succ : N -> N }.
 
-Global Instance Countable_nat : Countable nat | 0 :=
+  Global Instance Countable_nat : Countable nat | 0 :=
   { zero := O; succ := S }.
 
-Inductive nat' {T} (tag : T) : Type :=
-| Tagged : nat -> nat' tag.
-
-Global Instance Countable_nat' T (tag : T)
-  : Countable (nat' tag) :=
-  { zero := Tagged O; succ := fun '(Tagged n) => Tagged (S n) }.
-
-(* Parameterizing by the type of counters makes it easier
+  (* Parameterizing by the type of counters makes it easier
    to have more than one counter at once. *)
-Inductive counterE (N : Type) : Type -> Type :=
-| Incr : counterE N N.
+  Inductive counterE (N : Type) : Type -> Type :=
+  | Incr : counterE N N.
 
-Definition incr {N E} `{counterE N -< E} : itree E N :=
-  do Incr.
+  Definition incr {N E} `{counterE N -< E} : itree E N :=
+    do Incr.
 
-(* todo(gmm): define in terms of `eff_hom` *)
-CoFixpoint run_counter_from' {N E} `{Countable N} {R}
-           (c : N) (t : itree (counterE N +' E) R)
+  Definition eval_counter {N E} `{Countable N}
+  : eff_hom_s N (counterE N) E :=
+    fun _ e s =>
+      match e with
+      | Incr => Ret (succ s, s)
+      end.
+
+  Definition run_counter {N} `{Countable N} {E R} (t : itree (counterE N +' E) R)
   : itree E R :=
-  match t with
-  | Ret r => Ret r
-  | Tau t => Tau (run_counter_from' c t)
-  | Vis ( e |) k =>
-    match e in counterE _ X return (X -> _) -> _ with
-    | Incr => fun k => Tau (run_counter_from' (succ c) (k c))
-    end k
-  | Vis (| e ) k =>
-    Vis e (fun x => run_counter_from' c (k x))
-  end.
-
-Definition run_counter' {N} `{Countable N} {E R}
-  : itree (counterE N +' E) R -> itree E R :=
-  run_counter_from' zero.
-
-Definition run_counter_for {T} (tag : T) {E R}
-  : itree (counterE (nat' tag) +' E) R -> itree E R :=
-  run_counter'.
+    fmap snd (interp_state (into_state eval_counter) t zero).
 
 End Counter.
 
-Arguments run_counter_for {T} tag {_ _} t.
+Arguments run_counter {_ _ _} [_] _.
 
 Section Writer.
 
-Variable (W : Type).
+  Variable (W : Type).
 
-Inductive writerE : Type -> Type :=
-| Tell : W -> writerE unit.
+  Inductive writerE : Type -> Type :=
+  | Tell : W -> writerE unit.
 
-Definition tell {E} `{writerE -< E} (w : W) : itree E unit :=
-  do (Tell w).
+  Definition tell {E} `{writerE -< E} (w : W) : itree E unit :=
+    do (Tell w).
 
 End Writer.
 
@@ -347,23 +373,23 @@ Arguments stop {E S R _}.
 
 Section Trace.
 
-Inductive traceE : Type -> Type :=
-| Trace : string -> traceE unit.
+  Inductive traceE : Type -> Type :=
+  | Trace : string -> traceE unit.
 
-Definition trace {E} `{traceE -< E} (msg : string) : itree E unit :=
-  do (Trace msg).
+  Definition trace {E} `{traceE -< E} (msg : string) : itree E unit :=
+    do (Trace msg).
 
-(* todo(gmm): define in terms of `eff_hom` *)
-CoFixpoint ignore_trace {E R} (t : itree (traceE +' E) R) :
-  itree E R :=
-  match t with
-  | Ret r => Ret r
-  | Tau t => Tau (ignore_trace t)
-  | Vis ( e |) k =>
-    match e in traceE T return (T -> _) -> _ with
-    | Trace _ => fun k => Tau (ignore_trace (k tt))
-    end k
-  | Vis (| e ) k => Vis e (fun x => ignore_trace (k x))
-  end.
+  (* todo(gmm): define in terms of `eff_hom` *)
+  CoFixpoint ignore_trace {E R} (t : itree (traceE +' E) R) :
+    itree E R :=
+    match t with
+    | Ret r => Ret r
+    | Tau t => Tau (ignore_trace t)
+    | Vis ( e |) k =>
+      match e in traceE T return (T -> _) -> _ with
+      | Trace _ => fun k => Tau (ignore_trace (k tt))
+      end k
+    | Vis (| e ) k => Vis e (fun x => ignore_trace (k x))
+    end.
 
 End Trace.

--- a/theories/Equivalence.v
+++ b/theories/Equivalence.v
@@ -157,6 +157,7 @@ Proof.
 Qed.
 
 
+(*
 Lemma finite_taus_bind_inv1 : forall {E R S} (t : itree E R) (f : R -> itree E S),
     finite_taus (bind t f) -> finite_taus t.
 Proof.
@@ -178,6 +179,7 @@ Proof.
     + exists (Vis e k). split. simpl; auto. apply NoTau.
     + inversion I1.
 Qed.
+*)
 
 Lemma finite_taus_tau1: forall (E : Type -> Type) (R : Type) (t : itree E R),
     finite_taus t -> finite_taus (Tau t).
@@ -272,6 +274,7 @@ Proof.
     + inversion I.
 Qed.
 
+(*
 Lemma finite_taus_bind : forall E R S (t1 t2 : itree E R) (f : R -> itree E S),
     t1 ~ t2 -> finite_taus (bind t1 f) -> finite_taus (bind t2 f).
 Proof.
@@ -288,3 +291,4 @@ Lemma eutt_bind_hom1 : forall {E R S} (t1 t2 : itree E R) (f : R -> itree E S),
     t1 ~ t2 -> (bind t1 f) ~ (bind t2 f).
 Proof.
 Admitted.
+*)

--- a/theories/Equivalence.v
+++ b/theories/Equivalence.v
@@ -1,4 +1,5 @@
 Require Import Coq.Classes.RelationClasses.
+Require Import Coq.Setoids.Setoid.
 Require Import Coq.Relations.Relations.
 
 Require Import Paco.paco.
@@ -146,11 +147,13 @@ Hint Resolve monotone_eutt_0 : paco.
 Hint Resolve monotone_eutt_ : paco.
 Infix "~" := (@eutt _ _) (at level 80).
 
-Lemma bind_tau : forall {E R S} (t : itree E R) (f : R -> itree E S) , bind (Tau t) f = Tau (bind t f).
+
+Lemma bind_tau : forall {E R S} (t : itree E R) (f : R -> itree E S) ,
+    bind (Tau t) f = Tau (bind t f).
 Proof.
   intros E R S t f.
-  rewrite bind_def.
-  simpl. reflexivity.
+  rewrite match_itree at 1.
+  reflexivity.
 Qed.
 
 

--- a/theories/Fix.v
+++ b/theories/Fix.v
@@ -8,8 +8,6 @@ Require Import ITree.ITree.
 Require Import ITree.Morphisms.
 Require Import ITree.Effect.
 
-Require Import ExtLib.Structures.Monad.
-
 Module Type FixSig.
   Section Fix.
     (* the ambient effects *)
@@ -58,7 +56,7 @@ Module FixImpl : FixSig.
         | Vis (inr e) k =>
           match e in fixpoint X return (X -> _) -> _ with
           | call x => fun k =>
-                       Tau (homFix (bind (f x) k))
+                       Tau (homFix (Core.bind (f x) k))
           end k
         | Tau x => Tau (homFix x)
         end.

--- a/theories/Fix.v
+++ b/theories/Fix.v
@@ -5,6 +5,7 @@
  *   https://gmalecha.github.io/reflections/2018/compositional-coinductive-recursion-in-coq
  *)
 Require Import ITree.ITree.
+Require Import ITree.Morphisms.
 Require Import ITree.Effect.
 
 Require Import ExtLib.Structures.Monad.
@@ -74,9 +75,10 @@ Module FixImpl : FixSig.
           end
         end.
 
-      Theorem homFix_is_hom : forall {T} (c : itree _ T),
-          homFix c = hom eval_fixpoint c.
-      Proof. Admitted.
+      Theorem homFix_is_interp : forall {T} (c : itree _ T),
+          homFix c = interp eval_fixpoint c.
+      Proof.
+      Admitted.
 
       Theorem _mfix_unroll : forall x, _mfix x = homFix (f x).
       Proof. reflexivity. Qed.
@@ -103,7 +105,7 @@ Module FixImpl : FixSig.
       : forall x : dom, itree E (codom x) :=
         _mfix
           (body (E +' fixpoint)
-                (fun t : Type => hoist (fun X : Type => inl))
+                (fun t => @interp _ _ (fun _ e => do e) _)
                 (fun x0 : dom => Vis (inr (call x0)) Ret)).
 
       Theorem mfix_unfold : forall x,

--- a/theories/ITree.v
+++ b/theories/ITree.v
@@ -1,20 +1,9 @@
+Require Import ExtLib.Structures.Functor.
+Require Import ExtLib.Structures.Applicative.
 Require Import ExtLib.Structures.Monad.
 
 Set Implicit Arguments.
 Set Contextual Implicit.
-
-(* Naming conventions:
-   - [python_case] definitions
-   - [CamelCase] constructors and classes
-
-   Variables:
-   - [E E1 E2 F F1 F2 : Type -> Type] effect types
-   - [X Y Z : Type] effect output types
-   - [e : E X] effects
-   - [R S : Type] return/result types ([Ret : R -> itree E R])
-   - [t u : itree E R] itrees
-   - [k h : R -> itree E S] itree continuations (iforests?)
- *)
 
 (** An [itree E R] is the denotation of a program as coinductive
     (possibly infinite) tree where the leaves [Ret] are labeled with
@@ -75,20 +64,18 @@ Module Core.
 
 End Core.
 
+(* note(gmm): There needs to be generic automation for monads to simplify
+ * using the monad laws up to a setoid.
+ * this would be *really* useful to a lot of projects.
+ *
+ * this will be especially important for this project because coinductives
+ * don't simplify very nicely.
+ *)
 
-Global Instance Monad_itree {E} : Monad (itree E) :=
-{ ret := @Ret E
-; bind := @Core.bind E
-}.
 
-
-Definition liftE (E : Type -> Type) (X : Type)
+Definition liftE {E : Type -> Type} {X : Type}
            (e : E X) : itree E X :=
   Vis e Ret.
-
-Definition sequ {E R S}
-           (t : itree E R) (u : itree E S) : itree E S :=
-  bind t (fun _ => u).
 
 (** Functorial map ([fmap]) *)
 Definition map {E R S} (f : R -> S) : itree E R -> itree E S :=
@@ -98,6 +85,20 @@ Definition map {E R S} (f : R -> S) : itree E R -> itree E S :=
     | Vis e k => Vis e (fun x => go (k x))
     | Tau t => Tau (go t)
     end.
+
+Instance Functor_itree {E} : Functor (itree E) :=
+{ fmap := @map E }.
+
+Instance Applicative_itree {E} : Applicative (itree E) :=
+{ pure := @Ret E
+; ap _ _ f x := Core.bind f (fun f => Core.bind x (fun x => Ret (f x)))
+}.
+
+Global Instance Monad_itree {E} : Monad (itree E) :=
+{ ret  := @Ret E
+; bind := @Core.bind E
+}.
+
 
 (** Ignore the result of a tree. *)
 Definition ignore {E R} : itree E R -> itree E unit :=
@@ -109,53 +110,10 @@ CoFixpoint spin {E R} : itree E R := Tau spin.
 Definition forever {E R S} (t : itree E R) : itree E S :=
   cofix forever_t := Core.bindTau t (fun _ => forever_t).
 
-(* Homomorphisms between effects *)
-Definition eff_hom (E E' : Type -> Type) : Type :=
-  forall t, E t -> itree E' t.
 
-(* Stateful homomorphisms between effects *)
-Definition eff_hom_s (s : Type) (E E' : Type -> Type) : Type :=
-  forall t, E t -> s -> itree E' (s * t).
-
-(** If we can interpret the effects of a tree as computations in
-    another, we can extend that interpretation to the whole tree. *)
-Definition hom {E F : Type -> Type}
-           (f : eff_hom E F) (R : Type)
-: itree E R -> itree F R :=
-  cofix hom_f t :=
-    match t with
-    | Ret r => Ret r
-    | Vis e k => Core.bindTau (f _ e) (fun x => hom_f (k x))
-    | Tau t => Tau (hom_f t)
-    end.
-Arguments hom {E F} _ [R] _.
-
-(* todo: We should probably export this using a state transformer.
+(* this definition exists in ExtLib (or should because it is
+ * generic to Monads)
  *)
-Definition hom_state {E F : Type -> Type} {S : Type}
-           (f : eff_hom_s S E F) (R : Type)
-: itree E R -> S -> itree F (S * R) :=
-  cofix homState_f t s :=
-    match t with
-    | Ret r => Ret (s, r)
-    | Vis e k => Core.bindTau (f _ e s) (fun '(s',x) => homState_f (k x) s')
-    | Tau t => Tau (homState_f t s)
-    end.
-Arguments hom_state {_ _} _ [_] _.
-
-(** With a mapping from one effect to one single other effect,
-    a more economical mapping is possible, using [Vis] instead
-    of [bind]. *)
-Definition hoist {E F R}
-           (f : forall X, E X -> F X) :
-  itree E R -> itree F R :=
-  cofix hoist_f m :=
-    match m with
-    | Ret r => Ret r
-    | Vis e k => Vis (f _ e) (fun x => hoist_f (k x))
-    | Tau n => Tau (hoist_f n)
-    end.
-
 Definition when {E}
            (b : bool) (body : itree E unit) : itree E unit :=
   if b then body else ret tt.

--- a/theories/Morphisms.v
+++ b/theories/Morphisms.v
@@ -53,3 +53,24 @@ Definition interp_state {E F : Type -> Type} {S : Type}
     | Tau t => Tau (homState_f t s)
     end.
 Arguments interp_state {_ _ _} _ [_] _.
+
+(* A propositional "interpreter"
+ * This can be useful for non-determinism.
+ *)
+Section interp_prop.
+  Context {E F : Type -> Type}.
+
+  Definition eff_hom_prop : Type :=
+    forall t, E t -> itree F t -> Prop.
+
+  CoInductive interp_prop (f : eff_hom_prop) (R : Type)
+  : itree E R -> itree F R -> Prop :=
+  | ipRet : forall x, interp_prop f R (Ret x) (Ret x)
+  | ipVis : forall T (e : E T) (e' : itree F T) (k : _ -> itree E R) (k' : T -> itree F R),
+      f _ e e' ->
+      (forall x, interp_prop f R (k x) (k' x)) ->
+      interp_prop f R (Vis e k) (Core.bind e' k')
+  | ipDelay : forall a b, interp_prop f R a b ->
+                     interp_prop f R (Tau a) (Tau b).
+
+End interp_prop.

--- a/theories/Morphisms.v
+++ b/theories/Morphisms.v
@@ -1,0 +1,55 @@
+(* Effects form a category where the arrows are effect morphisms
+ *)
+Require Import ITree.ITree.
+
+(* * Homomorphisms between effects *)
+Definition eff_hom (E E' : Type -> Type) : Type :=
+  forall t, E t -> itree E' t.
+
+(** If we can interpret the effects of a tree as computations in
+    another, we can extend that interpretation to the whole tree. *)
+Definition interp {E F : Type -> Type}
+           (f : eff_hom E F) (R : Type)
+: itree E R -> itree F R :=
+  cofix hom_f t :=
+    match t with
+    | Ret r => Ret r
+    | Vis e k => Core.bindTau (f _ e) (fun x => hom_f (k x))
+    | Tau t => Tau (hom_f t)
+    end.
+Arguments interp {E F} _ [R] _.
+
+(* todo(gmm): it would be good to have notation for this.
+ * - if there was a "category" class like in Haskell, then we could
+ *   get composition from something like that.
+ *)
+Definition eh_compose {A B C} (g : eff_hom B C) (f : eff_hom A B)
+: eff_hom A C :=
+  fun _ e =>
+    interp g (f _ e).
+
+Definition eh_id {A} : eff_hom A A :=
+  fun _ e => Vis e Ret.
+
+(* * Stateful homomorphisms between effects *)
+Definition eff_hom_s (s : Type) (E E' : Type -> Type) : Type :=
+  forall t, E t -> s -> itree E' (s * t).
+
+(* question(gmm): Should we export this using `stateT`? That is,
+ *
+ * interp_state {E F S} (f : eff_hom_s S E F) (R : Type)
+ *   itree E R -> stateT S (itree F) R.
+ *
+ * a nice benefit of this is that it makes the structure a bit more
+ * explicit (and hints at the generalization to arbitary monads).
+ *)
+Definition interp_state {E F : Type -> Type} {S : Type}
+           (f : eff_hom_s S E F) (R : Type)
+: itree E R -> S -> itree F (S * R) :=
+  cofix homState_f t s :=
+    match t with
+    | Ret r => Ret (s, r)
+    | Vis e k => Core.bindTau (f _ e s) (fun '(s',x) => homState_f (k x) s')
+    | Tau t => Tau (homState_f t s)
+    end.
+Arguments interp_state {_ _ _} _ [_] _.

--- a/theories/Morphisms.v
+++ b/theories/Morphisms.v
@@ -1,13 +1,20 @@
-(* Effects form a category where the arrows are effect morphisms
+(* Effects form a category where the arrows are effect morphisms.
+ *
+ * These morphisms can be used to transport itrees from one effect
+ * to another.
+ *
+ * Some morphisms interpret effects using additional structure.
+ * In general, this additional structure is monadic in nature.
  *)
 Require Import ITree.ITree.
+Require Import ExtLib.Structures.Functor.
 
 (* * Homomorphisms between effects *)
 Definition eff_hom (E E' : Type -> Type) : Type :=
   forall t, E t -> itree E' t.
 
-(** If we can interpret the effects of a tree as computations in
-    another, we can extend that interpretation to the whole tree. *)
+(* An `eff_hom` can be used to transport itrees between different effects.
+ *)
 Definition interp {E F : Type -> Type}
            (f : eff_hom E F) (R : Type)
 : itree E R -> itree F R :=
@@ -18,6 +25,11 @@ Definition interp {E F : Type -> Type}
     | Tau t => Tau (hom_f t)
     end.
 Arguments interp {E F} _ [R] _.
+
+(* * Effects form a category
+ * The objects are effects: i.e. `Type -> Type`
+ * The morphisms from `a` to `b` are `eff_hom a b`
+ *)
 
 (* todo(gmm): it would be good to have notation for this.
  * - if there was a "category" class like in Haskell, then we could
@@ -31,28 +43,86 @@ Definition eh_compose {A B C} (g : eff_hom B C) (f : eff_hom A B)
 Definition eh_id {A} : eff_hom A A :=
   fun _ e => Vis e Ret.
 
-(* * Stateful homomorphisms between effects *)
-Definition eff_hom_s (s : Type) (E E' : Type -> Type) : Type :=
-  forall t, E t -> s -> itree E' (s * t).
+Section eff_hom_state.
+  Variable s : Type.
+  Variable E E' : Type -> Type.
 
-(* question(gmm): Should we export this using `stateT`? That is,
- *
- * interp_state {E F S} (f : eff_hom_s S E F) (R : Type)
- *   itree E R -> stateT S (itree F) R.
- *
- * a nice benefit of this is that it makes the structure a bit more
- * explicit (and hints at the generalization to arbitary monads).
- *)
-Definition interp_state {E F : Type -> Type} {S : Type}
-           (f : eff_hom_s S E F) (R : Type)
-: itree E R -> S -> itree F (S * R) :=
-  cofix homState_f t s :=
+  (* * Stateful homomorphisms between effects *)
+  Definition eff_hom_s : Type :=
+    forall t, E t -> s -> itree E' (s * t).
+
+  (* question(gmm): Should we export this using `stateT`? That is,
+   *
+   * interp_state {E F S} (f : eff_hom_s S E F) (R : Type)
+   *   itree E R -> stateT S (itree F) R.
+   *
+   * a nice benefit of this is that it makes the structure a bit more
+   * explicit (and hints at the generalization to arbitary monads).
+   *)
+  Variable f : eff_hom_s.
+  CoFixpoint interp_state (R : Type) (t : itree E R) (st : s)
+  : itree E' (s * R) :=
     match t with
-    | Ret r => Ret (s, r)
-    | Vis e k => Core.bindTau (f _ e s) (fun '(s',x) => homState_f (k x) s')
-    | Tau t => Tau (homState_f t s)
+    | Ret r => Ret (st, r)
+    | Vis e k => Core.bindTau (f _ e st) (fun '(s',x) => interp_state _ (k x) s')
+    | Tau t => Tau (interp_state _ t st)
     end.
-Arguments interp_state {_ _ _} _ [_] _.
+End eff_hom_state.
+Arguments interp_state {_ _ _} _ [_] _ _.
+
+(* * Reader homomorphisms between effects *)
+Section eff_hom_reader.
+  Variable s : Type.
+  Variable E E' : Type -> Type.
+
+  Definition eff_hom_r : Type :=
+    forall t, E t -> s -> itree E' t.
+
+  Variable f : eff_hom_r.
+  CoFixpoint interp_reader (R : Type) (t : itree E R) (st : s) : itree E' R :=
+    match t with
+    | Ret r => Ret r
+    | Vis e k => Core.bindTau (f _ e st) (fun x => interp_reader _ (k x) st)
+    | Tau t => Tau (interp_reader _ t st)
+    end.
+
+End eff_hom_reader.
+
+Arguments interp_reader {_ _ _} _ [_] _ _.
+
+Require Import ExtLib.Structures.Monoid.
+
+(* * Writer homomorphisms between effects *)
+Section eff_hom_writer.
+  Variable s : Type.
+  Variable E E' : Type -> Type.
+
+  Definition eff_hom_w : Type :=
+    forall t, E t -> itree E' (s * t).
+
+  Context {Monoid_s : Monoid s}.
+  Variable f : eff_hom_w.
+
+  (* Note that we have to give an intepretation in terms of state in order
+   * to pass the productivity checker. This definition is equivalent to:
+   *
+   * CoFixpoint interp_reader (R : Type) (t : itree E R) (st : s) : itree E' R :=
+   *   match t with
+   *   | Ret r => Ret r
+   *   | Vis e k => Core.bindTau (f _ e st)
+   *     (fun x => fmap (fun '(s',x) => (monoid_plus Monoid_s s s', x))
+   *                    (interp_writer _ (k x) st))
+   *   | Tau t => Tau (interp_writer _ t st)
+   *   end.
+   *)
+  Definition interp_writer (R : Type) (t : itree E R) : itree E' (s * R) :=
+    interp_state
+      (fun _ e s => fmap (fun '(s',x) => (monoid_plus Monoid_s s s', x)) (f _ e))
+      t (monoid_unit Monoid_s).
+
+End eff_hom_writer.
+
+Arguments interp_writer {_ _ _ _} _ [_] _.
 
 (* A propositional "interpreter"
  * This can be useful for non-determinism.
@@ -66,7 +136,8 @@ Section interp_prop.
   CoInductive interp_prop (f : eff_hom_prop) (R : Type)
   : itree E R -> itree F R -> Prop :=
   | ipRet : forall x, interp_prop f R (Ret x) (Ret x)
-  | ipVis : forall T (e : E T) (e' : itree F T) (k : _ -> itree E R) (k' : T -> itree F R),
+  | ipVis : forall {T} {e : E T} {e' : itree F T}
+              (k : _ -> itree E R) (k' : T -> itree F R),
       f _ e e' ->
       (forall x, interp_prop f R (k x) (k' x)) ->
       interp_prop f R (Vis e k) (Core.bind e' k')
@@ -74,3 +145,4 @@ Section interp_prop.
                      interp_prop f R (Tau a) (Tau b).
 
 End interp_prop.
+Arguments eff_hom_prop _ _ : clear implicits.


### PR DESCRIPTION
This simplifies the definition of `bind` based on the discussion in #9 . I haven't had a chance to update the proofs in `Equivalence.v` yet. Are you guys building on top of those proofs?