### PR TITLE
only works with paco 2.0.2

### DIFF
--- a/coq-itree.opam
+++ b/coq-itree.opam
@@ -16,7 +16,7 @@ remove: [ "rm" "-rf" "%{lib}%/coq/user-contrib/ITree" ]
 depends: [
   "coq" {>= "8.8" & < "8.10~"}
   "coq-ext-lib"
-  "coq-paco" {>= "2.0.2" & < "2.1"}
+  "coq-paco" {= "2.0.2"}
 ]
 
 authors: [

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -31,7 +31,7 @@ example-threads: Makefile.coq $(THREADSML)
 	ocamlbuild -I extracted runthread.native
 	./runthread.native
 
-clean: _CoqProject
-	$(MAKE) -f Makefile.coq clean
+clean:
+	if [ -e Makefile.coq ]; then $(MAKE) -f Makefile.coq clean; fi
 	ocamlbuild -clean
-	$(RM) -rf extracted
+	$(RM) -rf extracted Makefile.coq*


### PR DESCRIPTION
Paco 2.0.3 causes error:
```
#=== ERROR while compiling coq-itree.dev ======================================#
# context              2.0.2 | linux/x86_64 | ocaml-base-compiler.4.05.0 | https://coq.inria.fr/opam/extra-dev#2019-03-05 21:12
# path                 ~/.opam/4.05.0/.opam-switch/build/coq-itree.dev
# command              /usr/bin/make -j1
# exit-code            2
# env-file             ~/.opam/log/coq-itree-747-eec089.env
# output-file          ~/.opam/log/coq-itree-747-eec089.out
### output ###
# [...]
# COQC theories/Eq/Eq.v
# File "./theories/Eq/Eq.v", line 454, characters 16-22:
# Error: Ltac call to "pupto2" failed.
#        No applicable tactic.
# 
# Makefile.coq:656: recipe for target 'theories/Eq/Eq.vo' failed
# make[2]: *** [theories/Eq/Eq.vo] Error 1
# Makefile.coq:317: recipe for target 'all' failed
# make[1]: *** [all] Error 2
# make[1]: Leaving directory '/home/coq/.opam/4.05.0/.opam-switch/build/coq-itree.dev'
# Makefile:8: recipe for target 'coq' failed
# make: *** [coq] Error 2
```