### PR TITLE
Licence and OPAM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+language: c
+sudo: required
+install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-opam.sh
+script: bash -ex .travis-opam.sh
+env:
+  global:
+  - EXTRA_REMOTES="https://coq.inria.fr/opam/released https://coq.inria.fr/opam/extra-dev"
+  matrix:
+  - OCAML_VERSION=4.02
+  - OCAML_VERSION=4.07
+os:
+  - linux
+  - osx
+matrix:
+  fast_finish: true
+  allow_failures:
+  - os: osx
+cache:
+  apt: true
+  directories:
+  - $HOME/.opam
+  - $HOME/Library/Caches/Homebrew

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 DeepSpec
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/coq-itree.opam
+++ b/coq-itree.opam
@@ -2,9 +2,10 @@ opam-version: "1.2"
 name: "coq-itree"
 version: "dev"
 maintainer: "Li-yao Xia <lysxia@gmail.com>"
+synopsis: "Formalization of the Interaction Tree Datatype in Coq"
 
 homepage: "https://github.com/DeepSpec/InteractionTrees"
-dev-repo: "https://github.com/DeepSpec/InteractionTrees"
+dev-repo: "git+https://github.com/DeepSpec/InteractionTrees"
 bug-reports: "https://github.com/DeepSpec/InteractionTrees/issues"
 license: "MIT"
 

--- a/opam
+++ b/opam
@@ -1,0 +1,26 @@
+opam-version: "1.2"
+name: "coq-itree"
+version: "dev"
+maintainer: "Li-yao Xia <lysxia@gmail.com>"
+
+homepage: "https://github.com/DeepSpec/InteractionTrees"
+dev-repo: "https://github.com/DeepSpec/InteractionTrees"
+bug-reports: "https://github.com/DeepSpec/InteractionTrees/issues"
+license: "MIT"
+
+build: [ make "-j%{jobs}%" ]
+install: [ make "install" ]
+remove: [ "rm" "-rf" "%{lib}%/coq/user-contrib/ITree" ]
+
+depends: [
+  "coq-ext-lib"
+  "coq-paco"
+]
+
+authors: [
+  "Li-yao Xia <lysxia@gmail.com>"
+  "Gregory Malecha <gmalecha@gmail.com>"
+  "Steve Zdancewic <stevez@cis.upenn.edu>"
+]
+
+tags: "org:deepspec"


### PR DESCRIPTION
Prepare for releasing on [coq-extra-dev](/coq/opam-coq-archive/tree/master/extra-dev).
## Added
- MIT license
- `opam` file