### PR TITLE
change Tau to notation?

### DIFF
--- a/examples/IO.v
+++ b/examples/IO.v
@@ -12,12 +12,12 @@ Definition example : itree IO unit :=
 Definition SOME_NUMBER := 13.
 
 Definition test_interp : itree IO unit -> bool := fun t =>
-  match t with
-  | Vis e k =>
+  match t.(observe) with
+  | VisF e k =>
     match e in IO X return (X -> _) -> _ with
     | Read => fun id =>
-      match k (id SOME_NUMBER) with
-      | Vis (Write n) _ => n =? SOME_NUMBER
+      match (k (id SOME_NUMBER)).(observe) with
+      | VisF (Write n) _ => n =? SOME_NUMBER
       | _ => false
       end
     | _ => fun _ => false

--- a/examples/Nimp.v
+++ b/examples/Nimp.v
@@ -4,7 +4,7 @@ From Coq Require Import
      Relations.
 
 From ITree Require Import
-     ITree Equivalence Fix.
+     ITree Eq.UpToTaus Fix.
 
 Inductive com : Type :=
 | loop : com -> com (* Nondeterministically, continue or stop. *)
@@ -137,7 +137,9 @@ Definition one_loop_tree : itree nd unit :=
     else
       Ret tt)%itree.
 
-Lemma eval_one_loop : (eval one_loop ~ one_loop_tree)%eutt.
+
+(* SAZ: the [~] notation for eutt wasn't working here. *)
+Lemma eval_one_loop : eutt (eval one_loop) (one_loop_tree).
 Proof.
 Abort.
 

--- a/tests/extraction/MetaModule.v
+++ b/tests/extraction/MetaModule.v
@@ -1,5 +1,5 @@
 From ITree Require Import
-     ITree Equivalence UpTo MutFix.
+     ITree Eq.Eq Eq.UpToTaus MutFix.
 
 (* Coq extraction seems to have problem with module synonyms.
    We just make these synonyms abstract for now. *)

--- a/theories/Eq/Eq.v
+++ b/theories/Eq/Eq.v
@@ -148,7 +148,7 @@ Defined.
 
 Lemma bind_ret {E R} :
   forall s : itree E R,
-    (s >>= Ret) ≅ s.
+    (s >>= (fun x => Ret x)) ≅ s.
 Proof.
   cofix bind_ret.
   intros s.

--- a/theories/Fix.v
+++ b/theories/Fix.v
@@ -69,7 +69,7 @@ Module FixImpl <: FixSig.
 
       Definition eval_fixpoint T (X : sum1 E fixpoint T) : itree E T :=
         match X with
-        | inlE e => Vis e Ret
+        | inlE e => Vis e (fun x => Ret x)
         | inrE f0 =>
           match f0 with
           | call x => Tau (_mfix x)
@@ -107,7 +107,7 @@ Module FixImpl <: FixSig.
         _mfix
           (body (E +' fixpoint)
                 (fun t => @interp _ _ (fun _ e => do e) _)
-                (fun x0 : dom => Vis (inrE (call x0)) Ret)).
+                (fun x0 : dom => Vis (inrE (call x0)) (fun x => Ret x))).
 
       Theorem mfix_unfold : forall x,
           mfix x = body E (fun t => id) mfix x.

--- a/theories/ITree.v
+++ b/theories/ITree.v
@@ -28,12 +28,21 @@ Section itree.
   Definition Ret (x : R) : itree := do (RetF x).
   Definition Vis {u} (e : E u) (k : u -> itree) : itree :=
     do (VisF e k).
-  Definition Tau (t : itree) : itree := do (TauF t).
 
 End itree.
 
 Arguments itreeF _ _ : clear implicits.
 Arguments itree _ _ : clear implicits.
+
+(** We could use a definition for [Tau] as with [Ret] and [Vis] above, but
+    notation works better for extraction.  (The [spin] definition, given below
+    does not extract correctly if [Tau] is a definition.
+*)
+Bind Scope itree_scope with itree.
+Delimit Scope itree_scope with itree.
+Local Open Scope itree_scope.
+(* SAZ: What is the right precedence for [Tau]? *)
+Notation "'Tau' t" := (do (TauF t)) (at level 100, right associativity) : itree_scope.
 
 Section bind.
   Context {E : Type -> Type} {T U : Type}.
@@ -87,8 +96,6 @@ Definition map {E R S} (f : R -> S) : itree E R -> itree E S :=
    We can also make ExtLib's [bind] opaque, in which case it still
    doesn't hurt to have these notations around.
  *)
-Bind Scope itree_scope with itree.
-Delimit Scope itree_scope with itree.
 
 Notation "t1 >>= k2" := (bind t1 k2)
   (at level 50, left associativity) : itree_scope.

--- a/theories/MFixITree.v
+++ b/theories/MFixITree.v
@@ -187,9 +187,9 @@ Section EX2.
   Hint Resolve monotone_body.
 
 
-  Definition undef := Vis Undef Ret.
-  Definition store x := Vis (Store x) Ret.
-  Definition load := Vis Load Ret.
+  Definition undef := Vis Undef (fun x => Ret x).
+  Definition store x := Vis (Store x) (fun x => Ret x).
+  Definition load := Vis Load (fun x => Ret x).
 
   Definition prog1 : itree SIO nat  :=
     x <- undef ;;

--- a/theories/Morphisms.v
+++ b/theories/Morphisms.v
@@ -60,7 +60,7 @@ Definition eh_compose {A B C} (g : eff_hom B C) (f : eff_hom A B)
     interp g (f _ e).
 
 Definition eh_id {A} : eff_hom A A :=
-  fun _ e => Vis e Ret.
+  fun _ e => Vis e (fun x => Ret x).
 
 Section eff_hom_state.
   Variable s : Type.

--- a/theories/Morphisms.v
+++ b/theories/Morphisms.v
@@ -9,6 +9,8 @@
 Require Import ITree.ITree.
 Require Import ExtLib.Structures.Functor.
 
+Open Scope itree_scope.
+
 (* * Homomorphisms between effects *)
 Definition eff_hom (E E' : Type -> Type) : Type :=
   forall t, E t -> itree E' t.

--- a/theories/OpenSum.v
+++ b/theories/OpenSum.v
@@ -54,7 +54,7 @@ Section into.
     fun _ e =>
       match e with
       | inlE e => h _ e
-      | inrE e => Vis e Ret
+      | inrE e => Vis e (fun x => Ret x)
       end.
 
   Definition into_state {s} (h : eff_hom_s s E F) : eff_hom_s s (E +' F) F :=
@@ -68,7 +68,7 @@ Section into.
     fun _ e s =>
       match e with
       | inlE e => h _ e s
-      | inrE e => Vis e Ret
+      | inrE e => Vis e (fun x => Ret x)
       end.
 
   Definition into_writer {s} `{Monoid_s : Monoid s} (h : eff_hom_w s E F)
@@ -179,7 +179,7 @@ Definition vis {E F R X} `{F -< E}
 
 Definition do {E F X} `{F -< E}
            (e : F X) : itree E X :=
-  Vis (convert e) Ret.
+  Vis (convert e) (fun x => Ret x).
 
 
 Section Failure.
@@ -310,7 +310,7 @@ Section Tagged.
   {| unTag := e |}.
 
   Definition eval_tagged {tag} : eff_hom (Tagged tag) E :=
-    fun _ e => Vis e.(unTag) Ret.
+    fun _ e => Vis e.(unTag) (fun x => Ret x).
 
 End Tagged.
 


### PR DESCRIPTION
The current master branch doesn't work cleanly with extraction because the definition of `Tau`, which is the body of `spin`, isn't allowed by OCaml (it doesn't allow an application on the right-hand-side of `let rec`).

This pull requests attempts to fix the issue by turning the `Tau` helper function into notation (which does extract cleanly). 

There are a couple questions:
- Is this the right solution?  
- Given that is , what is the right precedence for [Tau]
- Would we want to treat either [Ret] or [Bind] as notation instead of definitions?