### PR TITLE
Infrastructures and proofs using paco

### DIFF
--- a/_CoqConfig
+++ b/_CoqConfig
@@ -1,5 +1,7 @@
 -Q theories ITree
 
+theories/paco2_respectful.v
+
 theories/Core.v
 
 theories/Eq/Eq.v

--- a/theories/Core.v
+++ b/theories/Core.v
@@ -4,7 +4,14 @@ Require Import ExtLib.Structures.Monad.
 
 Set Implicit Arguments.
 Set Contextual Implicit.
-Set Primitive Projections.
+(* Set Primitive Projections. *)
+
+(* Move the following tactic somewhere appropriate *)
+Lemma hexploit_mp: forall P Q: Type, P -> (P -> Q) -> Q.
+Proof. intuition. Defined.
+Ltac hexploit x := eapply hexploit_mp; [eapply x|].
+
+Ltac inv H := inversion H; clear H; subst.
 
 Section itree.
 
@@ -42,12 +49,18 @@ Section itree.
 
    ]]
 
-  *)
+   *)
+
+  Lemma itree_unfold : forall s:itree, s = go (s.(observe)).
+  Proof.
+    intros. destruct s; auto.
+  Qed.
   
 End itree.
 
 Arguments itreeF _ _ : clear implicits.
 Arguments itree _ _ : clear implicits.
+Arguments itree_unfold {E R} s.
 
 (** We introduce notation for the [Tau], [Ret], and [Vis] constructors. Using
     notation rather than definitions works better for extraction.  (The [spin]

--- a/theories/Core.v
+++ b/theories/Core.v
@@ -4,7 +4,7 @@ Require Import ExtLib.Structures.Monad.
 
 Set Implicit Arguments.
 Set Contextual Implicit.
-(* Set Primitive Projections. *)
+Set Primitive Projections.
 
 (* Move the following tactic somewhere appropriate *)
 Lemma hexploit_mp: forall P Q: Type, P -> (P -> Q) -> Q.
@@ -32,6 +32,8 @@ Section itree.
   CoInductive itree : Type := go
   { observe : itreeF itree }.
 
+  Axiom itree_eta : forall s, s = go (s.(observe)).
+
   (** Notes about using [itree]:
 
      - You should simplify using [cbn] rather than [simpl] when working
@@ -51,16 +53,11 @@ Section itree.
 
    *)
 
-  Lemma itree_unfold : forall s:itree, s = go (s.(observe)).
-  Proof.
-    intros. destruct s; auto.
-  Qed.
-  
 End itree.
 
 Arguments itreeF _ _ : clear implicits.
 Arguments itree _ _ : clear implicits.
-Arguments itree_unfold {E R} s.
+Arguments itree_eta {E R} s.
 
 (** We introduce notation for the [Tau], [Ret], and [Vis] constructors. Using
     notation rather than definitions works better for extraction.  (The [spin]
@@ -232,3 +229,9 @@ Global Instance Monad_itree {E} : Monad (itree E) :=
 {| ret := fun _ x => Ret x
 ;  bind := @ITree.bind E
 |}.
+
+Lemma bind'_to_bind {E R U} : forall (t: itree E U) (k: U -> itree E R),
+    ITree.bind' k t = ITree.bind t k.
+Proof. reflexivity. Qed.
+
+Ltac fold_bind := rewrite !bind'_to_bind in *.

--- a/theories/Eq/Eq.v
+++ b/theories/Eq/Eq.v
@@ -210,7 +210,8 @@ Instance eq_itree_vis {E R u} (e: E u) :
   Proper (pointwise_relation _ eq_itree ==>
           @eq_itree E R) (fun k => Vis e k).
 Proof.
-  repeat intro. econstructor; [| econstructor; apply H]; eauto.
+  repeat intro. pfold. econstructor.
+  intros. left. apply H.
 Qed.
 
 Lemma bind_ret {E R} :

--- a/theories/Eq/Eq.v
+++ b/theories/Eq/Eq.v
@@ -5,193 +5,230 @@
 (* TODO: paco-fy this *)
 
 From Coq Require Import
+     Program
      Setoid
      Morphisms
+     RelationClasses
      ProofIrrelevance.
 
+
 From ITree Require Import
+     paco2_respectful
      Core.
+
+From Paco Require Import paco.
 
 Section eq_itree.
   Context {E : Type -> Type} {R : Type}.
 
-  Inductive eq_itreeF {t} (sim : t -> t -> Prop) : relation (@itreeF E R t) :=
-  | EqRet : forall x, eq_itreeF sim (RetF x) (RetF x)
-  | EqTau : forall m1 m2,
-      sim m1 m2 -> eq_itreeF sim (TauF m1) (TauF m2)
-  | EqVis : forall {u} (e : E u) k1 k2,
-      (forall y, sim (k1 y) (k2 y)) ->
-      eq_itreeF sim (VisF e k1) (VisF e k2)
+  Inductive eq_itreeF (sim: relation (itree E R)) : relation (itree E R) :=
+  | EqRet: forall r,
+               eq_itreeF sim (Ret r) (Ret r)
+  | EqTau: forall t1 t2
+                 (REL: sim t1 t2),
+               eq_itreeF sim (Tau t1) (Tau t2)
+  | EqVis: forall u (e: E u) k1 k2
+                  (REL: forall v, sim (k1 v) (k2 v)),
+               eq_itreeF sim (Vis e k1) (Vis e k2)
   .
+  Hint Constructors eq_itreeF.
 
-  Global Instance Reflexive_eq_itreeF {t} {sim : t -> t -> Prop}
-  : Reflexive sim -> Reflexive (@eq_itreeF t sim).
+  Global Instance Reflexive_eq_itreeF sim
+  : Reflexive sim -> Reflexive (@eq_itreeF sim).
   Proof.
-    red. destruct x.
-    - constructor.
-    - constructor. reflexivity.
-    - constructor. intro; eapply H.
+    red. destruct x, observe; eauto.
   Qed.
 
-  Global Instance Symmetric_eq_itreeF {t} {sim : t -> t -> Prop}
-  : Symmetric sim -> Symmetric (@eq_itreeF t sim).
+  Global Instance Symmetric_eq_itreeF sim
+  : Symmetric sim -> Symmetric (@eq_itreeF sim).
   Proof.
-    red. inversion 2.
-    - constructor.
-    - constructor. eauto.
-    - constructor. intros; eapply H. eapply H1.
+    red. inversion 2; eauto.
   Qed.
 
-  Global Instance Transitive_eq_itreeF {t} {sim : t -> t -> Prop}
-  : Transitive sim -> Transitive (@eq_itreeF t sim).
+  Global Instance Transitive_eq_itreeF sim
+  : Transitive sim -> Transitive (@eq_itreeF sim).
   Proof.
-    red. inversion 2.
-    - inversion 1. constructor.
-    - inversion 1. constructor. eauto.
-    - inversion 1.
-      (* todo(gmm): i don't think these are strictly necessary *)
-      eapply inj_pair2 in H7.
-      eapply inj_pair2 in H8.
-      subst. constructor. eauto.
+    red. inversion 2; inversion 1; eauto.
+    subst. dependent destruction H6. dependent destruction H7. eauto.
   Qed.
 
-  CoInductive eq_itree (l r : itree E R) : Prop :=
-  { observe_eq : eq_itreeF eq_itree l.(observe) r.(observe) }.
+  Lemma eq_itreeF_mono : monotone2 eq_itreeF.
+  Proof. pmonauto. Qed.
+
+  Definition peq_itree r := paco2 eq_itreeF r.
+
+  Definition eq_itree : relation (itree E R) := peq_itree bot2.
 
 End eq_itree.
 
+Hint Constructors eq_itreeF.
+Hint Resolve eq_itreeF_mono : paco.
+Hint Unfold peq_itree.
+Hint Unfold eq_itree.
 
 Delimit Scope eq_itree_scope with eq_itree.
 (* note(gmm): overriding `=` seems like a bad idea *)
 Notation "t1 ≅ t2" := (eq_itree t1%itree t2%itree) (at level 70).
 (* you can write ≅ using \cong in tex-mode *)
 
-Instance Reflexive_eq_itree {E R} : Reflexive (@eq_itree E R).
+Global Instance Reflexive_eq_itree {E R} : Reflexive (@eq_itree E R).
 Proof.
-  cofix self.
-  intro.
-  constructor.
-  destruct (observe x).
-  - constructor.
-  - constructor. eapply self.
-  - constructor. intros. eapply self.
+  pcofix CIH; intros.
+  pfold. destruct x, observe; eauto.
 Qed.
 
-Instance Symmetric_eq_itree {E R} : Symmetric (@eq_itree E R).
+Global Instance Symmetric_eq_itree {E R} : Symmetric (@eq_itree E R).
 Proof.
-  cofix self.
-  intros x y H.
-  constructor. eapply observe_eq in H.
-  destruct H; constructor.
-  - apply self. assumption.
-  - intros. eapply self. eapply H.
+  pcofix CIH; intros.
+  pfold. punfold H0. destruct H0; eauto.
+  - pclearbot. eauto.
+  - econstructor. intros. specialize (REL v). pclearbot. eauto.
 Qed.
 
-Instance Transitive_eq_itree {E R} : Transitive (@eq_itree E R).
+Global Instance Transitive_eq_itree {E R} : Transitive (@eq_itree E R).
 Proof.
-  cofix self.
-  intros x y z; intros.
-  eapply observe_eq in H.
-  eapply observe_eq in H0.
-  constructor.
-  generalize dependent (observe x); generalize dependent (observe y);
-    generalize dependent (observe z).
-  inversion 1; subst.
-  - clear. eauto.
-  - inversion 1. subst.
-    constructor.
-    eapply self. eassumption. eassumption.
-  - inversion 1.
-    subst.
-    eapply inj_pair2 in H5. subst.
-    eapply inj_pair2 in H6. subst.
-    constructor.
-    intros.
-    eapply self. eapply H4. eapply H.
+  pcofix CIH. intros.
+  pfold. punfold H0. punfold H1. destruct H0; dependent destruction H1; eauto.
+  - pclearbot. eauto.
+  - econstructor. intros. specialize (REL v). specialize (REL0 v). pclearbot. eauto.
 Qed.
 
-Instance Equivalence_eq_itree {E R} :
+Global Instance Equivalence_eq_itree {E R} :
   Equivalence (@eq_itree E R).
 Proof.
   constructor; typeclasses eauto.
 Qed.
 
-Instance Proper_bind {E R S} :
-  Proper (eq_itree ==> pointwise_relation _ eq_itree ==> eq_itree)
-         (@ITree.bind E R S).
-Proof.
-  intros s1 s2 Hs k1 k2 Hk.
-  generalize dependent s2.
-  generalize dependent s1.
-  cofix core_bind_mor.
-  intros.
-  constructor. simpl. unfold ITree.bind_match.
-  inversion Hs.
-  do 2 rewrite ITree.observe_bind.
-  inversion observe_eq0.
-  { eapply Hk. }
-  { constructor.
-    eapply core_bind_mor. eapply H1. }
-  { constructor; intros.
-    eapply core_bind_mor. eapply H1. }
-Defined.
+(* The right notion of equality for coinductive types is the bisimilarity.
+   We can axiomatize it in Coq as we axiomatize the function extensionality for function types.
+   Though it is possible to use setoids for bisimilarity without using this axiom,
+   assuming it would make proof engineering much simpler.
+ *)
+(* Axiom eq_itree_eq: forall E R (s t: itree E R), eq_itree s t -> s = t. *)
+
 
 Definition bind_unfold {E R S}
            (t : itree E R) (k : R -> itree E S) :
-  eq_itree (ITree.bind t k) (ITree.bind_match k (ITree.bind' k) t).
+  ITree.bind t k = ITree.bind_match k (ITree.bind' k) t.
 Proof.
-  revert t.
-  cofix bind_unfold.
-  constructor; cbn.
-  destruct (observe t); auto.
-  - reflexivity.
-  - constructor. reflexivity.
-  - constructor. reflexivity.
+  simpl. rewrite (itree_unfold (ITree.bind t k)). simpl.
+  setoid_rewrite <-itree_unfold. reflexivity.
 Qed.
 
 Lemma ret_bind {E R S} (r : R) :
   forall k : R -> itree E S,
-    eq_itree (Ret r >>= k) (k r).
+    ITree.bind (Ret r) k = (k r).
 Proof.
-  constructor; cbn; reflexivity.
+  intros. rewrite bind_unfold. reflexivity.
+Qed.
+
+Lemma tau_bind {E R} U t (k: U -> itree E R) :
+  ITree.bind (Tau t) k = Tau (ITree.bind t k).
+Proof.
+  setoid_rewrite bind_unfold at 1. reflexivity.
+Qed.
+
+Lemma vis_bind {E R} U V (e: E V) (ek: V -> itree E U) (k: U -> itree E R) :
+  ITree.bind (Vis e ek) k = Vis e (fun x => ITree.bind (ek x) k).
+Proof.
+  setoid_rewrite bind_unfold at 1. reflexivity.
+Qed.
+
+Inductive eq_itree_trans_clo {E R} (r: relation (itree E R)) : relation (itree E R) :=
+| eq_itree_trans_clo_intro (t1 t2 t3 t4: itree E R)
+      (EQVl: t1 ≅ t2)
+      (EQVr: t4 ≅ t3)
+      (RELATED: r t2 t3)
+  : eq_itree_trans_clo r t1 t4
+.
+Hint Constructors eq_itree_trans_clo.
+
+Lemma eq_itree_clo_trans E R: weak_respectful2 (@eq_itreeF E R) eq_itree_trans_clo.
+Proof.
+  econstructor; [pmonauto|].
+  intros. dependent destruction PR.
+  apply GF in RELATED.
+  punfold EQVl. punfold EQVr.
+  dependent destruction EQVl; dependent destruction EQVr; pclearbot
+  ; dependent destruction RELATED; eauto using rclo2.
+
+  econstructor. intros. specialize (REL v). specialize (REL0 v). pclearbot. eauto using rclo2.
+Qed.
+
+Inductive eq_itree_bind_clo {E R} (r: relation (itree E R)) : relation (itree E R) :=
+| pbc_intro U (t1 t2: itree E U) k1 k2
+      (EQV: t1 ≅ t2)
+      (REL: forall v, r (k1 v) (k2 v))
+  : eq_itree_bind_clo r (ITree.bind t1 k1) (ITree.bind t2 k2)
+.
+Hint Constructors eq_itree_bind_clo.
+
+Lemma eq_itree_clo_bind E R: weak_respectful2 (@eq_itreeF E R) eq_itree_bind_clo.
+Proof.
+  econstructor; try pmonauto.
+  intros. dependent destruction PR.
+  punfold EQV. dependent destruction EQV.
+  - rewrite !ret_bind. eapply eq_itreeF_mono; eauto using rclo2.
+  - rewrite !tau_bind. pclearbot. eauto 7 using rclo2.
+  - rewrite !vis_bind. econstructor.
+    intros x. specialize (REL x). pclearbot. eauto 7 using rclo2.
+Qed.
+
+Instance eq_itree_bind {E R S} :
+  Proper (@eq_itree E R ==>
+          pointwise_relation _ eq_itree ==>
+          @eq_itree E S) ITree.bind.
+Proof.
+  repeat intro. pupto2_init.
+  pupto2 (eq_itree_clo_bind E S). econstructor; eauto.
+  intros. pupto2_final. apply H0.
+Qed.
+
+Instance eq_itree_tau {E R} :
+  Proper (@eq_itree E R ==>
+          @eq_itree E R) (fun t => Tau t).
+Proof. repeat intro. eauto 10. Qed.
+
+Instance eq_itree_vis {E R u} (e: E u) :
+  Proper (pointwise_relation _ eq_itree ==>
+          @eq_itree E R) (fun k => Vis e k).
+Proof.
+  repeat intro. econstructor; [| econstructor; apply H]; eauto.
 Qed.
 
 Lemma bind_ret {E R} :
   forall s : itree E R,
-    (s >>= (fun x => Ret x))%itree ≅ s.
+    ITree.bind s (fun x => Ret x) ≅ s.
 Proof.
-  cbn; cofix bind_ret.
-  intros s; constructor; cbn.
-  destruct (observe s); constructor; eauto.
+  pcofix CIH. intros.
+  pfold. destruct s, observe.
+  - rewrite ret_bind. eauto.
+  - rewrite tau_bind. eauto.
+  - rewrite vis_bind. eauto.
 Qed.
 
 Lemma bind_bind {E R S T} :
   forall (s : itree E R) (k : R -> itree E S) (h : S -> itree E T),
-    ( (s >>= k) >>= h
-      ≅
-      s >>= (fun r => k r >>= h)
-    ).
+    ITree.bind (ITree.bind s k) h ≅ ITree.bind s (fun r => ITree.bind (k r) h).
 Proof.
-  cofix bind_bind.
-  intros s k h.
-  constructor; cbn.
-  destruct (observe s).
-  - reflexivity.
-  - constructor.
-    eapply (bind_bind t k h).
-  - constructor.
-    intros.
-    apply (bind_bind (k0 y) k h).
+  revert R S.
+  pcofix CIH. intros.
+  destruct s, observe.
+  - rewrite !ret_bind.
+    eapply paco2_mon; [apply Reflexive_eq_itree|contradiction].
+  - rewrite !tau_bind. eauto.
+  - rewrite !vis_bind. eauto.
 Qed.
 
-Lemma map_map : forall {E R S T} (f : R -> S) (g : S -> T) (t : itree E R),
+Lemma map_map {E R S T}: forall (f : R -> S) (g : S -> T) (t : itree E R),
     ITree.map g (ITree.map f t) ≅ ITree.map (fun x => g (f x)) t.
 Proof.
-  intros E R S T f g.
-  cofix ch.
-  intros t.
-  econstructor; cbn.
-  destruct (observe t); cbn; econstructor; eauto.
+  unfold ITree.map. revert R S.
+  pcofix CIH. intros.
+  pfold. destruct t, observe.
+  - rewrite !ret_bind. eauto.
+  - rewrite !tau_bind. eauto.
+  - rewrite !vis_bind. eauto.
 Qed.
 
 (*

--- a/theories/Eq/UpToTaus.v
+++ b/theories/Eq/UpToTaus.v
@@ -17,6 +17,8 @@
  *)
 
 From Coq Require Import
+     Program
+     Lia
      Classes.RelationClasses
      Classes.Morphisms
      Setoids.Setoid
@@ -25,13 +27,26 @@ From Coq Require Import
 
 Require Import Paco.paco.
 
-From ITree Require Import Core Eq.Eq.
+From ITree Require Import paco2_respectful Core Eq.Eq.
 
 Set Bullet Behavior "Strict Subproofs".
 
 Lemma iff_or_and {P Q : Prop} :
   P <-> Q -> P \/ Q -> P /\ Q.
 Proof. firstorder. Qed.
+
+
+(* [notau t] holds when [t] does not start with a [Tau]. *)
+Definition notau E R (t : itree E R) : Prop :=
+  match t.(observe) with
+  | TauF _ => False
+  | _ => True
+  end.
+Arguments notau [E] [R] t.
+
+Definition anyitree E R (t : itree E R) : Prop := True.
+Arguments anyitree [E] [R] t.
+Hint Unfold anyitree.
 
 Section EUTT.
 
@@ -46,57 +61,48 @@ Context {E : Type -> Type} {R : Type}.
 (* Equivalence between visible steps of computation (i.e., [Vis] or
    [Ret], parameterized by a relation [eutt] between continuations
    in the [Vis] case. *)
-Variant eutt_0F (eutt : relation (itree E R))
-: relation (itreeF E R (itree E R)) :=
-| Eutt_Ret : forall r, eutt_0F eutt (RetF r) (RetF r)
-| Eutt_Vis : forall {u1 u2} (e1 : E u1) (e2 : E u2) k1 k2,
+Variant euttF0 (eutt : relation (itree E R))
+: relation (itree E R) :=
+| Eutt_ret : forall r, euttF0 eutt (Ret r) (Ret r)
+| Eutt_vis : forall u (e : E u) k1 k2,
+    (forall x, eutt (k1 x) (k2 x)) ->
+    euttF0 eutt (Vis e k1) (Vis e k2).
+Hint Constructors euttF0.
+
+Variant euttF0' (eutt : relation (itree E R))
+: relation (itree E R) :=
+| Eutt_ret' : forall r, euttF0' eutt (Ret r) (Ret r)
+| Eutt_vis' : forall {u1 u2} (e1 : E u1) (e2 : E u2) k1 k2,
     eq_dep _ E _ e1 _ e2 ->
     (forall x1 x2, JMeq x1 x2 -> eutt (k1 x1) (k2 x2)) ->
-    eutt_0F eutt (VisF e1 k1) (VisF e2 k2).
-Hint Constructors eutt_0F.
+    euttF0' eutt (Vis e1 k1) (Vis e2 k2).
+Hint Constructors euttF0'.
 
-Inductive eutt_0 (eutt : relation (itree E R)) (l r : itree E R) : Prop :=
-{ eutt_0_observe : eutt_0F eutt l.(observe) r.(observe) }.
+Lemma euttF0_eq_euttF0': forall eutt t s,
+  euttF0 eutt t s <-> euttF0' eutt t s.
+Proof.
+  split; intros EUTT; destruct EUTT; eauto.
+  - econstructor; intros; subst; eauto.
+  - assert (u1 = u2) by (inv H; eauto).
+    subst. apply eq_dep_eq in H. subst. eauto.
+Qed.
 
 (* [untaus t' t] holds when [t = Tau (... Tau t' ...)]:
    [t] steps to [t'] by "peeling off" a finite number of [Tau].
    "Peel off" means to remove only taus at the root of the tree,
    not any behind a [Vis] step). *)
-Inductive untaus (t t' : itree E R) : Prop :=
-| NoTau : t' = t -> untaus t t'
-| OneTau : forall t_,
-    t.(observe) = TauF t_ -> untaus t_ t' -> untaus t t'
+Inductive untaus (P: forall E R, itree E R -> Prop) : nat -> relation (itree E R) :=
+| NoTau t (PROP: P _ _ t) : untaus P 0 t t
+| OneTau n t t' (TAUS: untaus P n t t') : untaus P (S n) (Tau t) t'
 .
 Hint Constructors untaus.
 
-(* [notau t] holds when [t] does not start with a [Tau]. *)
-Definition notau (t : itree E R) : Prop :=
-  match t.(observe) with
-  | TauF _ => False
-  | _ => True
-  end.
-
-Lemma notau_Tau t t' : t.(observe) = TauF t' -> notau t -> False.
-Proof.
-  unfold notau; intros Hobs; rewrite Hobs; auto.
-Qed.
-
-(* [unalltaus t t'] holds when [t] steps to [t'] by peeling off
-   all of its taus, of which there must be a finite number. *)
-Definition unalltaus t t' := notau t' /\ untaus t t'.
-
-Lemma unalltaus_Tau_ t t_ t' :
-  notau t' -> t.(observe) = TauF t_ -> untaus t t' -> untaus t_ t'.
-Proof.
-  intros Hnotau Hobs Huntaus.
-  inversion Huntaus.
-  + subst; edestruct notau_Tau; eauto.
-  + rewrite Hobs in H; inversion H; auto.
-Qed.
+Notation unalltaus := (untaus notau).
 
 (* [finite_taus t] holds when [t] has a finite number of taus
    to peel. *)
-Definition finite_taus t : Prop := exists t', unalltaus t t'.
+Definition finite_taus t : Prop := exists n t', unalltaus n t t'.
+Hint Unfold finite_taus.
 
 (* [eutt_ eutt t1 t2] means that, if [t1] or [t2] ever takes a
    visible step ([Vis] or [Ret]), then the other takes the same
@@ -106,237 +112,219 @@ Definition finite_taus t : Prop := exists t', unalltaus t t'.
    case, the parameter [eutt] is irrelevant.
 
    This is the relation we will take a fixpoint of. *)
-Definition eutt_ (eutt : relation _) : relation _ := fun t1 t2 =>
-  (finite_taus t1 <-> finite_taus t2) /\
-  forall t1' t2',
-    unalltaus t1 t1' -> unalltaus t2 t2' ->
-    eutt_0 eutt t1' t2'.
+Inductive euttF (eutt : relation (itree E R)) (t1 t2: itree E R) : Prop :=
+| euttF_ (FIN: finite_taus t1 <-> finite_taus t2)
+         (EQV: forall n m t1' t2'
+                  (UNTAUS1: unalltaus n t1 t1')
+                  (UNTAUS2: unalltaus m t2 t2'),
+               euttF0 eutt t1' t2')
+.
+Hint Constructors euttF.
 
 (* Paco takes the greatest fixpoints of monotone relations. *)
 
 (* [eutt_0] is monotone: if a binary relation [eutt] implies [eutt'],
    then [eutt_0 eutt] implies [eutt_0 eutt']. *)
-Lemma monotone_eutt_0 : monotone2 eutt_0.
+Lemma monotone_euttF0 : monotone2 euttF0.
 Proof.
-  constructor. inversion IN.
-  inversion eutt_0_observe0; constructor; eauto.
+  pmonauto.
 Qed.
-
-Hint Resolve monotone_eutt_0 : paco.
+Hint Resolve monotone_euttF0.
 
 (* [eutt_] is monotone. *)
-Lemma monotone_eutt_ : monotone2 eutt_.
+Lemma monotone_euttF : monotone2 euttF.
 Proof.
-  unfold monotone2.
-  intros t1 t2 r r' [I H] Hr.
-  split.
-  - auto.
-  - intros t1' t2' H1 H2.
-    eapply monotone_eutt_0; eauto.
+  pmonauto.
 Qed.
-
-Hint Resolve monotone_eutt_ : paco.
+Hint Resolve monotone_euttF : paco.
 
 (* We now take the greatest fixpoint of [eutt_]. *)
 
 (* [eutt t1 t2]: [t1] is equivalent to [t2] up to taus. *)
-Definition eutt : relation (itree E R) := paco2 eutt_ bot2.
+Definition eutt : relation (itree E R) := paco2 euttF bot2.
 
 Global Arguments eutt t1%itree t2%itree.
 
-Delimit Scope eutt_scope with eutt.
-Local Open Scope eutt_scope.
-
 (* note: overlaps with [not] *)
-Infix "~" := eutt (at level 70) : eutt_scope.
+Infix "~~" := eutt (at level 70).
 
 (* Lemmas about the auxiliary relations. *)
 
 (* Many have a name [X_Y] to represent an implication
    [X _ -> Y _] (possibly with more arguments on either side). *)
 
-(* If a tree [t] does not start with a [Tau], then peeling off
-   all [Tau] does nothing to it. *)
-Lemma notau_unalltaus (t : itree E R) : notau t -> unalltaus t t.
-Proof. split; auto. Qed.
+
+Lemma untaus_change_prop Q P n (t t' : itree E R) :
+  untaus P n t t' -> (Q _ _ t':Prop) -> untaus Q n t t'.
+Proof. induction 1; eauto. Qed.
+
+Lemma untaus_prop P n (t t' : itree E R) : untaus P n t t' -> P _ _ t'.
+Proof. intros. induction H; eauto. Qed.
 
 (* If [t] does not start with [Tau], removing all [Tau] does
    nothing. Can be thought of as [notau_unalltaus] composed with
    [unalltaus_injective] (below). *)
-Lemma unalltaus_notau_id t t' :
-  unalltaus t t' -> notau t -> t' = t.
+Lemma unalltaus_notau_id n t t' :
+  unalltaus n t t' -> notau t -> t' = t.
 Proof.
-  intros [? []] Hnotau.
-  - auto.
-  - edestruct notau_Tau; eauto.
+  intros. destruct H; eauto. contradiction.
 Qed.
 
-(* "Peel off all taus" is a special case of "peel off taus". *)
-Lemma unalltaus_untaus (t t' : itree E R) :
-  unalltaus t t' -> untaus t t'.
-Proof. firstorder. Qed.
-
 (* There is only one way to peel off all taus. *)
-Lemma unalltaus_injective : forall t t1 t2,
-    unalltaus t t1 -> unalltaus t t2 -> t2 = t1.
+Lemma unalltaus_injective : forall n m t t1 t2,
+    unalltaus n t t1 -> unalltaus m t t2 -> t2 = t1.
 Proof.
-  intros t t1 t2 [I1 H1] [I2 H2].
-  induction H1 as [ | t t1 t_1 Hobs1 H1 IH1 ];
-    inversion H2 as [ H2' | t2_ Hobs2 H2' ];
-    subst; auto;
-      try solve [edestruct notau_Tau; eauto].
-  apply IH1; auto.
-  rewrite Hobs1 in Hobs2; inversion Hobs2; auto.
+  intros. revert m t2 H0.
+  induction H; intros; eauto using unalltaus_notau_id.
+  inv H0; eauto. contradiction.
 Qed.
 
 (* Adding a [Tau] to [t1] then peeling them all off produces
    the same result as peeling them all off from [t1]. *)
-Lemma unalltaus_tau (t1 t1_ t2 : itree E R) :
-  t1.(observe) = TauF t1_ ->
-  unalltaus t1 t2 <-> unalltaus t1_ t2.
+Lemma unalltaus_tau n t1 t2 :
+  unalltaus n (Tau t1) t2 -> unalltaus (pred n) t1 t2.
 Proof.
-  split; intros [I1 H1].
-  - split; auto.
-    inversion H1; subst.
-    + edestruct notau_Tau; eauto.
-    + rewrite H in H0; inversion H0; auto.
-  - split; auto.
-    eapply OneTau; eauto.
+  intros. inv H; eauto. contradiction.
 Qed.
 
 (* If [t] does not start with [Tau], then it starts with finitely
    many [Tau]. *)
 Lemma notau_finite_taus (t : itree E R) : notau t -> finite_taus t.
-Proof.
-  exists t; split; auto.
-Qed.
+Proof. eexists 0. eexists. eauto. Qed.
+
+Lemma notau_ret: forall r, notau (Ret r: itree E R).
+Proof. intros. cbn. eauto. Qed.
+Hint Resolve notau_ret.
+
+Lemma notau_vis u: forall (e: E u) k, notau (Vis e k: itree E R).
+Proof. intros. cbn. eauto. Qed.
+Hint Resolve notau_vis.
 
 (* [Vis] and [Ret] start with no taus, of course. *)
-Lemma finite_taus_Ret (r : R) : finite_taus (Ret r).
-Proof.
-  apply notau_finite_taus; constructor.
-Qed.
+Lemma finite_taus_ret (r : R) : finite_taus (Ret r).
+Proof. eexists 0. eauto. Qed.
 
-Lemma finite_taus_Vis {u} (e : E u) (k : u -> itree E R) :
+Lemma finite_taus_vis {u} (e : E u) (k : u -> itree E R) :
   finite_taus (Vis e k).
-Proof.
-  apply notau_finite_taus; constructor.
-Qed.
+Proof. eexists 0. eauto. Qed.
 
 (* [finite_taus] is preserved by removing or adding one [Tau]. *)
-Lemma finite_taus_Tau (t t' : itree E R) :
-  t.(observe) = TauF t' ->
-  finite_taus t <-> finite_taus t'.
+Lemma finite_taus_tau (t : itree E R) :
+  finite_taus (Tau t) <-> finite_taus t.
 Proof.
-  intro Hobs.
-  split; intros [t1 [I1 H1]].
-  - inversion H1; subst.
-    + edestruct notau_Tau; eauto.
-    + exists t1; split; auto.
-      rewrite Hobs in H; inversion_clear H; auto.
-  - exists t1; split; auto.
-    eapply OneTau; eauto.
+  split; intros TAUS; destruct TAUS, H; red; eexists; eauto using unalltaus_tau.
 Qed.
 
-(* [finite_taus] is preserved by removing or adding any finite
-   number of [Tau]. *)
-Lemma untaus_finite_taus (t t' : itree E R) :
-    untaus t t' -> (finite_taus t <-> finite_taus t').
+(* (* [finite_taus] is preserved by removing or adding any finite *)
+(*    number of [Tau]. *) *)
+Lemma untaus_finite_taus P n (t t' : itree E R) :
+    untaus P n t t' -> (finite_taus t <-> finite_taus t').
 Proof.
   induction 1.
-  - subst; reflexivity.
-  - erewrite finite_taus_Tau; eassumption.
-Qed.
-
-(* [finite_taus] is preserved by removing all taus. *)
-Lemma unalltaus_finite_taus (t t' : itree E R) :
-    unalltaus t t' -> (finite_taus t <-> finite_taus t').
-Proof.
-  intros []. apply untaus_finite_taus; assumption.
+  - reflexivity.
+  - erewrite finite_taus_tau; eassumption.
 Qed.
 
 (**)
 
 (* If [t1] and [t2] are equivalent, then either both start with
    finitely many taus, or both [spin]. *)
-Lemma eutt_finite_taus (t1 t2 : itree E R) :
-  t1 ~ t2 -> finite_taus t1 <-> finite_taus t2.
-Proof. intro H; punfold H; apply H. Qed.
+Lemma finite_taus_eutt (t1 t2 : itree E R) :
+  t1 ~~ t2 -> finite_taus t1 -> finite_taus t2.
+Proof. intros. punfold H. apply H. eauto. Qed.
+
+Lemma eq_unalltaus :
+  forall n (t1 t2 t1' : itree E R)
+    (FT: unalltaus n t1 t1')
+    (EQV: t1 ≅ t2),
+  exists t2', unalltaus n t2 t2'.
+Proof.
+  intros. revert t2 EQV.
+  induction FT; intros; punfold EQV.
+  - inv EQV; cbn; eauto.
+  - inv EQV. pclearbot.
+    edestruct IHFT; eauto.
+Qed.
+
+Lemma eq_unalltaus_eq :
+  forall n (t t' s : itree E R)
+    (UNTAUS : unalltaus n t t')
+    (EQV: t ≅ s),
+  exists s', unalltaus n s s' /\ t' ≅ s'.
+Proof.
+  intros. revert s EQV.
+  induction UNTAUS; intros.
+  - exists s. split; eauto.
+    punfold EQV. inv EQV; eauto.
+  - punfold EQV. inv EQV. pclearbot.
+    edestruct IHUNTAUS as [s' [? ?]]; eauto.
+Qed.
+
 
 (* If [t1] and [t2] are equivalent, and one starts with finitely many
    taus, then both do, and the peeled off [t1'] and [t2'] take
    the same visible step. *)
 Lemma eutt_unalltaus_1 (t1 t2 : itree E R) :
-  t1 ~ t2 -> finite_taus t1 ->
-  exists t1' t2',
-    unalltaus t1 t1' /\ unalltaus t2 t2' /\ eutt_0 eutt t1' t2'.
+  t1 ~~ t2 -> finite_taus t1 ->
+  exists n m t1' t2',
+    unalltaus n t1 t1' /\ unalltaus m t2 t2' /\ euttF0 eutt t1' t2'.
 Proof.
   intros Heutt Ht1. punfold Heutt.
   destruct Heutt as [Hfinite Heutt0].
   assert (Ht2 : finite_taus t2).
   { apply Hfinite; auto. }
-  destruct Ht1 as [t1' Ht1'].
-  destruct Ht2 as [t2' Ht2'].
-  exists t1'.
-  exists t2'.
-  do 2 (split; auto).
-  eapply monotone_eutt_0; eauto.
-  (* No idea what's going on. Paco magic *)
-  intros ? ? PR; pfold. destruct PR; [ punfold H | inversion H ].
+  destruct Ht1 as [n [t1' Ht1']].
+  destruct Ht2 as [m [t2' Ht2']].
+  exists n, m, t1', t2'; repeat split; eauto.
+  eapply monotone_euttF0; eauto.
+  intros. pclearbot. eauto.
 Qed.
 
 (* Reflexivity of [eutt_0], modulo a few assumptions. *)
-Lemma reflexive_eutt_0 eutt t :
-  Reflexive eutt -> notau t -> eutt_0 eutt t t.
+Lemma reflexive_euttF0 eutt t :
+  Reflexive eutt -> notau t -> euttF0 eutt t t.
 Proof.
-  intros Hrefl Ht.
-  revert Ht.
-  intros.
-  constructor.
-  unfold notau in *.
-  destruct (observe t); try constructor.
-  - contradiction.
-  - constructor.
+  intros. destruct t, observe; try contradiction; econstructor; intros; subst; eauto.
+Qed.
+
+Lemma euttF_tau r t1 t2 :
+  (euttF r t1 t2) ->
+  euttF r (Tau t1) (Tau t2).
+Proof.
+  intros. destruct H. econstructor.
+  - rewrite !finite_taus_tau. eauto.
+  - intros. eapply EQV; apply unalltaus_tau; eauto.
+Qed.
+
+Lemma euttF_vis {u} (r : relation (itree E R)) (e : _ u) k1 k2 :
+  (forall x, r (k1 x) (k2 x)) ->
+  euttF r (Vis e k1) (Vis e k2).
+Proof.
+  intros. econstructor.
+  - split; intros; now apply notau_finite_taus.
   - intros.
-    erewrite (JMeq_congr k) by apply H.
-    eapply Hrefl.
+    apply unalltaus_notau_id in UNTAUS1; [ | constructor ].
+    apply unalltaus_notau_id in UNTAUS2; [ | constructor ].
+    subst. eauto.
 Qed.
 
 (**)
 
-Lemma eutt_Vis_ {u} (r : relation (itree E R)) (e : _ u) k1 k2 :
-  (forall x1 x2, JMeq x1 x2 -> r (k1 x1) (k2 x2)) ->
-  eutt_ r (Vis e k1) (Vis e k2).
-Proof.
-  split.
-  - split; intros; now apply notau_finite_taus.
-  - intros t1' t2' H1 H2.
-    apply unalltaus_notau_id in H1; [ | constructor ].
-    apply unalltaus_notau_id in H2; [ | constructor ].
-    constructor. subst. constructor.
-    + constructor.
-    + apply H.
-Qed.
-
-Lemma Reflexive_eutt_ (r : relation (itree E R)) :
-  Reflexive r -> Reflexive (eutt_ r).
+Lemma Reflexive_euttF (r : relation (itree E R)) :
+  Reflexive r -> Reflexive (euttF r).
 Proof.
   split.
   - reflexivity.
-  - intros t1 t2 H1 H2.
-    erewrite (unalltaus_injective _ _ _ H1 H2).
-    apply reflexive_eutt_0; auto.
-    firstorder.
+  - intros.
+    erewrite (unalltaus_injective _ _ _ _ _ UNTAUS1 UNTAUS2).
+    apply reflexive_euttF0; eauto using (untaus_prop notau).
 Qed.
 
 (* [eutt] is an equivalence relation. *)
-Global Instance Reflexive_eutt
-: forall r, Reflexive (paco2 eutt_ r).
+Global Instance Reflexive_eutt: (Reflexive eutt).
 Proof.
   pcofix Reflexive_eutt.
-  intros.
-  pfold.
-  apply Reflexive_eutt_; auto.
+  intros. pfold. apply Reflexive_euttF. eauto.
 Qed.
 
 Global Instance Symmetric_eutt
@@ -349,78 +337,10 @@ Proof.
   destruct H12 as [I12 H12].
   split.
   - symmetry; assumption.
-  - intros t1' t2' H21' H12'.
-    specialize (H12 _ _ H12' H21').
-    constructor.
-    inversion H12.
-    + inversion eutt_0_observe0; try constructor.
-      * apply eq_dep_sym; auto.
-      * intros x2 x1 ex12.
-        destruct (H2 x1 x2) as [ | []]; auto.
+  - intros. hexploit H12; eauto. intros.
+    inv H; eauto.
+    econstructor. intros. specialize (H0 x). pclearbot. eauto.
 Qed.
-
-(*
-(* Inversion of an [eutt_0] assumption that doesn't produce
-   heterogeneous equalities ([existT _ _ _ = existT _ _ _]). *)
-Lemma eutt_0_inj_Vis : forall {u} rel e (k : u -> itree E R) z,
-    eutt_0 rel (Vis e k) z ->
-    exists k', z = Vis e k' /\ (forall x, rel (k x) (k' x)).
-Proof.
-  intros.
-  refine match H in eutt_0 _ X Z
-               return match X.(observe) return Prop with
-                      | VisF e k => _
-                      | _ => True
-                      end
-         with
-         | Eutt_Ret _ _ => I
-         | Eutt_Vis _ _ _ _ _ => _
-         end; simpl.
-  eexists; split. reflexivity. assumption.
-Defined.
-*)
-
-Definition VisF_eq_dep {u1 u2}
-      (e1 : E u1) (e2 : E u2)
-      (k1 : _ -> itree E R) (k2 : _ -> itree E R) :
-  @VisF E R _ _ e1 k1 = VisF e2 k2 -> eq_dep _ E _ e1 _ e2 :=
-  fun H =>
-    match H in _ = t
-          return match t with
-                 | VisF e2 _ => eq_dep _ _ _ e1 _ e2
-                 | _ => True
-                 end
-    with
-    | eq_refl => eq_dep_intro _ _ _ _
-    end.
-
-Definition VisF_f_eq_dep {u1 u2}
-           (e1 : E u1) (e2 : E u2)
-           (k1 : _ -> itree E R) (k2 : _ -> itree E R)
-           (x1 : u1) (x2 : u2) :
-  @VisF E R _ _ e1 k1 = VisF e2 k2 ->
-  JMeq x1 x2 ->
-  k1 x1 = k2 x2 :=
-  fun Hk =>
-    match Hk in _ = t
-          return match t with
-                 | VisF _ k2 => forall x2, JMeq x1 x2 -> k1 x1 = k2 x2
-                 | _ => True
-                 end
-    with
-    | eq_refl =>
-      JMeq_congr k1
-    end x2.
-
-Lemma eq_dep_eq U (P : U -> Type) p x q y :
-  eq_dep U P p x q y -> p = q.
-Proof. now intros []. Qed.
-
-Definition coerce_eq_JMeq u1 u2 (x1 : u1) (e : u1 = u2) :
-  exists x2 : u2, JMeq x1 x2 :=
-  match e with
-  | eq_refl => ex_intro _ x1 JMeq_refl
-  end.
 
 Global Instance Transitive_eutt : Transitive eutt.
 Proof.
@@ -433,84 +353,60 @@ Proof.
   destruct H23 as [I23 H23].
   split.
   - etransitivity; eauto.
-  - intros t1' t3' H1 H3.
-    destruct (proj1 I12 (ex_intro _ _ H1)) as [t2' H2].
-    specialize (H12 _ _ H1 H2).
-    specialize (H23 _ _ H2 H3).
-    destruct H12 as [H12], H23 as [H23].
-    inversion H12; inversion H23.
-    + constructor.
-      rewrite <- H in H5; inversion H5; subst.
-      rewrite <- H0, <- H6.
-      apply Eutt_Ret.
-    + rewrite <- H in H4; discriminate.
-    + rewrite <- H0 in H7; discriminate.
-    + constructor.
-      rewrite <- H, <- H7.
-      assert (ee20 : eq_dep _ _ u2 e2 u0 e0).
-      { eapply VisF_eq_dep.
-        transitivity (observe t2'); eauto.
-      }
-      constructor.
-      * eapply eq_dep_trans; [eassumption|].
-        eapply eq_dep_trans; eassumption.
-      * intros x1 x3 ex13.
-        assert (Hx2 : exists (x0 : u0) (x2 : u2),
-                   JMeq x1 x2 /\ JMeq x2 x0 /\ JMeq x0 x3).
-        { inversion ee20.
-          apply eq_dep_eq in H4.
-          destruct (coerce_eq_JMeq _ u2 x1 H4) as [x2 e12].
-          do 2 exists x2.
-          repeat constructor; auto.
-          apply JMeq_trans with (y := x1); auto.
-        }
-        destruct Hx2 as [x0 [x2 [ex12 [ex20 ex03]]]].
-        specialize (H5 _ _ ex12); specialize (H9 _ _ ex03); pclearbot.
-        right.
-        eapply Transitive_eutt; eauto.
-        erewrite VisF_f_eq_dep; eauto.
-        etransitivity; eauto.
+  - intros n m t1' t3' H1 H3.
+    destruct I12 as [I1 I2].
+    destruct I1 as [n2' [t2' TAUS2]]; eauto.
+    hexploit H12; eauto. intros REL1.
+    hexploit H23; eauto. intros REL2.
+    dependent destruction REL1; dependent destruction REL2; eauto.
+    econstructor. intros.
+    specialize (H x); specialize (H0 x). pclearbot. eauto.
 Qed.
 
 (**)
 
 (* [eutt] is preserved by removing one [Tau]. *)
-Lemma eutt_tau (t t_ : itree E R) : t.(observe) = TauF t_ -> t ~ t_.
+Lemma eutt_tau1 (t : itree E R) : (Tau t) ~~ t.
 Proof.
-  intros Ht.
-  pfold.
-  split.
-  - apply finite_taus_Tau; auto.
-  - intros t1' t2' H1 H2.
-    rewrite unalltaus_tau in H1 by eauto.
-    pose proof (unalltaus_injective _ _ _ H1 H2); subst.
-    apply reflexive_eutt_0.
-    { left; apply Reflexive_eutt. }
-    { apply H1. }
+  pfold. split.
+  - apply finite_taus_tau; auto.
+  - intros n m t1' t2' H1 H2.
+    apply unalltaus_tau in H1.
+    assert (X := unalltaus_injective _ _ _ _ _ H1 H2); subst.
+    apply reflexive_euttF0; eauto using (untaus_prop notau).
+    left. apply Reflexive_eutt.
 Qed.
 
 (* [eutt] is preserved by removing all [Tau]. *)
-Lemma unalltaus_eutt (t t' : itree E R) : unalltaus t t' -> t ~ t'.
+Lemma untaus_eutt P n (t t' : itree E R) : untaus P n t t' -> t ~~ t'.
 Proof.
   intros H.
   pfold. split.
-  - now apply unalltaus_finite_taus.
-  - destruct H as [ Hnotau Huntaus ].
-    induction Huntaus as [ | t t' t_ Hobs Huntau IHuntaus ].
-    + subst. intros t1' t2' H1 H2.
-      rewrite (unalltaus_injective _ _ _ H1 H2).
-      apply reflexive_eutt_0.
-      { left; apply Reflexive_eutt. }
-      { apply H1. }
-    + intros t1' t2' H1 H2.
-      apply IHuntaus; auto.
-      eapply unalltaus_tau with (t1 := t); eauto.
+  - eapply untaus_finite_taus; eauto.
+  - induction H; intros.
+    + rewrite (unalltaus_injective _ _ _ _ _ UNTAUS1 UNTAUS2).
+      apply reflexive_euttF0; eauto using (untaus_prop notau).
+      left; apply Reflexive_eutt.
+    + apply unalltaus_tau in UNTAUS1. eauto.
 Qed.
 
 End EUTT.
 
-Hint Resolve monotone_eutt_0 : paco.
-Hint Resolve monotone_eutt_ : paco.
+Notation unalltaus := (untaus notau).
+
+Hint Constructors euttF0.
+Hint Constructors euttF0'.
+Hint Constructors untaus.
+Hint Unfold finite_taus.
+Hint Constructors euttF.
+Hint Resolve monotone_euttF0.
+Hint Resolve monotone_euttF : paco.
+Hint Resolve notau_ret.
+Hint Resolve notau_vis.
+
+Delimit Scope eutt_scope with eutt.
+
+Infix "~~" := eutt (at level 70).
 
 (* We can now rewrite with [eutt] equalities. *)
 Instance Equivalence_eutt E R : @Equivalence (itree E R) eutt.
@@ -518,49 +414,175 @@ Proof. constructor; typeclasses eauto. Qed.
 
 (* Lemmas about [bind]. *)
 
+Lemma untaus_bind P {E S R} : forall n t t' (k: S -> itree E R)
+      (UNTAUS: untaus P n t t'),
+  untaus anyitree n (ITree.bind t k) (ITree.bind t' k).
+Proof.
+  intros. induction UNTAUS; eauto.
+  rewrite tau_bind. eauto.
+Qed.
+
 Lemma finite_taus_bind_fst {E R S}
       (t : itree E R) (f : R -> itree E S) :
-  finite_taus (t >>= f) -> finite_taus t.
+  finite_taus (ITree.bind t f) -> finite_taus t.
 Proof.
-  remember (t >>= f)%itree as tf eqn:Etf.
-  intros [tf' [Hnotau Huntaus]].
+  remember (ITree.bind t f) as tf eqn:Etf.
+  intros [n [tf' TAUS]].
   generalize dependent t.
-  induction Huntaus as [ tf tf' | tf tf' tf_]; intros t Etf.
-  - subst. unfold notau in Hnotau. cbn in Hnotau.
-    destruct (t.(observe)) eqn:et;
-      try contradiction;
-      exists t;
-      (split; [unfold notau; rewrite et; constructor
-              |constructor; reflexivity]).
-  - subst. cbn in H.
-    destruct (t.(observe)) eqn:et; try discriminate.
-    + exists t; split.
-      * unfold notau; rewrite et; constructor.
-      * constructor; reflexivity.
-    + inversion H.
-      symmetry in H1.
-      destruct (IHHuntaus Hnotau t0 H1) as [t' [Hnotau' Huntaus']].
-      exists t'; split; auto.
-      eapply OneTau; eauto.
+  induction TAUS; intros; subst.
+  - destruct t0, observe; try contradiction; eauto using finite_taus_ret, finite_taus_vis.
+  - destruct t0, observe; eauto using finite_taus_ret, finite_taus_vis.
+    setoid_rewrite tau_bind in Etf.
+    inv Etf.
+    apply finite_taus_tau.
+    eauto.
+Qed.
+
+Lemma untaus_eq_idx P E R: forall n m (t1 t2: itree E R),
+    n = m -> untaus P n t1 t2 -> untaus P m t1 t2.
+Proof. intros; subst; eauto. Qed.
+
+Lemma untaus_untaus P Q E R: forall n m (t1 t2 t3: itree E R),
+    untaus P n t1 t2 -> untaus Q m t2 t3 -> untaus Q (n+m) t1 t3.
+Proof.
+  intros n m t1 t2 t3. induction 1; simpl; eauto.
+Qed.
+
+Lemma untaus_unalltus_rev P E R: forall n m (t1 t2 t3: itree E R),
+    untaus P n t1 t2 -> unalltaus m t1 t3 -> unalltaus (m-n) t2 t3.
+Proof.
+  intros. revert m t3 H0.
+  induction H; intros.
+  - eauto using untaus_eq_idx with arith.
+  - inversion H0; try contradiction. eauto.
+Qed.
+
+Lemma eutt_strengthen {E R}:
+  forall r (t1 t2: itree E R)
+     (FIN: finite_taus t1 <-> finite_taus t2)
+     (EQV: forall n1 n2 m1 m2 t1' t2'
+              (UNT1: unalltaus m1 t1 t1')
+              (UNT2: unalltaus m2 t2 t2')
+              (LEn: m1 < n1)
+              (LEm: m2 < n2),
+         paco2 (euttF ∘ grespectful2 euttF) r t1' t2'),
+    paco2 (euttF ∘ grespectful2 euttF) r t1 t2.
+Proof.
+  intros. pfold. econstructor; eauto.
+  intros. hexploit (EQV (S (max n m))); eauto with arith. intro EQV'.
+  punfold EQV'. destruct EQV'.
+  eauto 7 using (untaus_prop notau).
+Qed.
+
+Inductive eutt_trans_clo {E R} (r: relation (itree E R)) : relation (itree E R) :=
+| eutt_pre_clo_intro (t1 t2 t3 t4: itree E R)
+      (EQVl: t1 ~~ t2)
+      (EQVr: t4 ~~ t3)
+      (REL: r t2 t3)
+  : eutt_trans_clo r t1 t4
+.
+Hint Constructors eutt_trans_clo.
+
+Lemma eutt_clo_trans E R: weak_respectful2 (@euttF E R) eutt_trans_clo.
+Proof.
+  econstructor; [pmonauto|].
+  intros. inv PR.
+  punfold EQVl. punfold EQVr. destruct EQVl, EQVr. split.
+  { rewrite FIN, FIN0. apply GF in REL. destruct REL. eauto. }
+
+  intros. apply proj1 in FIN. edestruct FIN as [n'' [t2'' TAUS'']]; [eexists; eauto|].
+  hexploit EQV; eauto. intros EUTT1.
+  apply proj1 in FIN0. edestruct FIN0 as [n''' [t2''' TAUS''']]; [eexists; eauto|].
+  hexploit EQV0; eauto. intros EUTT2.
+  apply GF in REL. destruct REL.
+  hexploit EQV1; eauto. intros EUTT3.
+  dependent destruction EUTT1; dependent destruction EUTT2; dependent destruction EUTT3; eauto.
+  econstructor. intros. specialize (H x). specialize (H0 x). pclearbot. eauto using rclo2.
+Qed.
+
+Inductive eutt_bind_clo {E R} (r: relation (itree E R)) : relation (itree E R) :=
+| eutt_bind_clo_intro U (t1 t2: itree E U) k1 k2
+      (EQV: t1 ~~ t2)
+      (REL: forall v, r (k1 v) (k2 v))
+  : eutt_bind_clo r (ITree.bind t1 k1) (ITree.bind t2 k2)
+.
+Hint Constructors eutt_bind_clo.
+
+Lemma eutt_clo_bind E R: weak_respectful2 (@euttF E R) eutt_bind_clo.
+Proof.
+  econstructor; [pmonauto|].
+  intros. destruct PR. punfold EQV. destruct EQV. split.
+  - split; intros.
+    + assert (FT1 := H). apply finite_taus_bind_fst in FT1.
+      assert (FT2 := FT1). apply FIN in FT2.
+      destruct FT1 as [n [a FT1]], FT2 as [m [b FT2]].
+      hexploit EQV; eauto. intros EQV'.
+      edestruct @untaus_finite_taus; [eapply untaus_bind, FT1 | apply H0 in H].
+      eapply untaus_finite_taus; eauto using untaus_bind.
+      inv EQV'.
+      * rewrite ret_bind in *.
+        edestruct GF; eauto. apply FIN0. eauto.
+      * rewrite vis_bind. eauto using finite_taus_vis.
+    + assert (FT1 := H). apply finite_taus_bind_fst in FT1.
+      assert (FT2 := FT1). apply FIN in FT2.
+      destruct FT1 as [n [a FT1]], FT2 as [m [b FT2]].
+      hexploit EQV; eauto. intros EQV'.
+      edestruct @untaus_finite_taus; [eapply untaus_bind, FT1 | apply H0 in H].
+      eapply untaus_finite_taus; eauto using untaus_bind.
+      inv EQV'.
+      * rewrite ret_bind in *.
+        edestruct GF; eauto. apply FIN0. eauto.
+      * rewrite vis_bind. eauto using finite_taus_vis.
+  - intros.
+    hexploit (@finite_taus_bind_fst E); [do 2 eexists; apply UNTAUS1|]. intros [n' [a FT1]].
+    hexploit (@finite_taus_bind_fst E); [do 2 eexists; apply UNTAUS2|]. intros [m' [b FT2]].
+    hexploit @untaus_bind; [apply FT1|]. intros UT1.
+    hexploit @untaus_bind; [apply FT2|]. intros UT2.
+    specialize (EQV _ _ _ _ FT1 FT2).
+    hexploit untaus_unalltus_rev; [apply UT1| |]; eauto. intros UAT1.
+    hexploit untaus_unalltus_rev; [apply UT2| |]; eauto. intros UAT2.
+    inv EQV.
+    + rewrite ret_bind in UAT1, UAT2.
+      eapply GF in REL. destruct REL.
+      eapply monotone_euttF0; eauto using rclo2.
+    + rewrite vis_bind in UAT1, UAT2.
+      inversion UAT1; inversion UAT2. subst.
+      econstructor. intros. specialize (H x). pclearbot. eauto using rclo2.
+Qed.
+
+Instance eutt_tau {E R} :
+  Proper (@eutt E R ==>
+          @eutt E R) (fun t => Tau t).
+Proof.
+  repeat intro. etransitivity. apply eutt_tau1.
+  etransitivity. eauto.
+  symmetry. apply eutt_tau1.
+Qed.
+
+Instance eutt_vis {E R u} (e: E u) :
+  Proper (pointwise_relation _ eutt ==>
+          @eutt E R) (fun k => Vis e k).
+Proof.
+  repeat intro. red in H. pfold. split; intros.
+  - split; eauto.
+  - inversion UNTAUS1; subst. inv UNTAUS1. inv UNTAUS2.
+    econstructor; intros. left. apply H.
 Qed.
 
 (* [eutt] is a congruence wrt. [bind] *)
+
 Instance eutt_bind {E R S} :
   Proper (@eutt E R ==>
           pointwise_relation _ eutt ==>
           @eutt E S) ITree.bind.
 Proof.
-Admitted.
+  repeat intro. pupto2_init.
+  pupto2 (eutt_clo_bind E S). econstructor; eauto.
+  intros. pupto2_final. apply H0.
+Qed.
 
 Instance eutt_map {E R S} :
   Proper (pointwise_relation _ eq ==> @eutt E R ==> @eutt E S) ITree.map.
-Proof.
-Admitted.
-
-Lemma eutt_map_map {E R S T}
-      (f : R -> S) (g : S -> T) (t : itree E R) :
-  eutt (ITree.map g (ITree.map f t))
-       (ITree.map (fun x => g (f x)) t).
 Proof.
 Admitted.
 
@@ -576,4 +598,22 @@ Admitted.
 
 Instance subrelation_eq_eutt {E R} : subrelation (@eq_itree E R) eutt.
 Proof.
-Admitted.
+  pcofix CIH. intros.
+  pfold. econstructor.
+  { split; [|symmetry in H0]; intros; destruct H as [? []]; eauto using eq_unalltaus. }
+
+  intros. eapply eq_unalltaus_eq in H0; eauto. destruct H0 as [s' [UNTAUS' EQV']].
+  hexploit @unalltaus_injective; [apply UNTAUS' | apply UNTAUS2 | intro X]; subst.
+
+  punfold EQV'. inv EQV'; eauto.
+  - eapply untaus_prop in UNTAUS1. contradiction.
+  - econstructor. intros. specialize (REL x0). pclearbot. eauto.
+Qed.
+
+Lemma eutt_map_map {E R S T}
+      (f : R -> S) (g : S -> T) (t : itree E R) :
+  eutt (ITree.map g (ITree.map f t))
+       (ITree.map (fun x => g (f x)) t).
+Proof.
+  rewrite map_map. reflexivity.
+Qed.

--- a/theories/Eq/UpToTaus.v
+++ b/theories/Eq/UpToTaus.v
@@ -240,7 +240,7 @@ Lemma eq_unalltaus :
   exists t2', unalltaus n t2 t2'.
 Proof.
   intros. revert t2 EQV.
-  induction FT; intros; punfold EQV.
+  induction FT; intros; punfold EQV; unfold_eq_itree.
   - absobs t ot. absobs t2 ot2. inv EQV; cbn; eauto.
   - simpl in EQV. absobs t2 ot2. inv EQV. pclearbot.
     edestruct IHFT; eauto.
@@ -253,10 +253,10 @@ Lemma eq_unalltaus_eq :
   exists s', unalltaus n s s' /\ t' ≅ s'.
 Proof.
   intros. revert s EQV.
-  induction UNTAUS; intros.
+  induction UNTAUS; intros; punfold EQV; unfold_eq_itree.
   - exists s. split; eauto.
-    punfold EQV. absobs s os. absobs t ot. inv EQV; eauto.
-  - punfold EQV. absobs s os. inv EQV. pclearbot.
+    absobs s os. absobs t ot. inv EQV; eauto.
+  - absobs s os. inv EQV. pclearbot.
     edestruct IHUNTAUS as [s' [? ?]]; eauto.
 Qed.
 
@@ -605,7 +605,7 @@ Proof.
   intros. eapply eq_unalltaus_eq in H0; eauto. destruct H0 as [s' [UNTAUS' EQV']].
   hexploit @unalltaus_injective; [apply UNTAUS' | apply UNTAUS2 | intro X]; subst.
 
-  punfold EQV'. absobs t1' ot1'. absobs s' os'. inv EQV'; eauto.
+  punfold EQV'. unfold_eq_itree. absobs t1' ot1'. absobs s' os'. inv EQV'; eauto.
   - eapply untaus_prop in UNTAUS1. contradiction.
   - econstructor. intros. specialize (REL x0). pclearbot. eauto.
 Qed.

--- a/theories/Eq/UpToTaus.v
+++ b/theories/Eq/UpToTaus.v
@@ -241,8 +241,8 @@ Lemma eq_unalltaus :
 Proof.
   intros. revert t2 EQV.
   induction FT; intros; punfold EQV.
-  - inv EQV; cbn; eauto.
-  - inv EQV. pclearbot.
+  - absobs t ot. absobs t2 ot2. inv EQV; cbn; eauto.
+  - simpl in EQV. absobs t2 ot2. inv EQV. pclearbot.
     edestruct IHFT; eauto.
 Qed.
 
@@ -255,8 +255,8 @@ Proof.
   intros. revert s EQV.
   induction UNTAUS; intros.
   - exists s. split; eauto.
-    punfold EQV. inv EQV; eauto.
-  - punfold EQV. inv EQV. pclearbot.
+    punfold EQV. absobs s os. absobs t ot. inv EQV; eauto.
+  - punfold EQV. absobs s os. inv EQV. pclearbot.
     edestruct IHUNTAUS as [s' [? ?]]; eauto.
 Qed.
 
@@ -284,7 +284,7 @@ Qed.
 Lemma reflexive_euttF0 eutt t :
   Reflexive eutt -> notau t -> euttF0 eutt t t.
 Proof.
-  intros. destruct t, observe; try contradiction; econstructor; intros; subst; eauto.
+  intros. absobs t ot. destruct ot; try contradiction; econstructor; intros; subst; eauto.
 Qed.
 
 Lemma euttF_tau r t1 t2 :
@@ -430,8 +430,8 @@ Proof.
   intros [n [tf' TAUS]].
   generalize dependent t.
   induction TAUS; intros; subst.
-  - destruct t0, observe; try contradiction; eauto using finite_taus_ret, finite_taus_vis.
-  - destruct t0, observe; eauto using finite_taus_ret, finite_taus_vis.
+  - absobs t0 ot0; destruct ot0; try contradiction; eauto using finite_taus_ret, finite_taus_vis.
+  - absobs t0 ot0; destruct ot0; eauto using finite_taus_ret, finite_taus_vis.
     setoid_rewrite tau_bind in Etf.
     inv Etf.
     apply finite_taus_tau.
@@ -605,7 +605,7 @@ Proof.
   intros. eapply eq_unalltaus_eq in H0; eauto. destruct H0 as [s' [UNTAUS' EQV']].
   hexploit @unalltaus_injective; [apply UNTAUS' | apply UNTAUS2 | intro X]; subst.
 
-  punfold EQV'. inv EQV'; eauto.
+  punfold EQV'. absobs t1' ot1'. absobs s' os'. inv EQV'; eauto.
   - eapply untaus_prop in UNTAUS1. contradiction.
   - econstructor. intros. specialize (REL x0). pclearbot. eauto.
 Qed.

--- a/theories/Eq/UpToTaus.v
+++ b/theories/Eq/UpToTaus.v
@@ -465,8 +465,8 @@ Lemma eutt_strengthen {E R}:
               (UNT2: unalltaus m2 t2 t2')
               (LEn: m1 < n1)
               (LEm: m2 < n2),
-         paco2 (euttF ∘ grespectful2 euttF) r t1' t2'),
-    paco2 (euttF ∘ grespectful2 euttF) r t1 t2.
+         paco2 (euttF ∘ gres2 euttF) r t1' t2'),
+    paco2 (euttF ∘ gres2 euttF) r t1 t2.
 Proof.
   intros. pfold. econstructor; eauto.
   intros. hexploit (EQV (S (max n m))); eauto with arith. intro EQV'.

--- a/theories/Fix.v
+++ b/theories/Fix.v
@@ -216,9 +216,9 @@ Module FixImpl <: FixSig.
             pfold. econstructor; [split; eauto|].
             intros. inv UNTAUS1. inv UNTAUS2.
             econstructor. intros.
-            upto2_low_step (eutt_clo_bind E T). econstructor.
+            pupto2 (eutt_clo_bind E T). econstructor.
             { reflexivity. }
-            intros. upto2_low_final. eauto.
+            intros. pupto2_final. eauto.
           + rewrite ret_bind in TAUS4, TAUS5.
             hexploit @untaus_unalltus_rev; try apply TAUS4; eauto. intros TAUS6.
             hexploit @untaus_unalltus_rev; try apply TAUS5; eauto. intros TAUS7.

--- a/theories/Fix.v
+++ b/theories/Fix.v
@@ -6,7 +6,16 @@
  *)
 
 From ITree Require Import
-     Core Morphisms OpenSum.
+     paco2_respectful Core Morphisms MorphismsFacts OpenSum Eq.Eq Eq.UpToTaus.
+
+From Coq Require Import
+     Program
+     Lia
+     Setoid
+     Morphisms
+     RelationClasses.
+
+Require Import Paco.paco.
 
 Module Type FixSig.
   Section Fix.
@@ -53,13 +62,13 @@ Module FixImpl <: FixSig.
         | RetF x => Ret x
         | @VisF _ _ _ u ee k =>
           match ee with
+          | inlE e' =>
+            Vis e' (fun x => homFix (k x))
           | inrE e =>
             match e in fixpoint u return (u -> _) -> _ with
             | call x => fun k =>
               Tau (homFix (ITree.bind (f x) k))
             end k
-          | inlE e' =>
-            Vis e' (fun x => homFix (k x))
           end
         | TauF x => Tau (homFix x)
         end.
@@ -72,17 +81,150 @@ Module FixImpl <: FixSig.
         | inlE e => ITree.liftE e
         | inrE f0 =>
           match f0 with
-          | call x => Tau (_mfix x)
+          | call x => _mfix x
           end
         end.
+      
+      Instance eq_itree_homfix {T} :
+        Proper (@eq_itree _ T ==>
+                @eq_itree _ T) (@homFix T).
+      Proof.
+        pcofix CIH. intros.
+        rewrite (itree_unfold (homFix x)), (itree_unfold (homFix y)).
+        pfold. punfold H0.
+        inv H0; pclearbot; [| |destruct e; [|destruct f0]]; simpl; eauto.
+        - econstructor. intros. specialize (REL v). pclearbot. eauto.
+        - econstructor. right. eapply CIH.
+          eapply eq_itree_bind.
+          + reflexivity.
+          + intro. specialize (REL a). pclearbot. eauto.
+      Qed.
+
+      Theorem homfix_bind {U T}: forall t k,
+          @homFix T (ITree.bind t k) ≅ ITree.bind (@homFix U t) (fun x => homFix (k x)).
+      Proof.
+        intros. pupto2_init. revert t k.
+        pcofix CIH. intros.
+        destruct t, observe.
+        - rewrite (itree_unfold (homFix (Ret _))). simpl. rewrite !ret_bind.
+          pupto2_final.
+          eapply paco2_mon; [apply Reflexive_eq_itree | contradiction].
+        - rewrite tau_bind. repeat (rewrite (itree_unfold (homFix (Tau _))); simpl). rewrite tau_bind.
+          pupto2_final.
+        - rewrite vis_bind; repeat (rewrite (itree_unfold (homFix (Vis _ _))); simpl).
+          destruct e; [|destruct f0].
+          + pupto2_final. rewrite vis_bind. eauto.
+          + rewrite tau_bind.
+            pupto2 (eq_itree_clo_trans E T). econstructor; [|reflexivity|].
+            { eapply eq_itree_tau, eq_itree_homfix. rewrite <-bind_bind. reflexivity. }
+            pupto2_final.
+      Qed.
+
+      Lemma homfix_interp_finite : forall {T} (c : itree _ T),
+          finite_taus (homFix c) <-> finite_taus (interp eval_fixpoint c).
+      Proof.
+        split; intros.
+        { destruct H as [n [t FIN]]. move n before f. revert_until n.
+          generalize (PeanoNat.Nat.lt_succ_diag_r n); generalize (S n) at 1; intro m; revert n.
+          induction m; intros; [nia|].
+          rewrite (itree_unfold (homFix c)) in FIN.
+          destruct c, observe; [| |destruct e; [|destruct f0]]
+          ; simpl; try (inversion FIN; subst; try contradiction; eauto; fail).
+          - rewrite tau_interp.
+            eapply finite_taus_tau. simpl in FIN. inv FIN; try contradiction.
+            eauto with arith.
+          - rewrite vis_interp. simpl.
+            simpl in FIN. inv FIN; try contradiction.
+            hexploit @eq_unalltaus; try apply TAUS; eauto using homfix_bind. intros [t2 TAUS2].
+            hexploit @finite_taus_bind_fst; eauto. intros [n3 [t3 TAUS3]].
+            hexploit @untaus_prop; eauto. intros NOTAU.
+            hexploit untaus_bind; eauto. intros TAUS4.
+            hexploit untaus_bind; try apply TAUS3. intros TAUS5.
+            destruct t3, observe; try contradiction; cycle 1.
+            + do 2 eexists. eapply untaus_change_prop; eauto.
+            + rewrite ret_bind in TAUS4, TAUS5.
+              hexploit @untaus_unalltus_rev; try apply TAUS4; eauto. intros TAUS6.
+              eapply IHm in TAUS6; try nia.
+              eapply untaus_finite_taus; eauto.
+              eapply finite_taus_tau; eauto.
+        }
+        { destruct H as [n [t FIN]]. move n before f. revert_until n.
+          generalize (PeanoNat.Nat.lt_succ_diag_r n); generalize (S n) at 1; intro m; revert n.
+          induction m; intros; [nia|].
+          rewrite (itree_unfold (homFix _)).
+          destruct c, observe; [| |destruct e; [|destruct f0]]
+          ; simpl; try (inversion FIN; subst; try contradiction; eauto; fail).
+          - rewrite tau_interp in FIN. eapply finite_taus_tau.
+            inversion FIN; subst; try contradiction; eauto with arith.
+          - rewrite vis_interp in FIN. eapply finite_taus_tau.
+            eapply @finite_taus_eutt; [rewrite homfix_bind; reflexivity|].
+            simpl in FIN.
+            hexploit @finite_taus_bind_fst; eauto. intros [n3 [t3 TAUS3]].
+            hexploit @untaus_prop; eauto. intros NOTAU.
+            hexploit untaus_bind; eauto. intros TAUS4.
+            hexploit untaus_bind; try apply TAUS3. intros TAUS5.
+            destruct t3, observe; try contradiction; cycle 1.
+            + do 2 eexists. eapply untaus_change_prop; eauto.
+            + rewrite ret_bind in TAUS4, TAUS5.
+              hexploit @untaus_unalltus_rev; try apply TAUS4; eauto. intros TAUS6.
+              inversion TAUS6; try contradiction; subst.
+              hexploit IHm; eauto; try nia. intros TAUS7.
+              eapply untaus_finite_taus; eauto.
+        }
+      Qed.
 
       Theorem homFix_is_interp : forall {T} (c : itree _ T),
-          homFix c = interp eval_fixpoint c.
+          homFix c ~~ interp eval_fixpoint c.
       Proof.
-      Admitted.
-
-      Theorem _mfix_unroll : forall x, _mfix x = homFix (f x).
-      Proof. reflexivity. Qed.
+        intros. pupto2_init. revert c.
+        pcofix CIH. intros.
+        eapply eutt_strengthen; eauto using homfix_interp_finite.
+        intro n. revert c. induction n; intros; try nia.
+        rewrite (itree_unfold (homFix _)) in UNT1.
+        destruct c, observe; [| |destruct e; [|destruct f0]].
+        - inv UNT1. rewrite ret_interp in UNT2. inv UNT2.
+          pupto2_final. eapply paco2_mon; [apply Reflexive_eutt | contradiction].
+        - inv UNT1; try contradiction.
+          rewrite tau_interp in UNT2. apply unalltaus_tau in UNT2.
+          eapply IHn; eauto; nia.
+        - inv UNT1. rewrite vis_interp in UNT2. setoid_rewrite vis_bind in UNT2. inv UNT2.
+          pupto2 (eutt_clo_trans E T). econstructor; [reflexivity| |].
+          { eapply eutt_vis. intro v. rewrite ret_bind. apply eutt_tau1. }
+          pupto2_final. pfold.
+          simpl. econstructor; [split; eauto|].
+          intros. inv UNTAUS1. inv UNTAUS2.
+          econstructor. intros. eauto.
+        - simpl in UNT1. rewrite vis_interp in UNT2. simpl in UNT2.
+          inv UNT1; try contradiction.
+          hexploit @eq_unalltaus_eq; [eauto | apply homfix_bind | ..]. intros [s' [UNT' EQV']].
+          pupto2 (eutt_clo_trans E T). econstructor; [|reflexivity|].
+          { rewrite EQV'. reflexivity. }
+          hexploit @finite_taus_bind_fst; eauto. intros [n3 [t3 TAUS3]].
+          hexploit @untaus_prop; eauto. intros NOTAU.
+          hexploit untaus_bind; eauto. intros TAUS4.
+          hexploit untaus_bind; try apply TAUS3. intros TAUS5.
+          destruct t3, observe; try contradiction; cycle 1.
+          + rewrite vis_bind in TAUS4. rewrite vis_bind in TAUS5.
+            eapply (untaus_change_prop notau) in TAUS4; eauto.
+            eapply (untaus_change_prop notau) in TAUS5; eauto.
+            hexploit @unalltaus_injective; [apply UNT' | apply TAUS4 |]. intros X; subst.
+            hexploit @unalltaus_injective; [apply UNT2 | apply TAUS5 |]. intros X; subst.
+            pupto2 (eutt_clo_trans E T). econstructor; [reflexivity| |].
+            { eapply eutt_vis. intro v.
+              eapply eutt_bind; [reflexivity|].
+              intro w. apply eutt_tau1. }
+            pfold. econstructor; [split; eauto|].
+            intros. inv UNTAUS1. inv UNTAUS2.
+            econstructor. intros.
+            upto2_low_step (eutt_clo_bind E T). econstructor.
+            { reflexivity. }
+            intros. upto2_low_final. eauto.
+          + rewrite ret_bind in TAUS4, TAUS5.
+            hexploit @untaus_unalltus_rev; try apply TAUS4; eauto. intros TAUS6.
+            hexploit @untaus_unalltus_rev; try apply TAUS5; eauto. intros TAUS7.
+            eapply unalltaus_tau in TAUS7.
+            hexploit IHn; eauto; try nia.
+      Qed.
 
     End mfix.
 

--- a/theories/Fix.v
+++ b/theories/Fix.v
@@ -91,7 +91,7 @@ Module FixImpl <: FixSig.
       Proof.
         pcofix CIH. intros.
         rewrite (itree_eta (homFix x)), (itree_eta (homFix y)).
-        pfold. punfold H0. absobs x ox. absobs y oy.
+        pfold. punfold H0. unfold_eq_itree. absobs x ox. absobs y oy.
         inv H0; pclearbot; [| |destruct e; [|destruct f0]]; cbn; eauto.
         - econstructor. intros. specialize (REL v). pclearbot. eauto.
         - econstructor. right. eapply CIH.
@@ -110,14 +110,14 @@ Module FixImpl <: FixSig.
           pupto2_final.
           eapply paco2_mon; [apply Reflexive_eq_itree | contradiction].
         - rewrite tau_bind. repeat (rewrite (itree_eta (homFix (Tau _))); cbn). rewrite tau_bind.
-          pupto2_final. pfold. cbn. eauto.
+          pupto2_final. pfold. unfold_eq_itree. cbn. eauto.
         - rewrite vis_bind; repeat (rewrite (itree_eta (homFix (Vis _ _))); cbn).
           destruct e; [|destruct f0]; cbn.
-          + pupto2_final. rewrite vis_bind. pfold. cbn. eauto.
+          + pupto2_final. rewrite vis_bind. pfold. unfold_eq_itree. cbn. eauto.
           + rewrite tau_bind.
             pupto2 (eq_itree_clo_trans E T). econstructor; [|reflexivity|].
             { eapply eq_itree_tau, eq_itree_homfix. rewrite <-bind_bind. reflexivity. }
-            pupto2_final. pfold. cbn. eauto.
+            pupto2_final. pfold. unfold_eq_itree. cbn. eauto.
       Qed.
 
       Lemma homfix_interp_finite : forall {T} (c : itree _ T),

--- a/theories/Fix.v
+++ b/theories/Fix.v
@@ -90,9 +90,9 @@ Module FixImpl <: FixSig.
                 @eq_itree _ T) (@homFix T).
       Proof.
         pcofix CIH. intros.
-        rewrite (itree_unfold (homFix x)), (itree_unfold (homFix y)).
-        pfold. punfold H0.
-        inv H0; pclearbot; [| |destruct e; [|destruct f0]]; simpl; eauto.
+        rewrite (itree_eta (homFix x)), (itree_eta (homFix y)).
+        pfold. punfold H0. absobs x ox. absobs y oy.
+        inv H0; pclearbot; [| |destruct e; [|destruct f0]]; cbn; eauto.
         - econstructor. intros. specialize (REL v). pclearbot. eauto.
         - econstructor. right. eapply CIH.
           eapply eq_itree_bind.
@@ -105,19 +105,19 @@ Module FixImpl <: FixSig.
       Proof.
         intros. pupto2_init. revert t k.
         pcofix CIH. intros.
-        destruct t, observe.
-        - rewrite (itree_unfold (homFix (Ret _))). simpl. rewrite !ret_bind.
+        absobs t ot. destruct ot.
+        - rewrite (itree_eta (homFix (Ret _))). cbn. rewrite !ret_bind.
           pupto2_final.
           eapply paco2_mon; [apply Reflexive_eq_itree | contradiction].
-        - rewrite tau_bind. repeat (rewrite (itree_unfold (homFix (Tau _))); simpl). rewrite tau_bind.
-          pupto2_final.
-        - rewrite vis_bind; repeat (rewrite (itree_unfold (homFix (Vis _ _))); simpl).
-          destruct e; [|destruct f0].
-          + pupto2_final. rewrite vis_bind. eauto.
+        - rewrite tau_bind. repeat (rewrite (itree_eta (homFix (Tau _))); cbn). rewrite tau_bind.
+          pupto2_final. pfold. cbn. eauto.
+        - rewrite vis_bind; repeat (rewrite (itree_eta (homFix (Vis _ _))); cbn).
+          destruct e; [|destruct f0]; cbn.
+          + pupto2_final. rewrite vis_bind. pfold. cbn. eauto.
           + rewrite tau_bind.
             pupto2 (eq_itree_clo_trans E T). econstructor; [|reflexivity|].
             { eapply eq_itree_tau, eq_itree_homfix. rewrite <-bind_bind. reflexivity. }
-            pupto2_final.
+            pupto2_final. pfold. cbn. eauto.
       Qed.
 
       Lemma homfix_interp_finite : forall {T} (c : itree _ T),
@@ -127,20 +127,20 @@ Module FixImpl <: FixSig.
         { destruct H as [n [t FIN]]. move n before f. revert_until n.
           generalize (PeanoNat.Nat.lt_succ_diag_r n); generalize (S n) at 1; intro m; revert n.
           induction m; intros; [nia|].
-          rewrite (itree_unfold (homFix c)) in FIN.
-          destruct c, observe; [| |destruct e; [|destruct f0]]
+          rewrite (itree_eta (homFix c)) in FIN.
+          absobs c oc. destruct oc; [| |destruct e; [|destruct f0]]
           ; simpl; try (inversion FIN; subst; try contradiction; eauto; fail).
           - rewrite tau_interp.
             eapply finite_taus_tau. simpl in FIN. inv FIN; try contradiction.
             eauto with arith.
           - rewrite vis_interp. simpl.
-            simpl in FIN. inv FIN; try contradiction.
+            cbn in FIN. inv FIN; try contradiction.
             hexploit @eq_unalltaus; try apply TAUS; eauto using homfix_bind. intros [t2 TAUS2].
             hexploit @finite_taus_bind_fst; eauto. intros [n3 [t3 TAUS3]].
             hexploit @untaus_prop; eauto. intros NOTAU.
             hexploit untaus_bind; eauto. intros TAUS4.
             hexploit untaus_bind; try apply TAUS3. intros TAUS5.
-            destruct t3, observe; try contradiction; cycle 1.
+            absobs t3 ot3; destruct ot3; try contradiction; cycle 1.
             + do 2 eexists. eapply untaus_change_prop; eauto.
             + rewrite ret_bind in TAUS4, TAUS5.
               hexploit @untaus_unalltus_rev; try apply TAUS4; eauto. intros TAUS6.
@@ -151,19 +151,19 @@ Module FixImpl <: FixSig.
         { destruct H as [n [t FIN]]. move n before f. revert_until n.
           generalize (PeanoNat.Nat.lt_succ_diag_r n); generalize (S n) at 1; intro m; revert n.
           induction m; intros; [nia|].
-          rewrite (itree_unfold (homFix _)).
-          destruct c, observe; [| |destruct e; [|destruct f0]]
-          ; simpl; try (inversion FIN; subst; try contradiction; eauto; fail).
-          - rewrite tau_interp in FIN. eapply finite_taus_tau.
-            inversion FIN; subst; try contradiction; eauto with arith.
-          - rewrite vis_interp in FIN. eapply finite_taus_tau.
+          rewrite (itree_eta (homFix _)).
+          absobs c oc; destruct oc; [| |destruct e; [|destruct f0]]
+          ; try (inversion FIN; subst; cbn; try contradiction; eauto; fail).
+          - rewrite tau_interp in FIN. cbn. eapply finite_taus_tau.
+            inversion FIN; subst; try contradiction; cbn; eauto with arith.
+          - rewrite vis_interp in FIN. cbn. eapply finite_taus_tau.
             eapply @finite_taus_eutt; [rewrite homfix_bind; reflexivity|].
             simpl in FIN.
             hexploit @finite_taus_bind_fst; eauto. intros [n3 [t3 TAUS3]].
             hexploit @untaus_prop; eauto. intros NOTAU.
             hexploit untaus_bind; eauto. intros TAUS4.
             hexploit untaus_bind; try apply TAUS3. intros TAUS5.
-            destruct t3, observe; try contradiction; cycle 1.
+            absobs t3 ot3; destruct ot3; try contradiction; cycle 1.
             + do 2 eexists. eapply untaus_change_prop; eauto.
             + rewrite ret_bind in TAUS4, TAUS5.
               hexploit @untaus_unalltus_rev; try apply TAUS4; eauto. intros TAUS6.
@@ -180,8 +180,8 @@ Module FixImpl <: FixSig.
         pcofix CIH. intros.
         eapply eutt_strengthen; eauto using homfix_interp_finite.
         intro n. revert c. induction n; intros; try nia.
-        rewrite (itree_unfold (homFix _)) in UNT1.
-        destruct c, observe; [| |destruct e; [|destruct f0]].
+        rewrite (itree_eta (homFix _)) in UNT1.
+        absobs c oc; destruct oc; [| |destruct e; [|destruct f0]]; cbn in *.
         - inv UNT1. rewrite ret_interp in UNT2. inv UNT2.
           pupto2_final. eapply paco2_mon; [apply Reflexive_eutt | contradiction].
         - inv UNT1; try contradiction.
@@ -203,7 +203,7 @@ Module FixImpl <: FixSig.
           hexploit @untaus_prop; eauto. intros NOTAU.
           hexploit untaus_bind; eauto. intros TAUS4.
           hexploit untaus_bind; try apply TAUS3. intros TAUS5.
-          destruct t3, observe; try contradiction; cycle 1.
+          absobs t3 ot3; destruct ot3; try contradiction; cycle 1; cbn in *.
           + rewrite vis_bind in TAUS4. rewrite vis_bind in TAUS5.
             eapply (untaus_change_prop notau) in TAUS4; eauto.
             eapply (untaus_change_prop notau) in TAUS5; eauto.

--- a/theories/MorphismsFacts.v
+++ b/theories/MorphismsFacts.v
@@ -1,7 +1,7 @@
 From Paco Require Import paco.
 
 From ITree Require Import
-     Core Morphisms Eq.UpToTaus.
+     paco2_respectful Core Morphisms Eq.Eq Eq.UpToTaus.
 
 (* Proof of
    [interp f (t >>= k) ~ (interp f t >>= fun r => interp f (k r))]
@@ -22,35 +22,54 @@ From ITree Require Import
 
  *)
 
-(* Failed naive attempt. (The [Tau] case is the interesting one.) *)
-Lemma interp_bind_failed {E F R S}
-      (f : eff_hom E F) (t : itree E R) (k : R -> itree E S) :
-  eutt (interp f (t >>= k))
-       (interp f  t >>= fun r => interp f (k r)).
+Lemma interp_unfold {E F R} {f : eff_hom E F} (t : itree E R) :
+  interp f t = interp_match f (fun t' => interp f t') t.
 Proof.
-  revert t; pcofix interp_bind; rename r into e; intro t.
-  pfold. constructor.
-  { admit. }
-  { admit. }
-Abort.
+  setoid_rewrite (itree_unfold (interp f t)). simpl.
+  setoid_rewrite <-itree_unfold. eauto.
+Qed.
+
+Lemma ret_interp {E F R} {f : eff_hom E F} (x: R):
+  interp f (Ret x) = Ret x.
+Proof.
+  rewrite interp_unfold. reflexivity.
+Qed.
+
+Lemma tau_interp {E F R} {f : eff_hom E F} (t: itree E R):
+  interp f (Tau t) = Tau (interp f t).
+Proof.
+  rewrite interp_unfold. reflexivity.
+Qed.
+
+Lemma vis_interp {E F R} {f : eff_hom E F} U (e: E U) (k: U -> itree E R) :
+  interp f (Vis e k) = (x <- (f _ e);; Tau (interp f (k x))).
+Proof.
+  intros. rewrite interp_unfold. reflexivity.
+Qed.
 
 Lemma interp_bind {E F R S}
       (f : eff_hom E F) (t : itree E R) (k : R -> itree E S) :
-  eutt (interp f (t >>= k))
-       (interp f  t >>= fun r => interp f (k r)).
+   (interp f (ITree.bind t k)) ≅ (ITree.bind (interp f t) (fun r => interp f (k r))).
 Proof.
-  revert t; pcofix interp_bind; rename r into e; intro t.
-  pfold.
-  split.
-  - admit.
-  - intros tk1' tk2' Htk1 Htk2.
-    shelve.
-Abort.
+  pupto2_init.
+  revert R t k.
+  pcofix CIH. intros.
+  destruct t, observe.
+  - rewrite ret_interp, !ret_bind. pupto2_final.
+    eapply paco2_mon; [apply Reflexive_eq_itree | contradiction].
+  - rewrite tau_interp, !tau_bind, tau_interp.
+    pupto2_final.
+  - rewrite vis_interp, !vis_bind, vis_interp.
+    pupto2 (eq_itree_clo_trans F S). econstructor; [reflexivity| |].
+    { simpl. rewrite bind_bind. reflexivity. }
+    pupto2 (eq_itree_clo_bind F S). econstructor; [reflexivity|].
+    setoid_rewrite tau_bind. intros. pupto2_final.
+Qed.
 
 Lemma interp_state_liftE {E F : Type -> Type} {R S : Type}
       (f : forall T, E T -> S -> itree F (S * T)%type)
       (s : S) (e : E R) :
-  eutt (interp_state f (ITree.liftE e) s) (f _ e s).
+  (interp_state f (ITree.liftE e) s) ≅ (f _ e s).
 Proof.
 Admitted.
 
@@ -58,15 +77,15 @@ Lemma interp_state_bind {E F : Type -> Type} {A B S : Type}
       (f : forall T, E T -> S -> itree F (S * T)%type)
       (t : itree E A) (k : A -> itree E B)
       (s : S) :
-  eutt (interp_state f (t >>= k) s)
-       (interp_state f t s >>= fun st =>
-        interp_state f (k (snd st)) (fst st)).
+  (interp_state f (t >>= k) s)
+    ≅
+  (interp_state f t s >>= fun st => interp_state f (k (snd st)) (fst st)).
 Proof.
 Admitted.
 
 Lemma interp_state_ret {E F : Type -> Type} {R S : Type}
       (f : forall T, E T -> S -> itree F (S * T)%type)
       (s : S) (r : R) :
-  eutt (interp_state f (Ret r) s) (Ret (s, r)).
+  (interp_state f (Ret r) s) ≅ (Ret (s, r)).
 Proof.
 Admitted.

--- a/theories/MorphismsFacts.v
+++ b/theories/MorphismsFacts.v
@@ -25,8 +25,8 @@ From ITree Require Import
 Lemma interp_unfold {E F R} {f : eff_hom E F} (t : itree E R) :
   interp f t = interp_match f (fun t' => interp f t') t.
 Proof.
-  setoid_rewrite (itree_unfold (interp f t)). simpl.
-  setoid_rewrite <-itree_unfold. eauto.
+  setoid_rewrite (itree_eta (interp f t)). cbn.
+  setoid_rewrite <-itree_eta. eauto.
 Qed.
 
 Lemma ret_interp {E F R} {f : eff_hom E F} (x: R):
@@ -54,16 +54,17 @@ Proof.
   pupto2_init.
   revert R t k.
   pcofix CIH. intros.
-  destruct t, observe.
+  absobs t ot. destruct ot.
   - rewrite ret_interp, !ret_bind. pupto2_final.
     eapply paco2_mon; [apply Reflexive_eq_itree | contradiction].
   - rewrite tau_interp, !tau_bind, tau_interp.
-    pupto2_final.
+    pupto2_final. pfold. cbn. eauto.
   - rewrite vis_interp, !vis_bind, vis_interp.
     pupto2 (eq_itree_clo_trans F S). econstructor; [reflexivity| |].
     { simpl. rewrite bind_bind. reflexivity. }
     pupto2 (eq_itree_clo_bind F S). econstructor; [reflexivity|].
-    setoid_rewrite tau_bind. intros. pupto2_final.
+    setoid_rewrite tau_bind. intros.
+    pupto2_final. pfold. cbn. eauto.
 Qed.
 
 Lemma interp_state_liftE {E F : Type -> Type} {R S : Type}

--- a/theories/MorphismsFacts.v
+++ b/theories/MorphismsFacts.v
@@ -58,13 +58,13 @@ Proof.
   - rewrite ret_interp, !ret_bind. pupto2_final.
     eapply paco2_mon; [apply Reflexive_eq_itree | contradiction].
   - rewrite tau_interp, !tau_bind, tau_interp.
-    pupto2_final. pfold. cbn. eauto.
+    pupto2_final. pfold. unfold_eq_itree. cbn. eauto.
   - rewrite vis_interp, !vis_bind, vis_interp.
     pupto2 (eq_itree_clo_trans F S). econstructor; [reflexivity| |].
     { simpl. rewrite bind_bind. reflexivity. }
     pupto2 (eq_itree_clo_bind F S). econstructor; [reflexivity|].
     setoid_rewrite tau_bind. intros.
-    pupto2_final. pfold. cbn. eauto.
+    pupto2_final. pfold. unfold_eq_itree. cbn. eauto.
 Qed.
 
 Lemma interp_state_liftE {E F : Type -> Type} {R S : Type}

--- a/theories/paco2_respectful.v
+++ b/theories/paco2_respectful.v
@@ -222,7 +222,7 @@ Section Respectful2.
     inversion RES. auto.
   Qed.
 
-  Lemma upto2_low_step
+  Lemma upto2_step_under
      r clo (RES: weak_respectful2 clo):
    clo (grespectful2 r) <2= grespectful2 r.
 Proof.
@@ -242,7 +242,5 @@ Hint Resolve rclo2_mon: paco.
 Hint Constructors weak_respectful2.
 
 Ltac pupto2_init := eapply upto2_init; eauto with paco.
-Ltac pupto2_final := eapply upto2_final; eauto with paco.
-Ltac pupto2 H := eapply upto2_step; [|exact H|]; eauto with paco.
-Ltac upto2_low_step H := eapply upto2_low_step; [|exact H|]; eauto with paco.
-Ltac upto2_low_final := eapply grespectful2_incl.
+Ltac pupto2_final := first [eapply upto2_final; eauto with paco | eapply grespectful2_incl].
+Ltac pupto2 H := first [eapply upto2_step|eapply upto2_step_under]; [|exact H|]; eauto with paco.

--- a/theories/paco2_respectful.v
+++ b/theories/paco2_respectful.v
@@ -28,13 +28,13 @@ Section Respectful2.
   }.
   Hint Constructors respectful2.
 
-  Inductive grespectful2 (r: rel) e1 e2: Prop :=
-  | grespectful2_intro
+  Inductive gres2 (r: rel) e1 e2: Prop :=
+  | gres2_intro
       clo
       (RES: respectful2 clo)
       (CLO: clo r e1 e2)
   .
-  Hint Constructors grespectful2.
+  Hint Constructors gres2.
 
   Lemma gfclo2_mon: forall clo, sound2 clo -> monotone2 (compose gf clo).
   Proof. intros; destruct H; eauto using gf_mon. Qed.
@@ -83,39 +83,39 @@ Section Respectful2.
       + intros. eapply RESPECTFUL1; eauto.
   Qed.
 
-  Lemma grespectful2_respectful2: respectful2 grespectful2.
+  Lemma grespectful2_respectful2: respectful2 gres2.
   Proof.
     econstructor; repeat intro.
     - destruct IN; destruct RES; exists clo; eauto.
     - destruct PR; destruct RES; eapply gf_mon with (r:=clo r); eauto.
   Qed.
 
-  Lemma gfgres2_mon: monotone2 (compose gf grespectful2).
+  Lemma gfgres2_mon: monotone2 (compose gf gres2).
   Proof.
     destruct grespectful2_respectful2; eauto using gf_mon.
   Qed.
   Hint Resolve gfgres2_mon : paco.
 
-  Lemma grespectful2_greatest: forall clo (RES: respectful2 clo), clo <3= grespectful2.
+  Lemma grespectful2_greatest: forall clo (RES: respectful2 clo), clo <3= gres2.
   Proof.
     eauto.
   Qed.
 
-  Lemma grespectful2_incl: forall r, r <2= grespectful2 r.
+  Lemma grespectful2_incl: forall r, r <2= gres2 r.
   Proof.
     intros; eexists (fun x => x); eauto.
   Qed.
   Hint Resolve grespectful2_incl.
 
   Lemma grespectful2_compose: forall clo (RES: respectful2 clo) r,
-      clo (grespectful2 r) <2= grespectful2 r.
+      clo (gres2 r) <2= gres2 r.
   Proof.
-    intros; eapply grespectful2_greatest with (clo := compose clo grespectful2);
+    intros; eapply grespectful2_greatest with (clo := compose clo gres2);
       eauto using respectful2_compose, grespectful2_respectful2.
   Qed.
 
   Lemma grespectful2_incl_rev: forall r,
-      grespectful2 (paco2 (compose gf grespectful2) r) <2= paco2 (compose gf grespectful2) r.
+      gres2 (paco2 (compose gf gres2) r) <2= paco2 (compose gf gres2) r.
   Proof.
     intro r; pcofix CIH; intros; pfold.
     eapply gf_mon, grespectful2_compose, grespectful2_respectful2.
@@ -196,7 +196,7 @@ Section Respectful2.
   Qed.
 
   Lemma upto2_init:
-      paco2 (compose gf grespectful2) bot2 <2= paco2 gf bot2.
+      paco2 (compose gf gres2) bot2 <2= paco2 gf bot2.
   Proof.
     apply sound2_is_gf; eauto.
     apply respectful2_is_sound2.
@@ -204,7 +204,7 @@ Section Respectful2.
   Qed.
 
   Lemma upto2_final:
-    paco2 gf <3= paco2 (compose gf grespectful2).
+    paco2 gf <3= paco2 (compose gf gres2).
   Proof.
     pcofix CIH. intros. punfold PR. pfold.
     eapply gf_mon; [|apply grespectful2_incl].
@@ -213,7 +213,7 @@ Section Respectful2.
 
   Lemma upto2_step
         r clo (RES: weak_respectful2 clo):
-    clo (paco2 (compose gf grespectful2) r) <2= paco2 (compose gf grespectful2) r.
+    clo (paco2 (compose gf gres2) r) <2= paco2 (compose gf gres2) r.
   Proof.
     intros. apply grespectful2_incl_rev.
     assert (RES' := weak_respectful2_respectful2 RES).
@@ -224,7 +224,7 @@ Section Respectful2.
 
   Lemma upto2_step_under
      r clo (RES: weak_respectful2 clo):
-   clo (grespectful2 r) <2= grespectful2 r.
+   clo (gres2 r) <2= gres2 r.
 Proof.
   intros. apply weak_respectful2_respectful2 in RES; eauto.
   eapply grespectful2_compose; eauto. eauto using rclo2.
@@ -234,7 +234,7 @@ End Respectful2.
 
 Hint Constructors sound2.
 Hint Constructors respectful2.
-Hint Constructors grespectful2.
+Hint Constructors gres2.
 Hint Resolve gfclo2_mon : paco.
 Hint Resolve gfgres2_mon : paco.
 Hint Resolve grespectful2_incl.

--- a/theories/paco2_respectful.v
+++ b/theories/paco2_respectful.v
@@ -1,0 +1,248 @@
+From Paco Require Import paco2.
+Require Import Program.
+
+Set Implicit Arguments.
+
+Section Respectful2.
+  Variable T0: Type.
+  Variable T1: forall (x0: @T0), Type.
+  Definition rel := rel2 T0 T1.
+
+  Variable gf: rel -> rel.
+  Hypothesis gf_mon: monotone2 gf.
+
+  Inductive sound2 (clo: rel -> rel): Prop :=
+  | sound5_intro
+      (MON: monotone2 clo)
+      (SOUND:
+         forall r (PFIX: r <2= gf (clo r)),
+           r <2= paco2 gf bot2)
+  .
+  Hint Constructors sound2.
+
+  Structure respectful2 (clo: rel -> rel) : Prop := respectful2_intro {
+    MON: monotone2 clo;
+    RESPECTFUL:
+      forall l r (LE: l <2= r) (GF: l <2= gf r),
+        clo l <2= gf (clo r);
+  }.
+  Hint Constructors respectful2.
+
+  Inductive grespectful2 (r: rel) e1 e2: Prop :=
+  | grespectful2_intro
+      clo
+      (RES: respectful2 clo)
+      (CLO: clo r e1 e2)
+  .
+  Hint Constructors grespectful2.
+
+  Lemma gfclo2_mon: forall clo, sound2 clo -> monotone2 (compose gf clo).
+  Proof. intros; destruct H; eauto using gf_mon. Qed.
+  Hint Resolve gfclo2_mon : paco.
+
+  Lemma sound2_is_gf: forall clo (UPTO: sound2 clo),
+      paco2 (compose gf clo) bot2 <2= paco2 gf bot2.
+  Proof.
+    intros. punfold PR. edestruct UPTO.
+    eapply (SOUND (paco2 (compose gf clo) bot2)); eauto.
+    intros. punfold PR0.
+    eapply (gfclo2_mon UPTO); eauto.
+    intros. destruct PR1; eauto. contradiction.
+  Qed.
+
+  Lemma respectful2_is_sound2: respectful2 <1= sound2.
+  Proof.
+    intro clo.
+    set (rclo := fix rclo clo n (r: rel) :=
+           match n with
+           | 0 => r
+           | S n' => rclo clo n' r \2/ clo (rclo clo n' r)
+           end).
+    intros. destruct PR. econstructor; eauto.
+    intros. set (rr e1 e2 := exists n, rclo clo n r e1 e2).
+    assert (rr x0 x1) by (exists 0; eauto); clear PR.
+    cut (forall n, rclo clo n r <2= gf (rclo clo (S n) r)).
+    { intro X; revert x0 x1 H; pcofix CIH; intros.
+      unfold rr in *; destruct H0; eauto 10 using gf_mon. }
+    induction n; intros; [simpl; eauto using gf_mon|].
+    simpl in *; destruct PR; [eauto using gf_mon|].
+    eapply gf_mon; [eapply RESPECTFUL0; [|apply IHn|]|]; instantiate; simpl; eauto.
+  Qed.
+
+  Lemma respectful2_compose
+        clo1 clo2
+        (RES1: respectful2 clo1)
+        (RES2: respectful2 clo2):
+    respectful2 (compose clo1 clo2).
+  Proof.
+    intros. destruct RES1, RES2.
+    econstructor.
+    - repeat intro. eapply MON0; eauto.
+    - intros. eapply RESPECTFUL0; [| |apply PR].
+      + intros. eapply MON1; eauto.
+      + intros. eapply RESPECTFUL1; eauto.
+  Qed.
+
+  Lemma grespectful2_respectful2: respectful2 grespectful2.
+  Proof.
+    econstructor; repeat intro.
+    - destruct IN; destruct RES; exists clo; eauto.
+    - destruct PR; destruct RES; eapply gf_mon with (r:=clo r); eauto.
+  Qed.
+
+  Lemma gfgres2_mon: monotone2 (compose gf grespectful2).
+  Proof.
+    destruct grespectful2_respectful2; eauto using gf_mon.
+  Qed.
+  Hint Resolve gfgres2_mon : paco.
+
+  Lemma grespectful2_greatest: forall clo (RES: respectful2 clo), clo <3= grespectful2.
+  Proof.
+    eauto.
+  Qed.
+
+  Lemma grespectful2_incl: forall r, r <2= grespectful2 r.
+  Proof.
+    intros; eexists (fun x => x); eauto.
+  Qed.
+  Hint Resolve grespectful2_incl.
+
+  Lemma grespectful2_compose: forall clo (RES: respectful2 clo) r,
+      clo (grespectful2 r) <2= grespectful2 r.
+  Proof.
+    intros; eapply grespectful2_greatest with (clo := compose clo grespectful2);
+      eauto using respectful2_compose, grespectful2_respectful2.
+  Qed.
+
+  Lemma grespectful2_incl_rev: forall r,
+      grespectful2 (paco2 (compose gf grespectful2) r) <2= paco2 (compose gf grespectful2) r.
+  Proof.
+    intro r; pcofix CIH; intros; pfold.
+    eapply gf_mon, grespectful2_compose, grespectful2_respectful2.
+    destruct grespectful2_respectful2; eapply RESPECTFUL0, PR; intros; [apply grespectful2_incl; eauto|].
+    punfold PR0.
+    eapply gfgres2_mon; eauto; intros; destruct PR1; eauto.
+  Qed.
+
+  Inductive rclo2 clo (r: rel): rel :=
+  | rclo2_incl
+      e1 e2
+      (R: r e1 e2):
+      @rclo2 clo r e1 e2
+  | rclo2_step'
+      r' e1 e2
+      (R': r' <2= rclo2 clo r)
+      (CLOR':clo r' e1 e2):
+      @rclo2 clo r e1 e2
+  | rclo2_gf
+      r' e1 e2
+      (R': r' <2= rclo2 clo r)
+      (CLOR':@gf r' e1 e2):
+      @rclo2 clo r e1 e2
+  .
+  
+  Lemma rclo2_mon clo:
+    monotone2 (rclo2 clo).
+  Proof.
+    repeat intro. induction IN; eauto using rclo2.
+  Qed.
+  Hint Resolve rclo2_mon: paco.
+
+  Lemma rclo2_base
+        clo
+        (MON: monotone2 clo):
+    clo <3= rclo2 clo.
+  Proof.
+    simpl. intros. econstructor 2; eauto.
+    eapply MON; eauto using rclo2.
+  Qed.
+
+  Lemma rclo2_step
+        (clo: rel -> rel) r:
+    clo (rclo2 clo r) <2= rclo2 clo r.
+  Proof.
+    intros. econstructor 2; eauto.
+  Qed.
+
+  Lemma rclo2_rclo2
+        clo r
+        (MON: monotone2 clo):
+    rclo2 clo (rclo2 clo r) <2= rclo2 clo r.
+  Proof.
+    intros. induction PR; eauto using rclo2.
+  Qed.
+
+  Structure weak_respectful2 (clo: rel -> rel) : Prop := weak_respectful2_intro {
+    WEAK_MON: monotone2 clo;
+    WEAK_RESPECTFUL:
+      forall l r (LE: l <2= r) (GF: l <2= gf r),
+        clo l <2= gf (rclo2 clo r);
+  }.
+  Hint Constructors weak_respectful2.
+
+  Lemma weak_respectful2_respectful2
+        clo (RES: weak_respectful2 clo):
+    respectful2 (rclo2 clo).
+  Proof.
+    inversion RES. econstructor; eauto with paco. intros.
+    induction PR; intros.
+    - eapply gf_mon; eauto. intros.
+      apply rclo2_incl. auto.
+    - eapply gf_mon. 
+      + eapply WEAK_RESPECTFUL0; [|apply H|apply CLOR']. 
+        intros. eapply rclo2_mon; eauto.
+      + intros. apply rclo2_rclo2; auto.
+    - eapply gf_mon; eauto using rclo2.
+  Qed.
+
+  Lemma upto2_init:
+      paco2 (compose gf grespectful2) bot2 <2= paco2 gf bot2.
+  Proof.
+    apply sound2_is_gf; eauto.
+    apply respectful2_is_sound2.
+    apply grespectful2_respectful2.
+  Qed.
+
+  Lemma upto2_final:
+    paco2 gf <3= paco2 (compose gf grespectful2).
+  Proof.
+    pcofix CIH. intros. punfold PR. pfold.
+    eapply gf_mon; [|apply grespectful2_incl].
+    eapply gf_mon; eauto. intros. right. inversion PR0; auto.
+  Qed.
+
+  Lemma upto2_step
+        r clo (RES: weak_respectful2 clo):
+    clo (paco2 (compose gf grespectful2) r) <2= paco2 (compose gf grespectful2) r.
+  Proof.
+    intros. apply grespectful2_incl_rev.
+    assert (RES' := weak_respectful2_respectful2 RES).
+    eapply grespectful2_greatest. eauto.
+    eapply rclo2_base; eauto.
+    inversion RES. auto.
+  Qed.
+
+  Lemma upto2_low_step
+     r clo (RES: weak_respectful2 clo):
+   clo (grespectful2 r) <2= grespectful2 r.
+Proof.
+  intros. apply weak_respectful2_respectful2 in RES; eauto.
+  eapply grespectful2_compose; eauto. eauto using rclo2.
+Qed.
+
+End Respectful2.
+
+Hint Constructors sound2.
+Hint Constructors respectful2.
+Hint Constructors grespectful2.
+Hint Resolve gfclo2_mon : paco.
+Hint Resolve gfgres2_mon : paco.
+Hint Resolve grespectful2_incl.
+Hint Resolve rclo2_mon: paco.
+Hint Constructors weak_respectful2.
+
+Ltac pupto2_init := eapply upto2_init; eauto with paco.
+Ltac pupto2_final := eapply upto2_final; eauto with paco.
+Ltac pupto2 H := eapply upto2_step; [|exact H|]; eauto with paco.
+Ltac upto2_low_step H := eapply upto2_low_step; [|exact H|]; eauto with paco.
+Ltac upto2_low_final := eapply grespectful2_incl.


### PR DESCRIPTION
- Remove "Promitive Projections" for better automation.
- Add infrastructures for coinductive proofs.
- Prove key lemmas.