### PR TITLE
trying to fix the build

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,5 +17,5 @@ Once you do this, you can run `make _CoqProject` and it will build a `_CoqProjec
 **one liner**
 
 ```
-git clone https://github.com/DeepSpec/InteractionTrees.git && ./setup.sh
+git clone https://github.com/DeepSpec/InteractionTrees.git && cd InteractionTrees && ./setup.sh
 ```

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Run `setup.sh` from the root directory to setup dependencies and build the proje
 If you would like to use local versions of some of the dependencies, create a `_CoqPath` file and include the include paths for the libraries that you would like to include. For example,
 
 ```
--Q ...path/to/paco Paco
+-Q ...path/to/paco/src Paco
 ```
 
 Once you do this, you can run `make _CoqProject` and it will build a `_CoqProject` that contains your local paths and the repository-specific paths. This target is built automatically with `make` so you don't need to run it manually.

--- a/README.md
+++ b/README.md
@@ -3,28 +3,19 @@ Formalization of the Interaction Tree Datatype in Coq
 
 ## Installation instructions
 
-We recommend using [opam](http://coq.io/opam/) to install our dependencies. The one-liner for installing the dependencies is:
-
-```sh
-$ sh install-deps.sh
-```
+Run `setup.sh` from the root directory to setup dependencies and build the project.
 
 If you would like to use local versions of some of the dependencies, create a `_CoqPath` file and include the include paths for the libraries that you would like to include. For example,
 
 ```
--Q ...path/to/paco/theories... paco
+-Q ...path/to/paco Paco
 ```
 
 Once you do this, you can run `make _CoqProject` and it will build a `_CoqProject` that contains your local paths and the repository-specific paths. This target is built automatically with `make` so you don't need to run it manually.
 
-### Local Setup Instructions
 
-- run `setup.sh` from the root directory to setup dependencies.
-- run `make -C src` from the root directory to build.
+**one liner**
 
-** one liner **
 ```
-git clone https://github.com/DeepSpec/InteractionTrees.git && \
-      cd InteractionTrees/lib/ && ./setup.sh && cd src && make
+git clone https://github.com/DeepSpec/InteractionTrees.git && ./setup.sh
 ```
-

--- a/setup.sh
+++ b/setup.sh
@@ -12,4 +12,6 @@ git clone https://github.com/coq-ext-lib/coq-ext-lib.git
 
 cd ../ # at /
 
-make -C src
+printf -- '-Q lib/paco/ Paco\n-Q lib/coq-ext-lib/theories/ ExtLib\n' > _CoqPath
+
+make

--- a/setup.sh
+++ b/setup.sh
@@ -4,7 +4,7 @@ cd lib/
 
 # Set up paco
 git clone https://github.com/snu-sf/paco.git
-(cd paco && git checkout v1.2.8 && cd src && make)
+(cd paco/src; make)
 
 # Set up ExtLib
 git clone https://github.com/coq-ext-lib/coq-ext-lib.git
@@ -12,6 +12,6 @@ git clone https://github.com/coq-ext-lib/coq-ext-lib.git
 
 cd ../ # at /
 
-printf -- '-Q lib/paco/ Paco\n-Q lib/coq-ext-lib/theories/ ExtLib\n' > _CoqPath
+printf -- '-Q lib/paco/src Paco\n-Q lib/coq-ext-lib/theories/ ExtLib\n' > _CoqPath
 
 make

--- a/setup.sh
+++ b/setup.sh
@@ -3,8 +3,8 @@
 cd lib/
 
 # Set up paco
-git clone https://github.com/coq-contribs/paco.git
-(cd paco; make)
+git clone https://github.com/snu-sf/paco.git
+(cd paco && git checkout v1.2.8 && cd src && make)
 
 # Set up ExtLib
 git clone https://github.com/coq-ext-lib/coq-ext-lib.git


### PR DESCRIPTION
The readme tells me to run `install-deps.sh`, but there's no such file.

So I followed the "local" version, but running `./setup.sh` fails (at the very end of the script) with the message:

```
make: Entering directory '/home/sam/Documents/git/DeepSpec/InteractionTrees/src'
make: *** No targets specified and no makefile found.  Stop.
```

This PR brings this repo one step closer to build out-of-the box (with Coq 8.8.1), but running `./setup.sh` in a fresh repo with the changes of this PR still fails with the following message:

```
File "./theories/Equivalence.v", line 47, characters 7-15:
Error: The reference pmonauto was not found in the current environment.

make[2]: *** [Makefile.coq:657: theories/Equivalence.vo] Error 1
make[1]: *** [Makefile.coq:318: all] Error 2
```
