### PR TITLE
Alternative representation of effects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,14 @@ install: Makefile.coq all
 uninstall: Makefile.coq
 	$(MAKE) -f $< $@
 
+examples: example-imp example-lc
+
+example-imp: examples/Imp.v
+	coqc -Q theories/ ITree examples/Imp.v
+
+example-lc: examples/stlc.v
+	coqc -Q theories/ ITree examples/stlc.v
+
 Makefile.coq: _CoqProject
 	coq_makefile -f _CoqProject -o Makefile.coq
 

--- a/examples/stlc.v
+++ b/examples/stlc.v
@@ -7,7 +7,7 @@ Open Scope monad_scope.
 
 From ITree Require Import
      ITree
-     Effect
+     OpenSum
      Fix.
 
 Inductive term : Type :=

--- a/theories/Equivalence.v
+++ b/theories/Equivalence.v
@@ -9,13 +9,13 @@ Require Import ITree.ITree.
 
 Section EUTT.
 
-Variable E : Type -> Type.
+Variable E : Effect.
 Variable R : Type.
 
 Inductive eutt_0 (eutt : relation (itree E R)) :
   relation (itree E R) :=
 | Eutt_Ret : forall r, eutt_0 eutt (Ret r) (Ret r)
-| Eutt_Vis : forall X (e : E X) k1 k2,
+| Eutt_Vis : forall (e : E) k1 k2,
     (forall x, eutt (k1 x) (k2 x)) ->
     eutt_0 eutt (Vis e k1) (Vis e k2).
 Hint Constructors eutt_0.
@@ -115,7 +115,7 @@ Proof.
       auto.
 Qed.
 
-Lemma eutt_0_inj_Vis : forall {T} rel e (k : T -> itree E R) z,
+Lemma eutt_0_inj_Vis : forall rel e (k : reaction e -> itree E R) z,
     eutt_0 rel (Vis e k) z ->
     exists k', z = Vis e k' /\ (forall x, rel (k x) (k' x)).
 Proof.
@@ -127,7 +127,7 @@ Proof.
                       end
          with
          | Eutt_Ret _ _ => I
-         | Eutt_Vis _ _ _ _ _ _ => _
+         | Eutt_Vis _ _ _ _ _ => _
          end; simpl.
   eexists; split. reflexivity. assumption.
 Defined.
@@ -205,7 +205,7 @@ Proof.
 Qed.
 *)
 
-Lemma finite_taus_tau1: forall (E : Type -> Type) (R : Type) (t : itree E R),
+Lemma finite_taus_tau1: forall (E : Effect) (R : Type) (t : itree E R),
     finite_taus t -> finite_taus (Tau t).
 Proof.
   intros E R t H.
@@ -213,7 +213,7 @@ Proof.
   exists t'. split. assumption. apply OneTau. assumption.
 Qed.
 
-Lemma finite_taus_tau2: forall (E : Type -> Type) (R : Type) (t : itree E R),
+Lemma finite_taus_tau2: forall (E : Effect) (R : Type) (t : itree E R),
     finite_taus (Tau t) -> finite_taus t.
 Proof.
   intros E R t H.
@@ -223,7 +223,7 @@ Proof.
   - subst. inversion I1.
 Qed.
 
-Lemma untaus_tau_tau1 : forall (E : Type -> Type) (R : Type) (t1 t2 : itree E R),
+Lemma untaus_tau_tau1 : forall (E : Effect) (R : Type) (t1 t2 : itree E R),
     untaus t1 t2 -> untaus (Tau t1) t2.
 Proof.
   intros E R t1 t2 H.
@@ -233,7 +233,7 @@ Proof.
   - apply OneTau. assumption.
 Qed.
 
-Lemma untaus_tau_tau2 : forall (E : Type -> Type) (R : Type) (t1 t2 : itree E R),
+Lemma untaus_tau_tau2 : forall (E : Effect) (R : Type) (t1 t2 : itree E R),
     untaus (Tau t1) t2 -> untaus t1 t2.
 Proof.
   intros E R t1 t2 H.
@@ -243,13 +243,13 @@ Proof.
   - inversion I1.
 Qed.
 
-Lemma notau_finite_taus : forall (E : Type -> Type) (R : Type) (t : itree E R),
+Lemma notau_finite_taus : forall (E : Effect) (R : Type) (t : itree E R),
     notau E R t -> finite_taus t.
 Proof.
   intros E R t H. exists t. split. assumption. constructor.
 Qed.
 
-Lemma untaus'_finite_taus : forall (E : Type -> Type) (R : Type) (t t' : itree E R),
+Lemma untaus'_finite_taus : forall (E : Effect) (R : Type) (t t' : itree E R),
     untaus' E R t t' -> (finite_taus t <-> finite_taus t').
 Proof.
   intros E R t t' H. induction H.
@@ -258,13 +258,13 @@ Proof.
   - reflexivity.
 Qed.
 
-Lemma untaus_finite_taus :  forall (E : Type -> Type) (R : Type) (t t' : itree E R),
+Lemma untaus_finite_taus :  forall (E : Effect) (R : Type) (t t' : itree E R),
     untaus t t' -> (finite_taus t <-> finite_taus t').
 Proof.
   intros E R t t' [H1 H2]. symmetry. apply untaus'_finite_taus; assumption.
 Qed.
 
-Lemma equiv_tau1 : forall (E : Type -> Type) (R : Type) (t1 t2 : itree E R),
+Lemma equiv_tau1 : forall (E : Effect) (R : Type) (t1 t2 : itree E R),
     Tau t1 ~ t2 -> t1 ~ t2.
 Proof.
   intros E R.
@@ -281,7 +281,7 @@ Proof.
     + assumption.
 Qed.
 
-Lemma equiv_tau2 : forall (E : Type -> Type) (R : Type) (t1 t2 : itree E R),
+Lemma equiv_tau2 : forall (E : Effect) (R : Type) (t1 t2 : itree E R),
     t1 ~ t2 -> Tau t1 ~ t2.
 Proof.
   intros E R.
@@ -298,7 +298,7 @@ Proof.
     + assumption.
 Qed.
 
-Lemma untaus_equiv : forall (E : Type -> Type) (R : Type) (t t' : itree E R),
+Lemma untaus_equiv : forall (E : Effect) (R : Type) (t t' : itree E R),
     untaus t t' -> t ~ t'.
 Proof.
   intros E R t t' H.
@@ -315,7 +315,7 @@ Proof.
       * destruct (untaus_notau _ _ _ _ H1).
 Qed.
 
-Lemma finite_taus_equiv : forall (E : Type -> Type) (R : Type) (t1 t2 : itree E R),
+Lemma finite_taus_equiv : forall (E : Effect) (R : Type) (t1 t2 : itree E R),
     t1 ~ t2 -> finite_taus t1 -> finite_taus t2.
 Proof.
   intros E R t1 t2 H1 H2.

--- a/theories/Fix.v
+++ b/theories/Fix.v
@@ -11,7 +11,7 @@ Require Import ITree.OpenSum.
 Module Type FixSig.
   Section Fix.
     (* the ambient effects *)
-    Context {E : Type -> Type}.
+    Context {E : Effect}.
 
     Context {dom : Type}.
     Variable codom : dom -> Type.
@@ -33,30 +33,35 @@ End FixSig.
 Module FixImpl <: FixSig.
   Section Fix.
     (* the ambient effects *)
-    Variable E : Type -> Type.
+    Variable E : Effect.
 
     Variable dom : Type.
     Variable codom : dom -> Type.
 
     (* the fixpoint effect, used for representing recursive calls *)
-    Variant fixpoint : Type -> Type :=
-    | call : forall x : dom, fixpoint (codom x).
+    Variant fixpoint : Type :=
+    | call : forall x : dom, fixpoint.
+
+    Definition fixpointE : Effect := {|
+        action := fixpoint;
+        reaction := fun '(call x) => codom x;
+      |}.
 
     Section mfix.
       (* this is the body of the fixpoint. *)
-      Variable f : forall x : dom, itree (sum1 E fixpoint) (codom x).
+      Variable f : forall x : dom, itree (fixpointE +' E) (codom x).
 
       Local CoFixpoint homFix {T : Type}
-            (c : itree (sum1 E fixpoint) T)
+            (c : itree (fixpointE +' E) T)
         : itree E T :=
         match c with
         | Ret x => Ret x
-        | Vis (inl e) k =>
-          Vis e (fun x => homFix (k x))
-        | Vis (inr e) k =>
-          match e in fixpoint X return (X -> _) -> _ with
-          | call x => fun k =>
-                       Tau (homFix (Core.bind (f x) k))
+        | Vis e k =>
+          match e return (@reaction (_ +' _) e -> _) -> _ with
+          | inl (call x) => fun k =>
+            Tau (homFix (Core.bind (f x) k))
+          | inr e => fun k =>
+            Vis e (fun x => homFix (k x))
           end k
         | Tau x => Tau (homFix x)
         end.
@@ -64,10 +69,11 @@ Module FixImpl <: FixSig.
       Definition _mfix (x : dom) : itree E (codom x) :=
         homFix (f x).
 
-      Definition eval_fixpoint T (X : sum1 E fixpoint T) : itree E T :=
-        match X with
-        | inl e => Vis e Ret
-        | inr f0 =>
+      Definition eval_fixpoint (x : fixpointE +' E) :
+        itree E (reaction x) :=
+        match x with
+        | inr e => Vis e Ret
+        | inl f0 =>
           match f0 with
           | call x => Tau (_mfix x)
           end
@@ -102,9 +108,9 @@ Module FixImpl <: FixSig.
       Definition mfix
       : forall x : dom, itree E (codom x) :=
         _mfix
-          (body (E +' fixpoint)
-                (fun t => @interp _ _ (fun _ e => do e) _)
-                (fun x0 : dom => Vis (inr (call x0)) Ret)).
+          (body (fixpointE +' E)
+                (fun t => @interp _ _ (fun e => do e) _)
+                (fun x0 : dom => @Vis (fixpointE +' _) _ (inl (call x0)) Ret)).
 
       Theorem mfix_unfold : forall x,
           mfix x = body E (fun t => id) mfix x.

--- a/theories/ITree.v
+++ b/theories/ITree.v
@@ -1,6 +1,7 @@
-Require Import ExtLib.Structures.Functor.
-Require Import ExtLib.Structures.Applicative.
-Require Import ExtLib.Structures.Monad.
+From ExtLib.Structures Require Import
+     Functor Applicative Monad.
+
+From ITree Require Export Effect.
 
 Set Implicit Arguments.
 Set Contextual Implicit.
@@ -10,14 +11,14 @@ Set Contextual Implicit.
     [R] and every node is either a [Tau] node with one child, or a
     branching node [Vis] with a visible effect [E X] that branches
     on the values of [X]. *)
-CoInductive itree (E : Type -> Type) (R : Type) :=
+CoInductive itree (E : Effect) (R : Type) :=
 | Ret (r : R)
-| Vis {X : Type} (e : E X) (k : X -> itree E R)
+| Vis (e : E) (k : reaction e -> itree E R)
 | Tau (t : itree E R)
 .
 
 Arguments Ret {E R}.
-Arguments Vis {E R X}.
+Arguments Vis {E R}.
 Arguments Tau {E R}.
 
 (* [id_itree] as a notation makes it easier to
@@ -37,7 +38,7 @@ Arguments match_itree {E R} t.
 Module Core.
 
   Section bind.
-    Context {E : Type -> Type} {T U : Type}.
+    Context {E : Effect} {T U : Type}.
     Variable k : T -> itree E U.
 
     CoFixpoint bind' (c : itree E T) : itree E U :=
@@ -73,8 +74,7 @@ End Core.
  *)
 
 
-Definition liftE {E : Type -> Type} {X : Type}
-           (e : E X) : itree E X :=
+Definition liftE {E : Effect} (e : E) : itree E (reaction e) :=
   Vis e Ret.
 
 (** Functorial map ([fmap]) *)

--- a/theories/Morphisms.v
+++ b/theories/Morphisms.v
@@ -10,18 +10,18 @@ Require Import ITree.ITree.
 Require Import ExtLib.Structures.Functor.
 
 (* * Homomorphisms between effects *)
-Definition eff_hom (E E' : Type -> Type) : Type :=
-  forall t, E t -> itree E' t.
+Definition eff_hom (E E' : Effect) : Type :=
+  forall e : E, itree E' (reaction e).
 
 (* An `eff_hom` can be used to transport itrees between different effects.
  *)
-Definition interp {E F : Type -> Type}
+Definition interp {E F : Effect}
            (f : eff_hom E F) (R : Type)
 : itree E R -> itree F R :=
   cofix hom_f t :=
     match t with
     | Ret r => Ret r
-    | Vis e k => Core.bindTau (f _ e) (fun x => hom_f (k x))
+    | Vis e k => Core.bindTau (f e) (fun x => hom_f (k x))
     | Tau t => Tau (hom_f t)
     end.
 Arguments interp {E F} _ [R] _.
@@ -37,19 +37,19 @@ Arguments interp {E F} _ [R] _.
  *)
 Definition eh_compose {A B C} (g : eff_hom B C) (f : eff_hom A B)
 : eff_hom A C :=
-  fun _ e =>
-    interp g (f _ e).
+  fun e =>
+    interp g (f e).
 
 Definition eh_id {A} : eff_hom A A :=
-  fun _ e => Vis e Ret.
+  fun e => Vis e Ret.
 
 Section eff_hom_state.
   Variable s : Type.
-  Variable E E' : Type -> Type.
+  Variable E E' : Effect.
 
   (* * Stateful homomorphisms between effects *)
   Definition eff_hom_s : Type :=
-    forall t, E t -> s -> itree E' (s * t).
+    forall e : E, s -> itree E' (s * reaction e).
 
   (* question(gmm): Should we export this using `stateT`? That is,
    *
@@ -64,7 +64,7 @@ Section eff_hom_state.
   : itree E' (s * R) :=
     match t with
     | Ret r => Ret (st, r)
-    | Vis e k => Core.bindTau (f _ e st) (fun '(s',x) => interp_state _ (k x) s')
+    | Vis e k => Core.bindTau (f e st) (fun '(s',x) => interp_state _ (k x) s')
     | Tau t => Tau (interp_state _ t st)
     end.
 End eff_hom_state.
@@ -73,16 +73,16 @@ Arguments interp_state {_ _ _} _ [_] _ _.
 (* * Reader homomorphisms between effects *)
 Section eff_hom_reader.
   Variable s : Type.
-  Variable E E' : Type -> Type.
+  Variable E E' : Effect.
 
   Definition eff_hom_r : Type :=
-    forall t, E t -> s -> itree E' t.
+    forall e : E, s -> itree E' (reaction e).
 
   Variable f : eff_hom_r.
   CoFixpoint interp_reader (R : Type) (t : itree E R) (st : s) : itree E' R :=
     match t with
     | Ret r => Ret r
-    | Vis e k => Core.bindTau (f _ e st) (fun x => interp_reader _ (k x) st)
+    | Vis e k => Core.bindTau (f e st) (fun x => interp_reader _ (k x) st)
     | Tau t => Tau (interp_reader _ t st)
     end.
 
@@ -95,10 +95,10 @@ Require Import ExtLib.Structures.Monoid.
 (* * Writer homomorphisms between effects *)
 Section eff_hom_writer.
   Variable s : Type.
-  Variable E E' : Type -> Type.
+  Variable E E' : Effect.
 
   Definition eff_hom_w : Type :=
-    forall t, E t -> itree E' (s * t).
+    forall e : E, itree E' (s * reaction e).
 
   Context {Monoid_s : Monoid s}.
   Variable f : eff_hom_w.
@@ -117,7 +117,7 @@ Section eff_hom_writer.
    *)
   Definition interp_writer (R : Type) (t : itree E R) : itree E' (s * R) :=
     interp_state
-      (fun _ e s => fmap (fun '(s',x) => (monoid_plus Monoid_s s s', x)) (f _ e))
+      (fun e s => fmap (fun '(s',x) => (monoid_plus Monoid_s s s', x)) (f e))
       t (monoid_unit Monoid_s).
 
 End eff_hom_writer.
@@ -128,17 +128,17 @@ Arguments interp_writer {_ _ _ _} _ [_] _.
  * This can be useful for non-determinism.
  *)
 Section interp_prop.
-  Context {E F : Type -> Type}.
+  Context {E F : Effect}.
 
   Definition eff_hom_prop : Type :=
-    forall t, E t -> itree F t -> Prop.
+    forall e : E, itree F (reaction e) -> Prop.
 
   CoInductive interp_prop (f : eff_hom_prop) (R : Type)
   : itree E R -> itree F R -> Prop :=
   | ipRet : forall x, interp_prop f R (Ret x) (Ret x)
-  | ipVis : forall {T} {e : E T} {e' : itree F T}
-              (k : _ -> itree E R) (k' : T -> itree F R),
-      f _ e e' ->
+  | ipVis : forall {e : E} {e' : itree F (reaction e)}
+              (k : _ -> itree E R) (k' : reaction e -> itree F R),
+      f e e' ->
       (forall x, interp_prop f R (k x) (k' x)) ->
       interp_prop f R (Vis e k) (Core.bind e' k')
   | ipDelay : forall a b, interp_prop f R a b ->
@@ -150,7 +150,7 @@ Arguments eff_hom_prop _ _ : clear implicits.
 (* * An extensional effect morphism
  *)
 Section eff_hom_e.
-  Context {E F : Type -> Type}.
+  Context {E F : Effect}.
 
   (* note(gmm): you should be able to add effects here
    * using a monad transformer. In that case, the type
@@ -161,14 +161,14 @@ Section eff_hom_e.
    * but you have the usual conditions on strictly positive uses
    *)
   CoInductive eff_hom_e : Type :=
-  { eval : forall t, E t -> itree F (t * eff_hom_e) }.
+  { eval : forall e : E, itree F (reaction e * eff_hom_e) }.
 
   CoFixpoint interp_e (f : eff_hom_e) {t} (tr : itree E t)
   : itree F t :=
     match tr with
     | Ret v => Ret v
     | Vis e k =>
-      Core.bindTau (f.(eval) _ e) (fun '(x, f') => interp_e f' (k x))
+      Core.bindTau (f.(eval) e) (fun '(x, f') => interp_e f' (k x))
     | Tau tr => Tau (interp_e f tr)
     end.
 End eff_hom_e.

--- a/theories/MutFix.v
+++ b/theories/MutFix.v
@@ -6,10 +6,10 @@ Section mutual_fixpoints.
   Record ftype : Type :=
   { dom : Type
   ; codom : dom -> Type }.
-  Definition ftypeD (eff : Type -> Type) (ft : ftype) : Type :=
+  Definition ftypeD (eff : Effect) (ft : ftype) : Type :=
     forall x : ft.(dom), itree eff (ft.(codom) x).
 
-  Context {eff : Type -> Type}.
+  Context {eff : Effect}.
 
   Context {name : Type}.
   Variable type_of : name -> ftype.

--- a/theories/OpenSum.v
+++ b/theories/OpenSum.v
@@ -3,78 +3,81 @@
 (* TODO Swap sums (changed associativity). *)
 (* TODO Split framework for extensible effects from concrete effect definitions *)
 
-Set Implicit Arguments.
-Set Contextual Implicit.
-
-Require Import List.
+From Coq Require Import
+     List String.
 Import ListNotations.
-Require Import String.
 
-Require Import ITree.ITree.
-Require Import ITree.Morphisms.
+From ExtLib.Structures Require Import
+     Functor Monoid.
 
-Require Import ExtLib.Structures.Functor.
-Require Import ExtLib.Structures.Monoid.
-
-Variant void : Type := .
+From ITree Require Import
+     ITree Morphisms.
 
 (** Sums for extensible event types. *)
 
-Definition sum1 (E1 E2 : Type -> Type) (X : Type) : Type :=
-  E1 X + E2 X.
+Definition sumE (E1 E2 : Effect) : Effect := {|
+    action := action E1 + action E2;
+    reaction := fun e => match e with
+                         | inl e1 => reaction e1
+                         | inr e2 => reaction e2
+                         end;
+  |}.
 
-Variant emptyE : Type -> Type := .
+Notation "E1 +' E2" := (sumE E1 E2)
+(at level 50, left associativity) : type_scope.
+
+Definition emptyE : Effect := {|
+    action := Empty_set;
+    reaction := fun e => match e with end;
+  |}.
 
 (* Just for this section, [A B C D : Type -> Type] are more
    effect types. *)
 
-Definition swap1 {A B : Type -> Type} {X : Type}
-           (ab : sum1 A B X) : sum1 B A X :=
+Definition swap1 {A B : Effect}
+           (ab : A +' B) : B +' A :=
   match ab with
   | inl a => inr a
   | inr b => inl b
   end.
 
-Definition bimap_sum1 {A B C D : Type -> Type} {X Y : Type}
-           (f : A X -> C Y) (g : B X -> D Y)
-           (ab : sum1 A B X) : sum1 C D Y :=
+Definition bimap_sum1 {A B C D : Effect}
+           (f : A -> C) (g : B -> D)
+           (ab : sumE A B) : sumE C D :=
   match ab with
   | inl a => inl (f a)
   | inr b => inr (g b)
   end.
 
-Notation "E1 +' E2" := (sum1 E1 E2)
-(at level 50, left associativity) : type_scope.
-
 Section into.
-  Context {E F : Type -> Type}.
+  Context {E F : Effect}.
 
   Definition into (h : eff_hom E F) : eff_hom (E +' F) F :=
-    fun _ e =>
+    fun e =>
       match e with
-      | inl e => h _ e
+      | inl e => h e
       | inr e => Vis e Ret
       end.
 
   Definition into_state {s} (h : eff_hom_s s E F) : eff_hom_s s (E +' F) F :=
-    fun _ e s =>
+    fun e s =>
       match e with
-      | inl e => h _ e s
+      | inl e => h e s
       | inr e => Vis e (fun x => Ret (s, x))
       end.
 
   Definition into_reader {s} (h : eff_hom_r s E F) : eff_hom_r s (E +' F) F :=
-    fun _ e s =>
+    fun e s =>
       match e with
-      | inl e => h _ e s
+      | inl e => h e s
       | inr e => Vis e Ret
       end.
 
   Definition into_writer {s} `{Monoid_s : Monoid s} (h : eff_hom_w s E F)
   : eff_hom_w s (E +' F) F :=
-    fun _ e =>
+    fun e =>
       match e with
-      | inl e => h _ e
+      | inl e => h e
       | inr e => Vis e (fun x => Ret (monoid_unit Monoid_s, x))
       end.
 
@@ -88,36 +91,55 @@ End into.
    infinite instance resolution loops.
  *)
 
-Class Convertible (A B : Type -> Type) :=
-  { convert : forall {X}, A X -> B X }.
+Class Convertible (A B : Effect) := {
+    convert_action : A -> B;
+    convert_reaction : forall a : A,
+        reaction (convert_action a) -> reaction a;
+  }.
 
 (* Don't try to guess. *)
-Global Instance fluid_id A : Convertible A A | 0 :=
-  { convert X a := a }.
+Global Instance fluid_id A : Convertible A A | 0 := {
+    convert_action a := a;
+    convert_reaction _ x := x;
+  }.
 
 (* Destructure sums. *)
 Global Instance fluid_sum A B C `{Convertible A C} `{Convertible B C}
-: Convertible (sum1 A B) C | 7 :=
-  { convert X ab :=
+  : Convertible (A +' B) C | 7 := {
+    convert_action ab :=
       match ab with
-      | inl a => convert a
-      | inr b => convert b
-      end }.
+      | inl a => convert_action a
+      | inr b => convert_action b
+      end;
+    convert_reaction ab :=
+      match ab with
+      | inl a => convert_reaction a
+      | inr b => convert_reaction b
+      end;
+  }.
 
 (* Lean right by default for no reason. *)
 Global Instance fluid_left A B `{Convertible A B} C
-: Convertible A (sum1 B C) | 9 :=
-  { convert X a := inl (convert a) }.
+  : Convertible A (B +' C) | 9 := {
+    convert_action a := inl (convert_action a);
+    convert_reaction := convert_reaction;
+  }.
 
 (* Very incoherent instances. *)
 Global Instance fluid_right A C `{Convertible A C} B
-: Convertible A (sum1 B C) | 8 :=
-  { convert X a := inr (convert a) }.
+  : Convertible A (B +' C) | 8 := {
+    convert_action a := inr (convert_action a);
+    convert_reaction := convert_reaction;
+  }.
 
-Global Instance fluid_empty A : Convertible emptyE A :=
-  { convert X v := match v with end }.
+Global Instance fluid_empty A : Convertible emptyE A := {
+    convert_action v := match v with end;
+    convert_reaction v := match v with end;
+  }.
 
-Notation "EE ++' E" := (List.fold_right sum1 EE E)
+Arguments convert_reaction {_ _ _ a}.
+
+Notation "EE ++' E" := (List.fold_right sumE EE E)
 (at level 50, left associativity) : type_scope.
 
 Notation "E -< F" := (Convertible E F)
@@ -128,7 +150,7 @@ Module Import SumNotations.
 (* Is this readable? *)
 
 Delimit Scope sum_scope with sum.
-Bind Scope sum_scope with sum1.
+Bind Scope sum_scope with sumE.
 
 Notation "(| x )" := (inr x) : sum_scope.
 Notation "( x |)" := (inl x) : sum_scope.
@@ -172,31 +194,40 @@ Instance Embed_eff E F R `{Convertible E F} :
 Arguments embed {A B _} e.
 *)
 
-Definition vis {E F R X} `{F -< E}
-           (e : F X) (k : X -> itree E R) : itree E R :=
-  Vis (convert e) k.
+Notation compose f g := (fun x => f (g x)).
 
-Definition do {E F X} `{F -< E}
-           (e : F X) : itree E X :=
-  Vis (convert e) Ret.
+Definition vis {E F R} `{F -< E}
+           (e : F) (k : reaction e -> itree E R) : itree E R :=
+  Vis (convert_action e) (compose k convert_reaction).
 
+Definition do {E F} `{F -< E} (e : F) : itree E (reaction e) :=
+  Vis (convert_action e) (compose Ret convert_reaction).
 
 Section Failure.
 
-Variant failureE : Type -> Type :=
-| Fail : string -> failureE void.
+Variant failure : Type :=
+| Fail : string -> failure.
 
-Definition fail {E : Type -> Type} `{failureE -< E} {X}
+Definition failureE : Effect := {|
+    action := failure;
+    reaction := fun _ => Empty_set;
+  |}.
+
+Definition fail {E : Effect} `{failureE -< E} {X : Type}
            (reason : string)
   : itree E X :=
-  vis (Fail reason) (fun v : void => match v with end).
+  vis (Fail reason) (fun v : Empty_set => match v with end).
 
 End Failure.
 
 Section NonDeterminism.
 
-Variant nondetE : Type -> Type :=
-| Or : nondetE bool.
+Variant nondet : Type := Or.
+
+Definition nondetE : Effect := {|
+    action := nondet;
+    reaction := fun _ => bool;
+  |}.
 
 Definition or {E} `{nondetE -< E} {R} (k1 k2 : itree E R)
   : itree E R :=
@@ -232,14 +263,19 @@ Section Reader.
 
   Variable (env : Type).
 
-  Variant readerE : Type -> Type :=
-  | Ask : readerE env.
+  Variant reader : Type :=
+  | Ask : reader.
+
+  Definition readerE : Effect := {|
+      action := reader;
+      reaction := fun _ => env;
+    |}.
 
   Definition ask {E} `{Convertible readerE E} : itree E env :=
-    liftE (convert Ask).
+    vis Ask Ret.
 
   Definition eval_reader {E} : eff_hom_r env readerE E :=
-    fun _ e r =>
+    fun e r =>
       match e with
       | Ask => Ret r
       end.
@@ -257,9 +293,17 @@ Section State.
 
   Variable (S : Type).
 
-  Variant stateE : Type -> Type :=
-  | Get : stateE S
-  | Put : S -> stateE unit.
+  Variant state : Type :=
+  | Get : state
+  | Put : S -> state.
+
+  Definition stateE : Effect := {|
+      action := state;
+      reaction e := match e with
+                    | Get => S
+                    | Put _ => unit
+                    end;
+    |}.
 
   Definition get {E} `{stateE -< E} : itree E S := do Get.
   Definition put {E} `{stateE -< E} (s : S) : itree E unit :=
@@ -267,7 +311,7 @@ Section State.
 
 
   Definition eval_state {E} : eff_hom_s S stateE E :=
-    fun _ e s =>
+    fun e s =>
       match e with
       | Get => Ret (s, s)
       | Put s' => Ret (s', tt)
@@ -301,16 +345,23 @@ Arguments put {S E _}.
 Arguments run_state {_ _} [_] _ _.
 
 Section Tagged.
-  Variable E : Type -> Type.
+  Variable E : Effect.
 
-  Record Tagged (tag : Set) (t : Type) : Type := mkTagged
-  { unTag : E t }.
+  Record Tagged (tag : Set) : Type := mkTagged
+  { unTag : E }.
 
-  Definition atTag (tag : Set) {t} (e : E t) : Tagged tag t :=
+  Global Arguments unTag {tag}.
+
+  Definition atTag (tag : Set) (e : E) : Tagged tag :=
   {| unTag := e |}.
 
-  Definition eval_tagged {tag} : eff_hom (Tagged tag) E :=
-    fun _ e => Vis e.(unTag) Ret.
+  Definition taggedE tag : Effect := {|
+      action := Tagged tag;
+      reaction e := reaction (unTag e);
+    |}.
+
+  Definition eval_tagged {tag} : eff_hom (taggedE tag) E :=
+    fun e => Vis (unTag e) Ret.
 
 End Tagged.
 
@@ -324,15 +375,22 @@ Section Counter.
 
   (* Parameterizing by the type of counters makes it easier
    to have more than one counter at once. *)
-  Variant counterE (N : Type) : Type -> Type :=
-  | Incr : counterE N N.
+  Variant counter (N : Type) : Type :=
+  | Incr : counter N.
+
+  Global Arguments Incr {N}.
+
+  Definition counterE N : Effect := {|
+      action := counter N;
+      reaction _ := N;
+    |}.
 
   Definition incr {N E} `{counterE N -< E} : itree E N :=
     do Incr.
 
   Definition eval_counter {N E} `{Countable N}
   : eff_hom_s N (counterE N) E :=
-    fun _ e s =>
+    fun e s =>
       match e with
       | Incr => Ret (succ s, s)
       end.
@@ -349,8 +407,13 @@ Section Writer.
 
   Variable (W : Type).
 
-  Variant writerE : Type -> Type :=
-  | Tell : W -> writerE unit.
+  Variant writer : Type :=
+  | Tell : W -> writer.
+
+  Definition writerE : Effect := {|
+      action := writer;
+      reaction _ := unit;
+    |}.
 
   Definition tell {E} `{writerE -< E} (w : W) : itree E unit :=
     do (Tell w).
@@ -360,22 +423,33 @@ End Writer.
 Section Stop.
   (* "Return" as an effect. *)
 
-  Variant stopE (S : Type) : Type -> Type :=
-  | Stop : S -> stopE S void.
+  Variant stop_ (S : Type) : Type :=
+  | Stop : S -> stop_ S.
+
+  Global Arguments Stop {S}.
+
+  Definition stopE S : Effect := {|
+      action := stop_ S;
+      reaction _ := Empty_set;
+    |}.
 
   Definition stop {E S R} `{stopE S -< E} : S -> itree E R :=
     fun s =>
-      vis (Stop s) (fun v : void => match v with end).
+      vis (Stop s) (fun v : Empty_set => match v with end).
 
 End Stop.
 
-Arguments stopE S X.
 Arguments stop {E S R _}.
 
 Section Trace.
 
-  Variant traceE : Type -> Type :=
-  | Trace : string -> traceE unit.
+  Variant trace_ : Type :=
+  | Trace : string -> trace_.
+
+  Definition traceE : Effect := {|
+      action := trace_;
+      reaction _ := unit;
+    |}.
 
   Definition trace {E} `{traceE -< E} (msg : string) : itree E unit :=
     do (Trace msg).
@@ -386,11 +460,11 @@ Section Trace.
     match t with
     | Ret r => Ret r
     | Tau t => Tau (ignore_trace t)
-    | Vis ( e |) k =>
-      match e in traceE T return (T -> _) -> _ with
-      | Trace _ => fun k => Tau (ignore_trace (k tt))
+    | Vis e k =>
+      match e return (@reaction (_ +' _) e -> _) -> _ with
+      | ( Trace _ |) => fun k => Tau (ignore_trace (k tt))
+      | (| e ) => fun k => Vis e (fun x => ignore_trace (k x))
       end k
-    | Vis (| e ) k => Vis e (fun x => ignore_trace (k x))
     end.
 
 End Trace.

--- a/theories/Trace.v
+++ b/theories/Trace.v
@@ -3,64 +3,64 @@ Import ListNotations.
 
 Require Import ITree.ITree.
 
-Inductive event (E : Type -> Type) : Type :=
-| Event : forall X, E X -> X -> event E.
+Inductive event (E : Effect) : Type :=
+| Event : forall e : E, reaction e -> event E.
 
-Arguments Event {E X}.
+Arguments Event {E}.
 
-Definition trace (E : Type -> Type) : Type := list (event E).
+Definition trace (E : Effect) : Type := list (event E).
 
-Inductive is_trace {E : Type -> Type} {R : Type} :
+Inductive is_trace {E : Effect} {R : Type} :
   itree E R -> trace E -> option R -> Prop :=
 | TraceEmpty : forall t, is_trace t [] None
 | TraceRet : forall r, is_trace (Ret r) [] (Some r)
 | TraceTau : forall t tr r_,
   is_trace t tr r_ ->
   is_trace (Tau t) tr r_
-| TraceVis : forall X (e : E X) (x : X) k tr r_,
+| TraceVis : forall (e : E) (x : reaction e) k tr r_,
   is_trace (k x) tr r_ ->
   is_trace (Vis e k) (Event e x :: tr) r_
 .
 
-Definition trace_incl {E : Type -> Type} {R : Type} :
+Definition trace_incl {E : Effect} {R : Type} :
   itree E R -> itree E R -> Prop :=
   fun t1 t2 =>
     forall tr r_, is_trace t1 tr r_ -> is_trace t2 tr r_.
 
 (* [step_ ev t' t] if [t] steps to [t'] (read right to left!)
    with visible event [ev]. *) 
-Inductive step_ {E : Type -> Type} {R : Type}
+Inductive step_ {E : Effect} {R : Type}
           (ev : event E) (t' : itree E R) :
   itree E R -> Prop :=
 | StepTau : forall t, step_ ev t' t -> step_ ev t' (Tau t)
-| StepVis : forall X (e : E X) (x : X) k,
+| StepVis : forall (e : E) (x : reaction e) k,
     ev = Event e x ->
     t' = k x ->
     step_ ev t' (Vis e k)
 .
 
-Definition step {E : Type -> Type} {R : Type}
+Definition step {E : Effect} {R : Type}
            (ev : event E) (t t' : itree E R) : Prop :=
   step_ ev t' t.
 
-CoInductive simulates {E : Type -> Type} {R : Type} :
+CoInductive simulates {E : Effect} {R : Type} :
   itree E R -> itree E R -> Prop :=
 | SimStep : forall t1 t2,
     (forall ev t1', step ev t1 t1' ->
      exists    t2', step ev t2 t2' /\ simulates t1' t2') ->
     simulates t1 t2.
 
-Theorem simulates_trace_incl {E : Type -> Type} {R : Type} :
+Theorem simulates_trace_incl {E : Effect} {R : Type} :
   forall t1 t2 : itree E R,
     simulates t1 t2 -> trace_incl t1 t2.
 Proof.
 Abort.
 
 (* Set-of-traces monad *)
-Definition traces (E : Type -> Type) (R : Type) : Type :=
+Definition traces (E : Effect) (R : Type) : Type :=
   trace E -> option R -> Prop.
 
-Definition bind_traces {E : Type -> Type} {R S : Type}
+Definition bind_traces {E : Effect} {R S : Type}
            (ts : traces E R) (kts : R -> traces E S) : traces E S :=
   fun tr s_ =>
     (s_ = None /\ ts tr None) \/
@@ -69,7 +69,7 @@ Definition bind_traces {E : Type -> Type} {R S : Type}
         ts tr1 (Some r) /\
         kts r tr s_).
 
-Definition ret_traces {E : Type -> Type} {R : Type} :
+Definition ret_traces {E : Effect} {R : Type} :
   R -> traces E R :=
   fun r tr r_ =>
     tr = [] /\ (r_ = None \/ r_ = Some r).


### PR DESCRIPTION
This is still very experimental, and whether the change is really beneficial remains to be determined.

Instead of an indexed type `Type -> Type` an effect type is now a dependent record `{ action : Type; reaction : action -> Type }` and the `Vis` constructor now has type...

```coq
Vis : forall (e : action) (k : reaction e -> itree), itree
(* as opposed to: forall (X : Type) (e : E X) (k : X -> itree), itree *)
```

The point is that `Vis` has one fewer index, and that equality between effect constructors `e` can be expressed homogeneously `e = e'`, as opposed to the heterogeneous `existT _ X (e : E X) = existT _ X' (e' : E X')` that currently get generated by some uses of `inversion` with predicates about itrees. (But we still get heterogeneous equalities between continuations `existT _ e (k : reaction e -> _) = existT _ e' (k' : reaction e' -> _)`.)

There is a bit of type inference that needs to be figured out: in `Imp.v` I had to specialize some occurrences of `do` (function that lifts raw effects to trees: `(E -< F) -> E X -> itree F X` (old) or `(E -< F) -> forall e : E, itree F (reaction e)` (new)).