### PR TITLE
Converting interaction trees to up-to definitions

### DIFF
--- a/_CoqConfig
+++ b/_CoqConfig
@@ -4,3 +4,4 @@ theories/ITree.v
 theories/Effect.v
 theories/Equivalence.v
 theories/Fix.v
+theories/UpTo.v

--- a/theories/UpTo.v
+++ b/theories/UpTo.v
@@ -1,0 +1,102 @@
+(* From interaction trees you can define semantics in an "up-to" style.
+ * 
+ * With interaction trees, you need to maintain the effects so the output
+ * that you get is an inductive interaction tree with an extra
+ * `Unknown`/`OutOfFuel` constructor. This is analagous to the need to
+ * maintain the trace in a trace-based semantics.
+ *)
+Require Import Coq.Classes.RelationClasses.
+
+Require Import ITree.ITree.
+Require Import ITree.Effect.
+
+Section with_effects.
+  Variable E : Type -> Type.
+
+  Inductive Eff {t : Type} : Type :=
+  | Ret (_ : t)
+  | Vis {u} (_ : E u) (_ : u -> Eff)
+  | Unknown.
+  Arguments Eff _ : clear implicits.
+
+  (* `Approx a b` when `a` is a "prefix" of `b`
+   *)
+  Inductive Approx {t} : Eff t -> Eff t -> Prop :=
+  | Approx_Any : forall b, Approx Unknown b
+  | Approx_Ret : forall a, Approx (Ret a) (Ret a)
+  | Approx_Vis : forall u (e : E u) k1 k2,
+      (forall x, Approx (k1 x) (k2 x)) ->
+      Approx (Vis e k1) (Vis e k2).
+
+  Global Instance Reflexive_Approx {t} : Reflexive (@Approx t).
+  Proof. compute. induction x; constructor; eauto. Qed.
+
+  Lemma Approx_inj_Vis:
+    forall (t : Type) (z : Eff t) (u : Type) (e : E u) (k2 : u -> Eff t),
+      Approx (Vis e k2) z ->
+      exists k : u -> Eff t, z = Vis e k /\ (forall x : u, Approx (k2 x) (k x)).
+  Proof.
+    intros t z u e k2 H1.
+    refine
+      match H1 in Approx a b
+            return match a  return Prop with
+                   | Vis e' k' => _
+                   | _ => True
+                   end
+      with
+      | Approx_Vis _ _ _ _ keq =>
+        ex_intro _ _ (conj eq_refl keq)
+      | _ => I
+      end.
+  Defined.
+
+  Global Instance Transitive_Approx {t} : Transitive (@Approx t).
+  Proof. compute. intros x y z H; revert z.
+         induction H; simpl; intros; eauto; try econstructor.
+         eapply Approx_inj_Vis in H1.
+         destruct H1 as [ ? [ ? ? ] ].
+         subst. constructor.
+         intros. eapply H0. eauto.
+  Qed.
+
+End with_effects.
+
+Arguments Eff _ _ : clear implicits.
+Arguments Ret {_} [_] _.
+Arguments Vis {_ _ _} _ _.
+Arguments Unknown {_ _}.
+Arguments Approx {_ _} _ _.
+
+Section upto.
+  Variable E : Type -> Type.
+
+  Fixpoint upto {t} (n : nat) (i : itree E t) {struct n}
+  : Eff E t :=
+    match n with
+    | 0 => Unknown
+    | S n => match i with
+            | ITree.Ret t => Ret t
+            | ITree.Vis e k => Vis e (fun x => upto n (k x))
+            | ITree.Tau k => upto n k
+            end
+    end.
+
+  Lemma Approx_upto : forall n t (a : itree E t),
+      Approx (upto n a) (upto (S n) a).
+  Proof.
+    induction n; simpl; intros.
+    - constructor.
+    - destruct a; try constructor; eauto.
+  Qed.
+
+  Lemma Approx_upto_strong
+  : forall n m, n < m ->
+           forall t (a : itree E t),
+             Approx (upto n a) (upto m a).
+  Proof.
+    induction 1.
+    - eapply Approx_upto.
+    - intros. etransitivity. eapply IHle. eapply Approx_upto.
+  Qed.
+
+End upto.

--- a/theories/UpTo.v
+++ b/theories/UpTo.v
@@ -1,5 +1,5 @@
 (* From interaction trees you can define semantics in an "up-to" style.
- * 
+ *
  * With interaction trees, you need to maintain the effects so the output
  * that you get is an inductive interaction tree with an extra
  * `Unknown`/`OutOfFuel` constructor. This is analagous to the need to
@@ -19,41 +19,41 @@ Section with_effects.
   | Unknown.
   Arguments Eff _ : clear implicits.
 
-  (* `Approx a b` when `a` is a "prefix" of `b`
+  (* `EffLe a b` when `a` is a "prefix" of `b`
    *)
-  Inductive Approx {t} : Eff t -> Eff t -> Prop :=
-  | Approx_Any : forall b, Approx Unknown b
-  | Approx_Ret : forall a, Approx (Ret a) (Ret a)
-  | Approx_Vis : forall u (e : E u) k1 k2,
-      (forall x, Approx (k1 x) (k2 x)) ->
-      Approx (Vis e k1) (Vis e k2).
+  Inductive EffLe {t} : Eff t -> Eff t -> Prop :=
+  | EffLe_Any : forall b, EffLe Unknown b
+  | EffLe_Ret : forall a, EffLe (Ret a) (Ret a)
+  | EffLe_Vis : forall u (e : E u) k1 k2,
+      (forall x, EffLe (k1 x) (k2 x)) ->
+      EffLe (Vis e k1) (Vis e k2).
 
-  Global Instance Reflexive_Approx {t} : Reflexive (@Approx t).
+  Global Instance Reflexive_EffLe {t} : Reflexive (@EffLe t).
   Proof. compute. induction x; constructor; eauto. Qed.
 
-  Lemma Approx_inj_Vis:
+  Lemma EffLe_inj_Vis:
     forall (t : Type) (z : Eff t) (u : Type) (e : E u) (k2 : u -> Eff t),
-      Approx (Vis e k2) z ->
-      exists k : u -> Eff t, z = Vis e k /\ (forall x : u, Approx (k2 x) (k x)).
+      EffLe (Vis e k2) z ->
+      exists k : u -> Eff t, z = Vis e k /\ (forall x : u, EffLe (k2 x) (k x)).
   Proof.
     intros t z u e k2 H1.
     refine
-      match H1 in Approx a b
+      match H1 in EffLe a b
             return match a  return Prop with
                    | Vis e' k' => _
                    | _ => True
                    end
       with
-      | Approx_Vis _ _ _ _ keq =>
+      | EffLe_Vis _ _ _ _ keq =>
         ex_intro _ _ (conj eq_refl keq)
       | _ => I
       end.
   Defined.
 
-  Global Instance Transitive_Approx {t} : Transitive (@Approx t).
+  Global Instance Transitive_EffLe {t} : Transitive (@EffLe t).
   Proof. compute. intros x y z H; revert z.
          induction H; simpl; intros; eauto; try econstructor.
-         eapply Approx_inj_Vis in H1.
+         eapply EffLe_inj_Vis in H1.
          destruct H1 as [ ? [ ? ? ] ].
          subst. constructor.
          intros. eapply H0. eauto.
@@ -65,10 +65,17 @@ Arguments Eff _ _ : clear implicits.
 Arguments Ret {_} [_] _.
 Arguments Vis {_ _ _} _ _.
 Arguments Unknown {_ _}.
-Arguments Approx {_ _} _ _.
+Arguments EffLe {_ _} _ _.
 
 Section upto.
   Variable E : Type -> Type.
+
+  Inductive Approx {t} : itree E t -> Eff E t -> Prop :=
+  | A_Unknown : forall it, Approx it Unknown
+  | A_Ret     : forall v, Approx (ITree.Ret v) (Ret v)
+  | A_Vis     : forall {u} (e : E u) k1 k2, (forall x, Approx (k1 x) (k2 x)) ->
+                                       Approx (ITree.Vis e k1) (Vis e k2)
+  | A_Tau     : forall it e, Approx it e -> Approx (ITree.Tau it) e.
 
   Fixpoint upto {t} (n : nat) (i : itree E t) {struct n}
   : Eff E t :=
@@ -81,22 +88,30 @@ Section upto.
             end
     end.
 
-  Lemma Approx_upto : forall n t (a : itree E t),
-      Approx (upto n a) (upto (S n) a).
+  Theorem Approx_upto : forall t n (it : itree E t),
+      Approx it (upto n it).
+  Proof.
+    induction n; simpl.
+    - constructor.
+    - destruct it; try constructor; eauto.
+  Qed.
+
+  Lemma EffLe_upto : forall n t (a : itree E t),
+      EffLe (upto n a) (upto (S n) a).
   Proof.
     induction n; simpl; intros.
     - constructor.
     - destruct a; try constructor; eauto.
   Qed.
 
-  Lemma Approx_upto_strong
+  Lemma EffLe_upto_strong
   : forall n m, n < m ->
            forall t (a : itree E t),
-             Approx (upto n a) (upto m a).
+             EffLe (upto n a) (upto m a).
   Proof.
     induction 1.
-    - eapply Approx_upto.
-    - intros. etransitivity. eapply IHle. eapply Approx_upto.
+    - eapply EffLe_upto.
+    - intros. etransitivity. eapply IHle. eapply EffLe_upto.
   Qed.
 
 End upto.


### PR DESCRIPTION
- the `upto` function defines a finite approximation of
  an interaction tree.
- it should be the case that if you prove something for all
  finite approximations (i.e. `forall n, P (upto n it)`, then
  it (appropriately converted) should also hold for the infinite
  interaction tree.
- This is the standard connection between bisimulation and
  step-indexing.