### PR TITLE
Use aloop as a primitive + refactoring

### DIFF
--- a/examples/Imp2AsmCorrectness.v
+++ b/examples/Imp2AsmCorrectness.v
@@ -342,7 +342,7 @@ Section Correctness.
 
   Definition interp_locals {R: Type} (t: itree E R) (s: alist var value)
     : itree E' (alist var value * R) :=
-    run_env _ (interp1 evalLocals _ t) s.
+    run_env _ (interp (eh_both evalLocals eh_inr) _ t) s.
 
   Instance eutt_interp_locals {R}:
     Proper (@eutt E R R eq ==> eq ==> @eutt E' (prod (alist var value) R) (prod _ R) eq)
@@ -351,8 +351,8 @@ Section Correctness.
     repeat intro.
     unfold interp_locals.
     unfold run_env.
-    rewrite H0. eapply eutt_interp_state; auto. rewrite H.
-    reflexivity.
+    rewrite H0. eapply eutt_interp_state; auto.
+    rewrite H; reflexivity.
   Qed.
 
   Lemma interp_locals_bind: forall {R S} (t: itree E R) (k: R -> itree _ S) (s: alist var value),
@@ -363,7 +363,7 @@ Section Correctness.
     intros.
     unfold interp_locals.
     unfold run_env.
-    rewrite interp1_bind.
+    rewrite interp_bind.
     rewrite interp_state_bind.
     reflexivity.
   Qed.
@@ -408,7 +408,7 @@ Section Correctness.
   Proof.
     unfold eq_locals, interp_locals, run_env.
     intros. unfold loop.
-    rewrite 2 interp1_loop.
+    rewrite 2 interp_loop.
     eapply interp_state_loop; auto.
   Qed.
 
@@ -628,14 +628,20 @@ Section Correctness.
     intros.
     destruct H as [_ [eq _]].
     unfold interp_locals.
-    rewrite interp1_liftE.
+    unfold lift.
+    rewrite interp_liftE.
     cbn.
     unfold run_env.
     rewrite env_lookupDefault_is_lift.
-    unfold lift; rewrite interp_state_liftE.
+    unfold lift.
+    rewrite unfold_interp_state; cbn.
+    rewrite bind_ret.
+    rewrite interp_state_liftE.
+    rewrite bind_ret.
     cbn.
     rewrite eq.
-    apply tau_eutt.
+    rewrite !tau_eutt.
+    reflexivity.
   Qed.
 
   Lemma compile_correct (s : stmt) :

--- a/theories/Core.v
+++ b/theories/Core.v
@@ -128,6 +128,22 @@ Definition cat {E T U V}
   T -> itree E V :=
   fun t => bind (k t) h.
 
+Definition _aloop {E : Type -> Type} {R I : Type}
+           (tau : _)
+           (aloop_ : I -> itree E R)
+           (step_i : itree E I + R) : itree E R :=
+  match step_i with
+  | inl cont => tau (ITree.bind cont aloop_)
+  | inr r => Ret r
+  end.
+
+(* Iterate a function updating an accumulator [A], until it produces
+   an output [B]. It's an Asymmetric variant of [loop], and it looks
+   similar to an Anamorphism, hence the name [aloop]. *)
+Definition aloop {E : Type -> Type} {R I: Type}
+           (step : I -> itree E I + R) : I -> itree E R :=
+  cofix aloop_ i := _aloop (fun t => Tau t) aloop_ (step i).
+
 (* note(gmm): There needs to be generic automation for monads to simplify
  * using the monad laws up to a setoid.
  * this would be *really* useful to a lot of projects.

--- a/theories/Eq/UpToTaus.v
+++ b/theories/Eq/UpToTaus.v
@@ -31,6 +31,7 @@ From ITree Require Import
      Core
      Eq.Eq.
 
+Import ITreeNotations.
 Local Open Scope itree.
 
 

--- a/theories/Fix.v
+++ b/theories/Fix.v
@@ -71,10 +71,13 @@ Import ITreeNotations.
 Definition interp_mrec {D E : Type -> Type}
            (ctx : D ~> itree (D +' E)) : itree (D +' E) ~> itree E :=
   fun R =>
-    cofix mutfix_ (t : itree (D +' E) R) : itree E R :=
-      handleF1 mutfix_
-               (fun _ d k => Tau (mutfix_ (ctx _ d >>= k)))
-               (observe t).
+    ITree.aloop (fun t : itree (D +' E) R =>
+      match observe t with
+      | RetF r => inr r
+      | TauF t => inl (Ret t)
+      | VisF (inl1 d) k => inl (Ret (ctx _ d >>= k))
+      | VisF (inr1 e) k => inl (Vis e (fun x => Ret (k x)))
+      end).
 
 (** Unfold a mutually recursive definition into separate trees,
     resolving the mutual references. *)
@@ -144,16 +147,3 @@ Definition loop {E : Type -> Type} {A B C : Type}
            (body : (C + A) -> itree E (C + B)) :
   A -> itree E B :=
   fun a => loop_ body (inr a).
-
-(* Iterate a function updating an accumulator [A], until it produces
-   an output [B]. It's an Asymmetric variant of [loop], and it looks
-   similar to an Anamorphism, hence the name [aloop]. *)
-Definition aloop {E : Type -> Type} {A B : Type}
-           (body : A -> itree E (A + B)) :
-  A -> itree E B :=
-  cofix aloop_ a :=
-    ab <- body a ;;
-    match ab with
-    | inl a => Tau (aloop_ a)
-    | inr b => Ret b
-    end.

--- a/theories/FixFacts.v
+++ b/theories/FixFacts.v
@@ -28,41 +28,50 @@ Context {D E : Type -> Type} (ctx : D ~> itree (D +' E)).
 
 (** Unfolding of [interp_mrec]. *)
 
-Definition interp_mrecF R :
-  itreeF (D +' E) R _ -> itree E R :=
-  handleF1 (interp_mrec ctx R)
-           (fun _ d k => Tau (interp_mrec ctx _ (ctx _ d >>= k))).
+Definition interp_mrecF R (ot : itreeF (D +' E) R _) : itree E R :=
+  match ot with
+  | RetF r => Ret r
+  | TauF t => Tau (interp_mrec ctx _ t)
+  | VisF e k => Tau
+    match e with
+    | inl1 d => interp_mrec ctx _ (ctx _ d >>= k)
+    | inr1 e => Vis e (fun x => interp_mrec ctx _ (k x))
+    end
+  end.
 
-Lemma observe_interp_mrecF R (t : itree (D +' E) R) :
-  observe (interp_mrec ctx _ t) = observe (interp_mrecF _ (observe t)).
-Proof. reflexivity. Qed.
-
-Lemma observe_interp_mrec R (t : itree (D +' E) R) :
-  eq_itree eq
-           (interp_mrec ctx _ t)
-           (interp_mrecF _ (observe t)).
+Lemma unfold_interp_mrec R (t : itree (D +' E) R) :
+  interp_mrec ctx _ t ≅ interp_mrecF _ (observe t).
 Proof.
-  rewrite itree_eta, observe_interp_mrecF, <-itree_eta.
-  reflexivity.
+  unfold interp_mrec.
+  rewrite unfold_aloop'.
+  destruct observe; cbn.
+  - reflexivity.
+  - rewrite ret_bind_; reflexivity. (* TODO: ret_bind, vis_bind are sloooow *)
+  - destruct e; cbn.
+    + rewrite ret_bind_; reflexivity.
+    + rewrite vis_bind_. pfold; constructor. left.
+      pfold; constructor.
+      left. rewrite ret_bind.
+      apply reflexivity.
 Qed.
 
 Lemma ret_mrec {T} (x: T) :
   interp_mrec ctx _ (Ret x) ≅ Ret x.
-Proof. rewrite observe_interp_mrec; reflexivity. Qed.
+Proof. rewrite unfold_interp_mrec; reflexivity. Qed.
 
 Lemma tau_mrec {T} (t: itree _ T) :
   interp_mrec ctx _ (Tau t) ≅ Tau (interp_mrec ctx _ t).
-Proof. rewrite observe_interp_mrec. reflexivity. Qed.
+Proof. rewrite unfold_interp_mrec. reflexivity. Qed.
 
 Lemma vis_mrec_right {T U} (e : E U) (k : U -> itree (D +' E) T) :
   interp_mrec ctx _ (Vis (inr1 e) k) ≅
-  Vis e (fun x => interp_mrec ctx _ (k x)).
-Proof. rewrite observe_interp_mrec. reflexivity. Qed.
+  Tau (Vis e (fun x => interp_mrec ctx _ (k x))).
+Proof. rewrite unfold_interp_mrec. reflexivity. Qed.
 
 Lemma vis_mrec_left {T U} (d : D U) (k : U -> itree (D +' E) T) :
   interp_mrec ctx _ (Vis (inl1 d) k) ≅
   Tau (interp_mrec ctx _ (ITree.bind (ctx _ d) k)).
-Proof. rewrite observe_interp_mrec. reflexivity. Qed.
+Proof. rewrite unfold_interp_mrec. reflexivity. Qed.
 
 Hint Rewrite @ret_mrec : itree.
 Hint Rewrite @vis_mrec_left : itree.
@@ -74,54 +83,56 @@ Instance eq_itree_mrec {R} :
 Proof.
   repeat intro. pupto2_init. revert_until R.
   pcofix CIH. intros.
-  rewrite !observe_interp_mrec.
+  rewrite !unfold_interp_mrec.
   pupto2_final.
   punfold H0. inv H0; pclearbot; [| |destruct e].
   - apply reflexivity.
   - pfold. econstructor. eauto.
   - pfold. econstructor. apply pointwise_relation_fold in REL.
     right. eapply CIH. rewrite REL. reflexivity.
-  - pfold. econstructor. eauto 7.
+  - pfold. econstructor. left; pfold; constructor. auto.
 Qed.
 
 Theorem interp_mrec_bind {U T} (t : itree _ U) (k : U -> itree _ T) :
   interp_mrec ctx _ (ITree.bind t k) ≅
   ITree.bind (interp_mrec ctx _ t) (fun x => interp_mrec ctx _ (k x)).
 Proof.
-  intros. pupto2_init. revert t k.
-  pcofix CIH. intros.
-  rewrite (itree_eta t).
-  destruct (observe t);
+  intros. pupto2_init; revert t k; pcofix CIH; intros.
+  rewrite (unfold_interp_mrec _ t), (unfold_bind t).
+  destruct (observe t); cbn;
     [| |destruct e];
     autorewrite with itree;
-    try rewrite <- bind_bind;
-    pupto2_final.
-  1: { apply reflexivity. }
+    try rewrite <- bind_bind.
+  1: { pupto2_final; apply reflexivity. }
   all: try (pfold; econstructor; eauto).
+  intros.
+  pupto2_final. left; pfold; constructor. auto.
 Qed.
 
-Theorem unfold_interp_mrec {T} (c : itree _ T) :
+Theorem interp_mrec_as_interp {T} (c : itree _ T) :
   interp_mrec ctx _ c ≈ interp (Sum1.elim (C:=itree E) (mrec ctx) ITree.liftE) _ c.
 Proof.
   repeat intro. pupto2_init. revert_until T. pcofix CIH. intros.
   pfold. pupto2_init. revert_until CIH. pcofix CIH'. intros.
-  rewrite observe_interp_mrecF, unfold_interp.
+  rewrite unfold_interp_mrec, unfold_interp.
   destruct (observe c); [| |destruct e]; simpl; eauto 7.
   - rewrite interp_mrec_bind.
-    pfold. econstructor.
-    pupto2 eutt_nested_clo_bind.
-    econstructor; [reflexivity|].
-    intros; subst. eauto.
+    pfold; constructor.
+    pupto2 eutt_nested_clo_bind; econstructor; [reflexivity|].
+    intros ? _ []; eauto.
+
   - unfold ITree.liftE. rewrite vis_bind_.
-    pfold. econstructor. econstructor. intros. left.
-    rewrite ret_bind.
-    pupto2_final. eauto.
+    pfold; constructor.
+    pupto2_final.
+    left; pfold; econstructor.
+    left.
+    rewrite ret_bind_. auto.
 Qed.
 
-Theorem unfold_mrec {T} (d : D T) :
+Theorem mrec_as_interp {T} (d : D T) :
   mrec ctx _ d ≈ interp (Sum1.elim (C:=itree E) (mrec ctx) ITree.liftE) _ (ctx _ d).
 Proof.
-  apply unfold_interp_mrec.
+  apply interp_mrec_as_interp.
 Qed.
 
 End Facts.
@@ -129,8 +140,8 @@ End Facts.
 Lemma rec_unfold {E A B} (f : A -> itree (callE A B +' E) B) (x : A) :
   rec f x ≈ interp (Sum1.elim (C:=itree E) (calling' (rec f)) ITree.liftE) _ (f x).
 Proof.
-  unfold rec. unfold mrec.
-  rewrite unfold_interp_mrec.
+  unfold rec.
+  rewrite mrec_as_interp.
   eapply eutt_interp.
   - red. intro. red. destruct a; try reflexivity.
     destruct c.
@@ -162,32 +173,6 @@ Proof.
   apply eutt_bind; try reflexivity.
   intros []; try reflexivity.
   rewrite tau_eutt; reflexivity.
-Qed.
-
-Lemma unfold_aloop' {E A B} (f : A -> itree E (A + B)) (x : A) :
-    aloop f x
-  ≅ (ab <- f x ;;
-     match ab with
-     | inl a => Tau (aloop f a)
-     | inr b => Ret b
-     end).
-Proof.
-  rewrite (itree_eta (aloop _ _)), (itree_eta (ITree.bind _ _)).
-  reflexivity.
-Qed.
-
-Lemma unfold_aloop {E A B} (f : A -> itree E (A + B)) (x : A) :
-    aloop f x
-  ≈ (ab <- f x ;;
-     match ab with
-     | inl a => aloop f a
-     | inr b => Ret b
-     end).
-Proof.
-  rewrite unfold_aloop'.
-  apply eutt_bind; try reflexivity.
-  intros []; try reflexivity.
-  apply tau_eutt.
 Qed.
 
 (* Equations for a traced monoidal category *)
@@ -389,29 +374,6 @@ Definition sum_map1 {A B C} (f : A -> B) (ac : A + C) : B + C :=
   | inl a => inl (f a)
   | inr c => inr c
   end.
-
-Lemma bind_aloop {E A B C} (f : A -> itree E (A + B)) (g : B -> itree E (B + C)) (x : A) :
-    (aloop f x >>= aloop g)
-  ≈ aloop (fun ab =>
-       match ab with
-       | inl a => ITree.map inl (f a)
-       | inr b => ITree.map (sum_map1 inr) (g b)
-       end) (inl x).
-Proof.
-  pupto2_init. revert_until g. pcofix CIH. intros.
-  pfold. pupto2_init. revert_until CIH. pcofix CIH'. intros.
-
-  rewrite !unfold_aloop', bind_bind, map_bind.
-  pupto2 eutt_nested_clo_bind. econstructor; [reflexivity|].
-  intros; subst. destruct v2; simpl.
-  - rewrite tau_bind_.
-    pfold. econstructor. eauto.
-  - rewrite ret_bind_. pfold. econstructor. pfold_reverse.
-    revert_until x. pcofix CIH''. intros.
-    rewrite !unfold_aloop', map_bind.
-    pupto2 eutt_nested_clo_bind. econstructor; [reflexivity|].
-    intros. subst. destruct v2; simpl; eauto 7.
-Qed.
 
 Instance eq_itree_loop {E A B C} :
   Proper ((eq ==> eq_itree eq) ==> eq ==> eq_itree eq) (@loop E A B C).
@@ -636,6 +598,7 @@ Proof.
   - rewrite !interp_state_ret. simpl. eauto 7.
 Qed.
 
+(*
 Lemma interp1_loop {E F G} `{F -< G} (f : E ~> itree G) {A B C}
       (t : C + A -> itree (E +' F) (C + B)) ca :
   interp1 f _ (loop_ t ca) ≅ loop_ (fun ca => interp1 f _ (t ca)) ca.
@@ -647,3 +610,4 @@ Proof.
   intros. subst. rewrite unfold_interp1. pupto2_final. pfold. red.
   destruct u2; simpl; eauto.
 Qed.
+*)

--- a/theories/FixFacts.v
+++ b/theories/FixFacts.v
@@ -142,10 +142,8 @@ Lemma rec_unfold {E A B} (f : A -> itree (callE A B +' E) B) (x : A) :
 Proof.
   unfold rec.
   rewrite mrec_as_interp.
-  eapply eutt_interp.
-  - red. intro. red. destruct a; try reflexivity.
-    destruct c.
-    reflexivity.
+  eapply eutt_interp_gen.
+  - do 2 red. intros ? [[] | ]; reflexivity.
   - reflexivity.
 Qed.
 
@@ -598,16 +596,14 @@ Proof.
   - rewrite !interp_state_ret. simpl. eauto 7.
 Qed.
 
-(*
-Lemma interp1_loop {E F G} `{F -< G} (f : E ~> itree G) {A B C}
-      (t : C + A -> itree (E +' F) (C + B)) ca :
-  interp1 f _ (loop_ t ca) ≅ loop_ (fun ca => interp1 f _ (t ca)) ca.
+Lemma interp_loop {E F} (f : E ~> itree F) {A B C}
+      (t : C + A -> itree E (C + B)) ca :
+  interp f _ (loop_ t ca) ≅ loop_ (fun ca => interp f _ (t ca)) ca.
 Proof.
   pupto2_init. revert ca. pcofix CIH. intros.
   unfold loop. rewrite !unfold_loop'. unfold loop_once.
-  rewrite interp1_bind.
+  rewrite interp_bind.
   pupto2 eq_itree_clo_bind. econstructor; [reflexivity|]. 
-  intros. subst. rewrite unfold_interp1. pupto2_final. pfold. red.
+  intros. subst. rewrite unfold_interp. pupto2_final. pfold. red.
   destruct u2; simpl; eauto.
 Qed.
-*)

--- a/theories/MorphismsFacts.v
+++ b/theories/MorphismsFacts.v
@@ -120,7 +120,7 @@ Proof.
 Qed.
 
 (* Note that this allows rewriting of handlers. *)
-Instance eutt_interp (E F : Type -> Type) (R : Type) :
+Definition eutt_interp_gen (E F : Type -> Type) (R : Type) :
   Proper (Rhom (fun _ => eutt eq) ==> eutt eq ==> eutt eq)
          (fun f => @interp E F f R).
 Proof.
@@ -138,6 +138,14 @@ Proof.
   - pfold; constructor. pfold_reverse. rewrite unfold_interp.
     auto.
   - pfold; constructor. pfold_reverse. rewrite unfold_interp. auto.
+Qed.
+
+Instance eutt_interp (E F : Type -> Type) f (R : Type) :
+  Proper (eutt eq ==> eutt eq)
+         (@interp E F f R).
+Proof.
+  apply eutt_interp_gen.
+  red; reflexivity.
 Qed.
 
 Lemma interp_ret : forall {E F R} x

--- a/theories/MorphismsFacts.v
+++ b/theories/MorphismsFacts.v
@@ -57,28 +57,38 @@ Notation "f ≡ g" := (eh_eutt f g) (at level 70).
  *)
 
 (* Unfolding of [interp]. *)
-Definition interp_u {E F} (f : E ~> itree F) R :
-  itreeF E R _ -> itree F R :=
-  handleF (interp f _)
-          (fun _ e k => Tau (ITree.bind (f _ e)
-                                        (fun x => interp f _ (k x)))).
+Definition interp_u {E F} (f : E ~> itree F) R (ot : itreeF E R _)
+  : itree F R :=
+  match ot with
+  | RetF r => Ret r
+  | TauF t => Tau (interp f _ t)
+  | VisF e k => Tau (f _ e >>= (fun x => interp f _ (k x)))
+  end.
 
 Lemma unfold_interp {E F R} {f : E ~> itree F} (t : itree E R) :
-  observing eq (interp f _ t) (interp_u f _ (observe t)).
-Proof. econstructor. reflexivity. Qed.
+  interp f _ t ≅ (interp_u f _ (observe t)).
+Proof.
+  unfold interp. rewrite unfold_aloop'.
+  destruct (observe t); cbn.
+  - reflexivity.
+  - rewrite ret_bind; reflexivity. (* TODO: Incredibly slow *)
+  - rewrite map_bind. apply eq_itree_tau. eapply eq_itree_bind.
+    reflexivity.
+    intros ? _ []; reflexivity.
+Qed.
 
 (** ** [interp] and constructors *)
 
 Lemma ret_interp {E F R} {f : E ~> itree F} (x: R):
-  observing eq (interp f _ (Ret x)) (Ret x).
+  interp f _ (Ret x) ≅ Ret x.
 Proof. rewrite unfold_interp. reflexivity. Qed.
 
 Lemma tau_interp {E F R} {f : E ~> itree F} (t: itree E R):
-  observing eq (interp f _ (Tau t)) (Tau (interp f _ t)).
+  eq_itree eq (interp f _ (Tau t)) (Tau (interp f _ t)).
 Proof. rewrite unfold_interp. reflexivity. Qed.
 
 Lemma vis_interp {E F R} {f : E ~> itree F} U (e: E U) (k: U -> itree E R) :
-  observing eq (interp f _ (Vis e k)) (Tau (ITree.bind (f _ e) (fun x => interp f _ (k x)))).
+  eq_itree eq (interp f _ (Vis e k)) (Tau (ITree.bind (f _ e) (fun x => interp f _ (k x)))).
 Proof. rewrite unfold_interp. reflexivity. Qed.
 
 (** ** [interp] properness *)
@@ -88,20 +98,18 @@ Instance eq_itree_interp {E F R}:
 Proof.
   intros f g Hfg.
   intros l r Hlr.
-  pupto2_init.
-  revert l r Hlr.
-  pcofix CIH.
-  rename r into rr.
-  intros l r Hlr.
-  rewrite itree_eta, (itree_eta (interp g _ r)), !unfold_interp.
+  pupto2_init; revert l r Hlr; pcofix CIH.
+  rename r into rr; intros l r Hlr.
+  rewrite 2 unfold_interp.
   punfold Hlr; red in Hlr.
-  destruct Hlr; pclearbot.
-  - pupto2_final. pfold. red. cbn. eauto.
-  - pupto2_final. pfold. red. cbn. eauto.
-  - pfold. econstructor. pupto2 eq_itree_clo_bind.
-    econstructor.
-    + eapply Hfg.
-    + intros; subst; pupto2_final; right; eauto.
+  destruct Hlr; pclearbot; cbn.
+  - pupto2_final. pfold. constructor; auto.
+  - pupto2_final. pfold. constructor; auto.
+  - pfold; constructor.
+    pupto2 @eq_itree_clo_bind. econstructor.
+    eapply Hfg.
+    intros ? _ [].
+    pupto2_final; auto.
 Qed.
 
 Global Instance Proper_interp_eq_itree {E F R f}
@@ -119,53 +127,53 @@ Proof.
   repeat intro. pupto2_init. revert_until H. pcofix CIH. intros.
   pfold. pupto2_init. revert_until CIH. pcofix CIH'. intros.
 
-  rewrite !unfold_interp. do 2 punfold H1. pfold.
+  rewrite !unfold_interp. do 2 punfold H1.
   induction H1; intros; subst; pclearbot; simpl; eauto.
-  - econstructor. pupto2 eutt_nested_clo_bind.
+  - pfold; constructor.
+    pupto2 eutt_nested_clo_bind.
     econstructor; [apply H|].
     intros; subst. pupto2_final.
     right. eapply CIH'. edestruct EUTTK; pclearbot; eauto.
-  - econstructor. pupto2_final. eauto 7.
+  - pfold; econstructor. pupto2_final. eauto 7.
+  - pfold; constructor. pfold_reverse. rewrite unfold_interp.
+    auto.
+  - pfold; constructor. pfold_reverse. rewrite unfold_interp. auto.
 Qed.
 
 Lemma interp_ret : forall {E F R} x
       (f : E ~> itree F),
    (interp f R (Ret x)) ≅ Ret x.
 Proof.
-  intros. rewrite (itree_eta (Ret x)).
-  rewrite unfold_interp. unfold interp_u. unfold handleF.
-  cbn. reflexivity.
+  intros. apply observing_eq_itree_eq.
+  constructor. reflexivity.
 Qed.
 
 Lemma interp_bind {E F R S}
       (f : E ~> itree F) (t : itree E R) (k : R -> itree E S) :
    (interp f _ (ITree.bind t k)) ≅ (ITree.bind (interp f _ t) (fun r => interp f _ (k r))).
 Proof.
-  pupto2_init.
-  revert R t k.
-  pcofix CIH. intros.
-  rewrite (itree_eta t). destruct (observe t).
+  pupto2_init; revert R t k; pcofix CIH; intros.
+  rewrite unfold_bind, (unfold_interp t).
+  destruct (observe t); cbn.
   (* TODO: [ret_bind] (0.8s) is much slower than [ret_bind_] (0.02s) *)
-  - rewrite ret_interp. rewrite !ret_bind. pupto2_final. apply reflexivity.
-  - rewrite tau_interp, !tau_bind, tau_interp.
+  - rewrite ret_bind. pupto2_final. apply reflexivity.
+  - rewrite tau_bind, !tau_interp.
     pupto2_final. pfold. econstructor. eauto.
   - rewrite vis_interp, tau_bind. rewrite bind_bind.
-    pfold. do 2 red; cbn. constructor.
+    pfold; constructor.
     pupto2 (eq_itree_clo_bind F S). econstructor.
     + reflexivity.
-    + intros; subst. specialize (CIH _ (k0 u2) k); auto.
+    + intros; subst. pupto2_final. auto.
 Qed.
 
 Lemma interp_liftE {E F : Type -> Type} {R : Type}
       (f : E ~> (itree F))
       (e : E R) :
-  interp f _ (ITree.liftE e) ≅ Tau (f _ e).
+  interp f _ (ITree.liftE e) ≅ Tau (f _ e >>= fun x => Ret x).
 Proof.
   unfold ITree.liftE. rewrite vis_interp.
-  apply itree_eq_tau.
-  assert (pointwise_relation _ (@eq_itree _ _ _ (@eq R)) (fun x : R => interp f R (Ret x)) (fun x => Ret x)).
-  {red. intros. rewrite ret_interp. reflexivity. }
-  rewrite H. rewrite bind_ret.
+  apply eq_itree_tau.
+  setoid_rewrite ret_interp.
   reflexivity.
 Qed.
 
@@ -175,22 +183,15 @@ Qed.
 Lemma interp_id_liftE {E R} (t : itree E R) :
   interp (fun _ e => ITree.liftE e) _ t ≈ t.
 Proof.
-  pupto2_init.
-  revert t.
-  pcofix CIH.
-  intros t.
-  rewrite unfold_interp. unfold interp_u. unfold handleF.
-  pfold. revert t. pcofix CIH'.
-  intros t.
+  pupto2_init; revert t; pcofix CIH; intros t.
+  pfold. pupto2_init; revert t; pcofix CIH'; intros t.
+  rewrite unfold_interp.
   destruct (observe t); cbn; eauto.
-  - pfold. econstructor.
-    right. rewrite unfold_interp. unfold interp_u. unfold handleF.
-    apply CIH'.
-  - pfold. econstructor. cbn. econstructor. intros.
-    assert (ITree.bind' (fun x0 : u => interp (fun (T : Type) (e0 : E T) => ITree.liftE e0) R (k x0)) (Ret x) = (x0 <- Ret x ;; interp (fun (T : Type) (e0 : E T) => ITree.liftE e0) R (k x0))).
-    { intros; reflexivity. }
-    left. rewrite H, ret_bind.
-    pupto2_final. eauto.
+  - pfold. constructor. pupto2_final; auto.
+  - unfold ITree.liftE. rewrite vis_bind; cbn.
+    pfold; constructor; constructor.
+    left. rewrite ret_bind.
+    auto.
 Qed.
 
 
@@ -204,30 +205,47 @@ Proof.
   revert t.
   pcofix CIH.
   intros t.
-  rewrite itree_eta.
-  rewrite (itree_eta t).
-  rewrite (itree_eta (interp (fun (T : Type) (e : E T) => interp g T (f T e)) R (go (observe t)))).
-  rewrite unfold_interp.
+  rewrite 2 (unfold_interp t).
   destruct (observe t); cbn.
-  - pupto2_final. pfold. econstructor. reflexivity.
-  - pupto2_final. pfold. econstructor. right.  apply CIH.
-  - rewrite interp_bind.
-    pfold. econstructor.
+  - rewrite ret_interp. pupto2_final. pfold. constructor. reflexivity.
+  - rewrite tau_interp. pupto2_final. pfold. constructor. auto.
+  - rewrite tau_interp, interp_bind.
+    pfold; constructor.
     pupto2 eq_itree_clo_bind.
     apply pbc_intro_h with (RU := eq).
     + reflexivity.
-    + intros.
-      pupto2_final. right. subst. apply CIH.
+    + intros ? _ [].
+      pupto2_final; auto.
 Qed.
 
 (** * [interp_state] *)
 
-Lemma unfold_interp_state : forall {E F S R} (h : E ~> Monads.stateT S (itree F)) t s,
-    observe (interp_state h _ t s) =
-    observe (interp_state_match h (interp_state h R) (observe t) s).
+Import Monads.
+
+Definition _interp_state {E F S}
+           (f : E ~> stateT S (itree F)) R (ot : itreeF E R _)
+  : stateT S (itree F) R := fun s =>
+  match ot with
+  | RetF r => Ret (s, r)
+  | TauF t => Tau (interp_state f _ t s)
+  | VisF e k => Tau (f _ e s >>= (fun sx => interp_state f _ (k (snd sx)) (fst sx)))
+  end.
+
+Lemma unfold_interp_state {E F S R} (h : E ~> Monads.stateT S (itree F)) t s :
+    eq_itree eq
+      (interp_state h _ t s)
+      (_interp_state h R (observe t) s).
 Proof.
-  intros E F S R h t s.
-  econstructor.
+  unfold interp_state.
+  rewrite unfold_aloop'.
+  destruct observe; cbn.
+  - reflexivity.
+  - rewrite ret_bind_.
+    reflexivity.
+  - rewrite map_bind. eapply eq_itree_tau.
+    eapply eq_itree_bind.
+    + reflexivity.
+    + intros [] _ []; reflexivity.
 Qed.
 
 Instance eq_itree_interp_state {E F S R} (h : E ~> Monads.stateT S (itree F)) :
@@ -236,49 +254,16 @@ Instance eq_itree_interp_state {E F S R} (h : E ~> Monads.stateT S (itree F)) :
 Proof.
   repeat intro. pupto2_init. revert_until R.
   pcofix CIH. intros h x y H0 x2 y0 H1.
-  rewrite itree_eta, (itree_eta (interp_state h _ y y0)), !unfold_interp_state.
-  unfold interp_state_match.
+  rewrite !unfold_interp_state.
+  unfold _interp_state.
   punfold H0; red in H0.
   genobs x ox; destruct ox; simpobs; dependent destruction H0; simpobs; pclearbot.
   - pupto2_final. pfold. red. cbn. subst. eauto.
   - pupto2_final. pfold. red. cbn. subst. eauto.
-  - pfold. econstructor. pupto2 (eq_itree_clo_bind F (S * R)).
-    econstructor.
-    + subst. reflexivity.
-    + intros; subst. pupto2_final; right; eauto.
+  - subst. pfold; constructor. pupto2 eq_itree_clo_bind. econstructor.
+    + reflexivity.
+    + intros [] _ []. pupto2_final. auto.
 Qed.
-
-
-Lemma unfold_interp1_state : forall {E F S R} (h : E ~> Monads.stateT S (itree F)) t s,
-    observe (interp1_state h _ t s) =
-    observe (interp1_state_match h (interp1_state h R) (observe t) s).
-Proof.
-  intros E F S R h t s.
-  econstructor.
-Qed.
-
-Instance eq_itree_interp1_state {E F S R} (h : E ~> Monads.stateT S (itree F)) :
-  Proper (eq_itree eq ==> eq ==> eq_itree eq) (interp1_state h R).
-Proof.
-  repeat intro.
-  pupto2_init. revert_until R.
-  pcofix CIH. intros h x y H0 x2 y0 H1.
-  rewrite itree_eta, (itree_eta (interp1_state h _ y y0)), !unfold_interp1_state.
-  unfold interp1_state_match.
-  punfold H0; red in H0.
-  genobs x ox; destruct ox; simpobs; dependent destruction H0; simpobs; pclearbot.
-  - pupto2_final. pfold. red. cbn. subst. eauto.
-  - pupto2_final. pfold. red. cbn. subst. eauto.
-  - pfold.
-    destruct e.
-    * econstructor. pupto2 (eq_itree_clo_bind F (S * R)).
-      econstructor.
-      + subst. reflexivity.
-      + intros; subst. pupto2_final. right. eauto.
-    * econstructor. intros. pupto2_final. right.
-      eauto.
-Qed.
-
 
 Lemma interp_state_ret {E F : Type -> Type} {R S : Type}
       (f : forall T, E T -> S -> itree F (S * T)%type)
@@ -288,97 +273,32 @@ Proof.
   rewrite itree_eta. reflexivity.
 Qed.
 
-
-Lemma interp1_state_ret {E F : Type -> Type} {R S : Type}
-      (f : forall T, E T -> S -> itree F (S * T)%type)
-      (s : S) (r : R) :
-  (interp1_state f _ (Ret r) s) ≅ (Ret (s, r)).
+Lemma interp_state_vis {E F:Type -> Type} {S T U : Type} (s:S) e k
+      (h : E ~> Monads.stateT S (itree F)) :
+    interp_state h U (Vis e k) s
+  ≅ Tau (h T e s >>= fun sx => interp_state h _ (k (snd sx)) (fst sx)).
 Proof.
-  rewrite itree_eta. reflexivity.
+  rewrite unfold_interp_state; reflexivity.
 Qed.
 
-
-Lemma interp_state_vis : forall {E F:Type -> Type} {S T U : Type} (s:S) e k
-                           (h : E ~> Monads.stateT S (itree F)),
-    interp_state h U (Vis e k) s ≅ Tau (ITree.bind (h T e s) (fun sx => interp_state h _ (k (snd sx)) (fst sx))).
-Proof.
-  intros E F S T U s e k h.
-  rewrite itree_eta.
-  reflexivity.
-Qed.
-
-Lemma interp1_state_vis1 : forall {E F:Type -> Type} {S T U : Type} (s:S) e k
-                           (h : E ~> Monads.stateT S (itree F)),
-    interp1_state h U (Vis (inl1 e) k) s ≅ Tau (ITree.bind (h T e s) (fun sx => interp1_state h _ (k (snd sx)) (fst sx))).
-Proof.
-  intros E F S T U s e k h.
-  rewrite itree_eta.
-  reflexivity.
-Qed.
-
-Lemma interp1_state_vis2 : forall {E F:Type -> Type} {S T U : Type} (s:S) (e : F T) k
-                           (h : E ~> Monads.stateT S (itree F)),
-    interp1_state h U (Vis (inr1 e) k) s ≅ (Vis e (fun x => interp1_state h _ (k x) s)).
-Proof.
-  intros E F S T U s e k h.
-  rewrite itree_eta.
-  reflexivity.
-Qed.
-
-Lemma interp_state_tau : forall {E F:Type -> Type} S {T : Type} (t:itree E T) (s:S)
-                           (h : E ~> Monads.stateT S (itree F)),
+Lemma interp_state_tau {E F:Type -> Type} S {T : Type} (t:itree E T) (s:S)
+      (h : E ~> Monads.stateT S (itree F)) :
     interp_state h _ (Tau t) s ≅ Tau (interp_state h _ t s).
 Proof.
-  intros E F S T t s h.
-  rewrite itree_eta. reflexivity.
-Qed.
-
-Lemma interp1_state_tau : forall {E F:Type -> Type} S {T : Type} (t:itree (E +' F) T) (s:S)
-                           (h : E ~> Monads.stateT S (itree F)),
-    interp1_state h _ (Tau t) s ≅ Tau (interp1_state h _ t s).
-Proof.
-  intros E F S T t s h.
-  rewrite itree_eta. reflexivity.
+  rewrite unfold_interp_state; reflexivity.
 Qed.
 
 Lemma interp_state_liftE {E F : Type -> Type} {R S : Type}
       (f : E ~> Monads.stateT S (itree F))
       (s : S) (e : E R) :
-  (interp_state f _ (ITree.liftE e) s) ≅ Tau (f _ e s).
+  (interp_state f _ (ITree.liftE e) s) ≅ Tau (f _ e s >>= fun i => Ret i).
 Proof.
   unfold ITree.liftE. rewrite interp_state_vis.
-  assert (pointwise_relation _ (eq_itree eq) (fun sx : S * R => interp_state f R (Ret (snd sx)) (fst sx)) (fun sx => Ret sx)).
-  { intros sx. destruct sx. simpl.
-    rewrite itree_eta. cbn. reflexivity. }
-  rewrite H.
-  rewrite bind_ret.
-  reflexivity.
+  apply eq_itree_tau.
+  eapply eq_itree_bind.
+  - reflexivity.
+  - intros [] _ []; rewrite interp_state_ret. reflexivity.
 Qed.
-
-Lemma interp1_state_liftE1 {E F : Type -> Type} {R S : Type}
-      (f : E ~> Monads.stateT S (itree F))
-      (s : S) (e : E R) :
-  (interp1_state f _ (ITree.liftE (inl1 e)) s) ≅ Tau (f _ e s).
-Proof.
-  unfold ITree.liftE. rewrite interp1_state_vis1.
-  assert (pointwise_relation _ (eq_itree eq) (fun sx : S * R => interp1_state f R (Ret (snd sx)) (fst sx)) (fun sx => Ret sx)).
-  { intros sx. destruct sx. simpl.
-    rewrite itree_eta. cbn. reflexivity. }
-  rewrite H.
-  rewrite bind_ret.
-  reflexivity.
-Qed.
-
-Lemma interp1_state_liftE2 {E F : Type -> Type} {R S : Type}
-      (f : E ~> Monads.stateT S (itree F))
-      (s : S) (e : F R) :
-  (interp1_state f _ (ITree.liftE (inr1 e)) s) ≅ Vis e (fun x => Ret (s, x)).
-Proof.
-  unfold ITree.liftE. rewrite interp1_state_vis2.
-  apply itree_eq_vis. intros.
-  rewrite interp1_state_ret. reflexivity.
-Qed.
-
 
 Lemma interp_state_bind {E F : Type -> Type} {A B S : Type}
       (f : forall T, E T -> S -> itree F (S * T)%type)
@@ -392,47 +312,19 @@ Proof.
   revert A t k s.
   pcofix CIH.
   intros A t k s.
-  rewrite (itree_eta t).
+  rewrite unfold_bind, (unfold_interp_state f t).
   destruct (observe t).
   (* TODO: performance issues with [ret|tau|vis_bind] here too. *)
-  - cbn. rewrite interp_state_ret. rewrite !ret_bind. simpl.
+  - cbn. rewrite !ret_bind. simpl.
     pupto2_final. apply reflexivity.
-  - cbn. rewrite interp_state_tau, !tau_bind, interp_state_tau.
+  - cbn. rewrite !tau_bind, interp_state_tau.
     pupto2_final. pfold. econstructor. right. apply CIH.
-  - cbn. rewrite interp_state_vis, tau_bind, vis_bind, bind_bind, interp_state_vis.
-    pfold. red. constructor.
-    pupto2 (eq_itree_clo_bind F (S * B)). econstructor.
+  - cbn. rewrite interp_state_vis, tau_bind, bind_bind.
+    pfold; constructor.
+    pupto2 eq_itree_clo_bind. econstructor.
     + reflexivity.
-    + intros. subst. specialize (CIH _ (k0 (snd u2)) k (fst u2)). auto.
-Qed.
-
-Lemma interp1_state_bind {E F : Type -> Type} {A B S : Type}
-      (f : forall T, E T -> S -> itree F (S * T)%type)
-      (t : itree (E +' F) A) (k : A -> itree (E +' F) B)
-      (s : S) :
-  (interp1_state f _ (t >>= k) s)
-    ≅
-  (interp1_state f _ t s >>= fun st => interp1_state f _ (k (snd st)) (fst st)).
-Proof.
-  pupto2_init.
-  revert A t k s.
-  pcofix CIH.
-  intros A t k s.
-  rewrite (itree_eta t).
-  destruct (observe t).
-  - cbn. rewrite interp1_state_ret. rewrite !ret_bind. simpl.
-    pupto2_final. apply reflexivity.
-  - cbn. rewrite interp1_state_tau, !tau_bind, interp1_state_tau.
-    pupto2_final. pfold. econstructor. right. apply CIH.
-  - cbn. destruct e.
-    * rewrite interp1_state_vis1, tau_bind, vis_bind, bind_bind, interp1_state_vis1.
-      pfold. red. constructor.
-      pupto2 (eq_itree_clo_bind F (S * B)). econstructor.
-      + reflexivity.
-      + intros. subst. specialize (CIH _ (k0 (snd u2)) k (fst u2)). auto.
-   * rewrite interp1_state_vis2, !vis_bind. rewrite itree_eta. rewrite unfold_interp1_state.
-     cbn. pfold. constructor. intros.
-     specialize (CIH _ (k0 v) k s). auto.
+    + intros u2 ? []. specialize (CIH _ (k0 (snd u2)) k (fst u2)).
+      auto.
 Qed.
 
 Instance eutt_interp_state {E F: Type -> Type} {S : Type}
@@ -442,13 +334,17 @@ Proof.
   repeat intro. subst. pupto2_init. revert_until R. pcofix CIH. intros.
   pfold. pupto2_init. revert_until CIH. pcofix CIH'. intros.
 
-  rewrite !unfold_interp_state. do 2 punfold H0. pfold.
+  rewrite !unfold_interp_state. do 2 punfold H0.
   induction H0; intros; subst; simpl; pclearbot; eauto.
-  - econstructor. pupto2 eutt_nested_clo_bind.
-    econstructor; [reflexivity|].
+  - pfold; constructor.
+    pupto2 eutt_nested_clo_bind; econstructor; [reflexivity|].
     intros; subst. pupto2_final.
     right. eapply CIH'. edestruct EUTTK; pclearbot; eauto.
-  - econstructor. pupto2_final. eauto 7.
+  - econstructor. pupto2_final. eauto 9.
+  - pfold; constructor. pfold_reverse.
+    rewrite unfold_interp_state; auto.
+  - pfold; constructor. pfold_reverse.
+    rewrite unfold_interp_state; auto.
 Qed.
 
 (* Commuting interpreters --------------------------------------------------- *)
@@ -460,50 +356,30 @@ Proof.
   revert t.
   pcofix CIH.
   intros t.
-  rewrite (itree_eta).
-  rewrite (itree_eta (interp (fun (T : Type) (e : E T) => g T (f T e)) R t)).
   rewrite !unfold_interp. unfold interp_u.
-  unfold handleF. rewrite unfold_translate. unfold translateF.
+  rewrite unfold_translate. unfold translateF.
   destruct (observe t); cbn.
   - pupto2_final. apply Reflexive_eq_itree. (* SAZ: typeclass resolution failure? *)
   - pfold. constructor. pupto2_final. right. apply CIH.
-  - pfold. constructor.
-    pupto2 eq_itree_clo_bind.
-    econstructor.
+  - pfold; constructor.
+    pupto2 eq_itree_clo_bind; econstructor.
     + reflexivity.
-    + intros. subst. pupto2_final. right. apply CIH.
+    + intros ? _ []. pupto2_final. auto.
 Qed.
 
 Lemma translate_to_interp {E F R} (f : E ~> F) (t : itree E R) :
   translate f t ≈ interp (fun _ e => ITree.liftE (f _ e)) _ t.
 Proof.
-  pupto2_init.
-  revert t.
-  pcofix CIH.
-  intros t.
-  rewrite itree_eta.
-  rewrite (itree_eta (interp (fun (T : Type) (e : E T) => ITree.liftE (f T e)) R t)).
+  pupto2_init; revert t; pcofix CIH; intros t.
+  pfold. pupto2_init; revert t; pcofix CIH'; intros t.
   rewrite unfold_translate.
   rewrite unfold_interp.
-  unfold translateF, interp_u, handleF.
-  pfold. revert t. pcofix CIH'.
-  intros t.
+  unfold translateF, interp_u.
   destruct (observe t); cbn; simpl in *; eauto.
-  - pfold. econstructor.
-    right. rewrite unfold_translate. unfold translateF.
-    rewrite unfold_interp. unfold interp_u. apply CIH'.
-  - pfold. econstructor. unfold ITree.liftE. rewrite vis_bind.
-    econstructor. intros.
-    left.
-    rewrite (itree_eta (x0 <- Ret x;; interp (fun (T : Type) (e0 : E T) => Vis (f T e0) (fun x1 : T => Ret x1)) R (k x0))).
-    assert ((observe (x0 <- Ret x;; interp (fun (T : Type) (e0 : E T) => Vis (f T e0) (fun x1 : T => Ret x1)) R (k x0)))
-            = observe (interp (fun (T : Type) (e0 : E T) => Vis (f T e0) (fun x1 : T => Ret x1)) R (k x))).
-    { reflexivity. }
-    rewrite H.
-    unfold ITree.liftE in CIH.
-    rewrite <- itree_eta.
-    pupto2_final. right.
-    apply CIH.
+  - pfold. constructor. auto.
+  - unfold ITree.liftE. rewrite vis_bind.
+    pfold. do 2 constructor.
+    left. rewrite ret_bind. auto.
 Qed.
 
 (* Morphism Category -------------------------------------------------------- *)
@@ -515,23 +391,14 @@ Lemma eh_cmp_id_left_strong :
 Proof.
   intros A R.
   intros t.
-  pupto2_init.
-  revert t.
-  pcofix CIH.
-  intros t.
-  rewrite unfold_interp. unfold interp_u. unfold handleF.
-  pfold. revert t. pcofix CIH'.
-  intros t.
+  pupto2_init; revert t; pcofix CIH; intros t.
+  pfold; pupto2_init; revert t; pcofix CIH'; intros.
+  rewrite unfold_interp. unfold interp_u.
   destruct (observe t); cbn; eauto.
-  - pfold. econstructor.
-    right. rewrite unfold_interp. unfold interp_u. unfold handleF.
-    apply CIH'.
-  - pfold. econstructor. cbn. econstructor. intros.
-    assert (ITree.bind' (fun x0 : u => interp eh_id R (k x0)) (Ret x) = (x0 <- Ret x ;; interp eh_id R (k x0))).
-    { intros; reflexivity. }
-    left.
-    rewrite H. rewrite ret_bind. (* TODO: [ret_bind] doesn't work *)
-    pupto2_final. right. apply CIH.
+  - pfold. econstructor. auto.
+  - unfold eh_id, ITree.liftE. rewrite vis_bind.
+    pfold; do 2 constructor.
+    left; rewrite ret_bind; auto.
 Qed.
 
 
@@ -550,11 +417,7 @@ Proof.
   unfold eh_cmp.
   unfold eh_id. unfold ITree.liftE.
   rewrite unfold_interp. unfold interp_u.
-  unfold handleF.
-  cbn. eapply transitivity. apply tau_eutt.
-  assert (pointwise_relation _ (eq_itree eq) (fun x : X => interp f X (Ret x)) (fun x => Ret x)).
-  { red. intros. apply interp_ret. }
-  rewrite H. rewrite bind_ret.
+  cbn. setoid_rewrite tau_eutt. setoid_rewrite interp_ret. rewrite bind_ret.
   reflexivity.
 Qed.
 
@@ -598,7 +461,9 @@ Lemma eh_swap_swap_id : forall A B, eh_cmp eh_swap eh_swap ≡ (eh_id : (A +' B)
 Proof.
   intros A B X e.
   unfold eh_cmp. unfold eh_swap. unfold eh_lift.
-  rewrite interp_liftE. rewrite tau_eutt. destruct e; simpl; reflexivity.
+  rewrite interp_liftE.
+  setoid_rewrite tau_eutt. rewrite bind_ret.
+  destruct e; simpl; reflexivity.
 Qed.                                                               
 
 Lemma eh_empty_unit_l : forall A, eh_cmp eh_empty_right eh_inl ≡ (eh_id : A ~> itree A).
@@ -609,7 +474,7 @@ Proof.
   unfold eh_inl.
   unfold eh_lift.
   rewrite interp_liftE.
-  rewrite tau_eutt.
+  setoid_rewrite tau_eutt. rewrite bind_ret.
   simpl. unfold Sum1.idE. reflexivity.
 Qed.
 
@@ -621,133 +486,6 @@ Proof.
   unfold eh_inr.
   unfold eh_lift.
   rewrite interp_liftE.
-  rewrite tau_eutt.
+  setoid_rewrite tau_eutt. rewrite bind_ret.
   simpl. unfold Sum1.idE. reflexivity.
-Qed.
-
-(***
- lemmas about [interp1].
- We can remove [interp1] but keep it just in case it is useful.
- ***)
-
-Definition interp1_u {E F G} `{F -< G} (h : E ~> itree G) R :
-  itreeF (E +' F) R _ -> itree G R :=
-  handleF (interp1 h _)
-          (fun _ ef k =>
-             match ef with
-             | inl1 e => Tau (ITree.bind (h _ e)
-                                         (fun x => interp1 h _ (k x)))
-             | inr1 f => Vis (subeffect _ f) (fun x => interp1 h _ (k x))
-             end).
-
-Lemma unfold_interp1 {E F G : Type -> Type} `{F -< G} (h : E ~> itree G) R (t : itree (E +' F) R) :
-  observing eq (interp1 h _ t) (interp1_u h _ (observe t)).
-Proof. econstructor. auto. Qed.
-
-Lemma unfold_interp1_ {E F G : Type -> Type} `{F -< G} (h : E ~> itree G) R (t : itree (E +' F) R) :
-  interp1 h _ t ≅ interp1_u h _ (observe t).
-Proof. rewrite itree_eta, unfold_interp1, <-itree_eta. reflexivity. Qed.
-
-(** ** [interp1] is equivalent to [interp] *)
-
-Section interp1_is_interp.
-
-Context {E F G : Type -> Type} `{F -< G} (f : E ~> itree G).
-  
-Definition interp_match : (E +' F) ~> itree G :=
-  fun _ ef => match ef with inl1 e => f _ e | inr1 e => Vis (subeffect _ e) (fun r => Ret r) end.
-
-Lemma interp_is_interp1 R (t: itree _ R) :
-  interp interp_match _ t ≈ interp1 f _ t.
-Proof.
-  pupto2_init. revert_until R. pcofix CIH. intros.
-  pfold. pupto2_init. revert_until CIH. pcofix CIH'. intros.
-
-  rewrite unfold_interp, unfold_interp1. unfold interp_u, interp1_u.
-  destruct (observe t); [| |destruct e]; simpl; eauto.
-  - pfold; econstructor. pupto2_final. eauto.
-  - pfold; econstructor. pupto2 eutt_nested_clo_bind.
-    econstructor; [reflexivity|].
-    intros. subst. eauto.
-  - rewrite vis_bind_. pfold. econstructor. econstructor.
-    left. rewrite ret_bind_. pupto2_final. eauto.
-Qed.
-
-End interp1_is_interp.
-
-Instance eq_itree_interp1 {E F G R} `{F -< G} (h : E ~> itree G) :
-  Proper (@eq_itree (E +' F) _ _ eq ==> eq_itree eq) (interp1 h R).
-Proof.
-  repeat intro. pupto2_init. revert_until R.
-  pcofix CIH. intros.
-  rewrite !unfold_interp1_.
-  punfold H1; red in H1.
-  destruct H1; pclearbot.
-  - pupto2_final. pfold. red. cbn. eauto.
-  - pupto2_final. pfold. red. cbn. eauto.
-  - pfold. destruct e; cbn; econstructor.
-    + pupto2 eq_itree_clo_bind.
-      econstructor.
-      * reflexivity.
-      * intros; subst. pupto2_final; eauto.
-    + intros. pupto2_final. eauto.
-Qed.
-
-Instance eutt_interp1 {E F G R} `{F -< G} (h: E ~> itree G):
-  Proper (eutt eq ==> eutt eq) (@interp1 E F G _ h R).
-Proof.
-  repeat intro. pupto2_init. revert_until H. pcofix CIH. intros.
-  pfold. pupto2_init. revert_until CIH. pcofix CIH'. intros.
-
-  rewrite !unfold_interp1. do 2 punfold H1. pfold.
-  induction H1; intros; subst; pclearbot; simpl; eauto.
-  - destruct e.
-    + econstructor. pupto2 eutt_nested_clo_bind.
-      econstructor; [reflexivity|].
-      intros; subst. pupto2_final.
-      right. eapply CIH'. edestruct EUTTK; pclearbot; eauto.
-    + econstructor. left. pupto2_final.
-      right. eapply CIH. edestruct EUTTK; pclearbot; eauto.
-  - econstructor. pupto2_final. eauto 7.
-Qed.
-
-Lemma interp1_bind {E F G} `{F -< G} {R S} (h : E ~> itree G) (t : _ R) (k : _ -> itree (E +' F) S) :
-  interp1 h _ (t >>= k) ≅ interp1 h _ t >>= fun x => interp1 h _ (k x).
-Proof.
-  pupto2_init.
-  revert t; pcofix self; intros.
-  rewrite !unfold_interp1_, unfold_bind, unfold_bind_.
-  destruct (observe t); cbn.
-  - rewrite unfold_interp1_.
-    pupto2_final. apply reflexivity.
-  - pfold; constructor; auto.
-  - destruct e; cbn.
-    + rewrite bind_bind. pfold; constructor.
-      pupto2 eq_itree_clo_bind. econstructor.
-      * reflexivity.
-      * intros; subst. eauto.
-    + pfold; constructor; auto.
-Qed.
-
-Lemma translate_interp1 {E F R} (h : F ~> itree E) :
-  forall (t : itree E R),
-    interp1 h _ (translate (fun _ e => inr1 e) t) ≅ t.
-Proof.
-  pcofix self; intros.
-  pfold; red.
-  rewrite unfold_interp1.
-  rewrite TranslateFacts.unfold_translate.
-  destruct (observe t); cbn; auto.
-Qed.
-
-Lemma interp1_liftE {E F G: Type -> Type} `{F -< G}:
-  forall (h: forall T: Type, E T -> itree G T) T (e : E T),
-    @interp1 E F G _ h T (lift e) ≈ h T e.
-Proof.
-  intros. unfold lift.
-  rewrite unfold_interp1_; cbn.
-  rewrite tau_eutt.
-  setoid_rewrite unfold_interp1_; cbn.
-  rewrite bind_ret.
-  reflexivity.
 Qed.


### PR DESCRIPTION
Several changes orthogonal to each other, so they can be split if required, but that's more work.

1. The main change is to use (an updated) `aloop` to implement all interpreters. Ideally the only `CoFixpoint` left with this are `bind` and `aloop`, though there are still some leftovers at the moment.

    1. As a consequence, outside of this little core, proofs do not rely on the reduction semantics of cofixpoints.

    2. It might be possible to reduce this further to a single cofixpoint.

    3. The benefits of this are certainly debatable. This mostly affects some internals of the library. From the outside, this changes little as long as all Cofixpoint come with associated unfolding lemmas (which just pushes the `cofix` deeper). And even within the library, in principle the change should only affect the proofs of these unfolding lemmas, which everything else should rely on. So I'm not sure whether reducing the number of cofixpoints inside the library is something to strive for.

2. Remove `interp1`. (Partly to reduce work, but there seems to be some agreement that it makes things more complicated than they need to be.)

3. Simplify proofs. In particular, I got rid of a lot of occurences of `itree_eta`. Most of the time you can use an unfolding lemma (this could also remove the need for all lemmas of the style `ret_bind`, `vis_bind`, `tau_bind`, but maybe they're still convenient to keep around in any case).