### PR TITLE
make bind into notation

### DIFF
--- a/examples/Factorial.v
+++ b/examples/Factorial.v
@@ -1,3 +1,4 @@
+(* begin hide *)
 Set Implicit Arguments.
 Set Contextual Implicit.
 
@@ -19,6 +20,9 @@ From ITree Require Import
 
 Import MonadNotation.
 Open Scope monad_scope.
+(* end hide *)
+
+(** * Factorial Example *)
 
 (** This file gives and example of defining a recursive version of the "factorial" 
     function using ITrees. It demonstrates
@@ -88,8 +92,7 @@ Proof.
     reflexivity.
 Qed.
 
-
-(* HIDE *)
+(* begin hide *)
 (* SAZ: we might experiment with automating monadic rewriting according to the equational reasoning, 
    something like: *)
 Ltac simpl_monad :=
@@ -97,8 +100,7 @@ Ltac simpl_monad :=
            | [ |- context[Tau ?T] ] => progress rewrite tau_eutt
            | [ |- context[ITree.bind (Ret ?X) ?K] ] => progress rewrite ret_bind
            | [ |- context[interp_mrec _ _ (ITree.bind ?T ?K)] ] => progress rewrite interp_mrec_bind
-           | [ |- context[interp_mrec _ _ (Ret ?X)] ] => progress rewrite ret_mrec                                                                         
-           end.
+           | [ |- context[interp_mrec _ _ (Ret ?X)] ] => progress rewrite ret_mrec                                            end.
                      
 (* Then the proof above becomes: 
 
@@ -107,5 +109,5 @@ Ltac simpl_monad :=
     simpl_monad.
     reflexivity.
 *)
-(* /HIDE *)
+(* end hide *)
 

--- a/theories/Core/ITree.v
+++ b/theories/Core/ITree.v
@@ -161,16 +161,16 @@ End bind.
 
 Arguments _bind _ _ /.
 
-Definition bind {E T U} (c : itree E T) (k : T -> itree E U)
-  : itree E U
-  := bind' k c.
+
+Notation bind c k := (bind' k c).
+
 
 (** Monadic composition of continuations (i.e., Kleisli composition).
  *)
 Definition cat {E T U V}
            (k : T -> itree E U) (h : U -> itree E V) :
   T -> itree E V :=
-  fun t => bind (k t) h.
+  fun t => bind' h (k t).
 
 (** [aloop]: A primitive for general recursion.
     Iterate a function updating an accumulator [A], until it produces
@@ -267,7 +267,7 @@ Instance Applicative_itree {E} : Applicative (itree E) :=
 
 Global Instance Monad_itree {E} : Monad (itree E) :=
 {| ret := fun _ x => Ret x
-;  bind := @ITree.bind E
+;  bind := fun T U t k => @ITree.bind' E T U k t
 |}.
 
 (** ** Tactics *)

--- a/theories/Core/KTreeFacts.v
+++ b/theories/Core/KTreeFacts.v
@@ -766,10 +766,10 @@ Proof.
   apply eutt_loop; [intros [] | reflexivity].
   all: unfold bimap, Bimap_Coproduct, case_, Case_ktree,
        cat, Cat_ktree, ITree.cat, id_, Id_ktree; cbn.
-  - apply eutt_bind; [reflexivity | intros []; simpl].
+  - apply eutt_bind; [intros []; simpl | reflexivity ].
     rewrite ret_bind_; reflexivity.
     reflexivity.
-  - apply eutt_bind; [reflexivity | intros []; simpl].
+  - apply eutt_bind; [intros []; simpl | reflexivity].
     rewrite ret_bind_; reflexivity.
     reflexivity.
 Qed.
@@ -805,8 +805,8 @@ Proof.
   apply eutt_loop; [intros [] | reflexivity].
   all: repeat rewrite bind_bind.
   2: repeat rewrite ret_bind_; reflexivity.
-  apply eutt_bind; [reflexivity | intros ?].
-  apply eutt_bind; [| intros ?; reflexivity].
+  apply eutt_bind; [intros ? | reflexivity ].
+  apply eutt_bind; [intros ?; reflexivity| ].
   apply tau_eutt.
 Qed.
 
@@ -821,8 +821,8 @@ Proof.
   rewrite bind_bind.
   rewrite ret_bind_.
   apply eutt_bind.
-  - reflexivity.
   - intros [[] | ]. reflexivity.
+  - reflexivity.
 Qed.
 
 (* [loop_loop]:
@@ -873,7 +873,7 @@ Proof.
   intros; reflexivity.
 Qed.
 
-Local Opaque ITree.bind.
+Local Opaque ITree.bind'.
 Local Opaque eutt.
 
 Lemma assoc_l_ktree {A B C} :
@@ -910,7 +910,7 @@ Proof.
     unfold loop_once; cbn.
     rewrite map_bind.
     rewrite bind_bind.
-    apply eutt_bind; [ reflexivity | ].
+    apply eutt_bind; [ | reflexivity ].
     intros d.
     rewrite ret_bind; cbn.
     reflexivity.

--- a/theories/Eq/Eq.v
+++ b/theories/Eq/Eq.v
@@ -411,9 +411,9 @@ Proof.
 Qed.
 
 Instance eq_itree_eq_bind {E R S} :
-  Proper (eq_itree eq ==>
-          pointwise_relation _ (eq_itree eq) ==>
-          eq_itree eq) (@ITree.bind E R S).
+  Proper (pointwise_relation _ (eq_itree eq) ==>
+          eq_itree eq ==>
+          eq_itree eq) (@ITree.bind' E R S).
 Proof.
   repeat intro; eapply eq_itree_bind; eauto.
   intros; subst; auto.

--- a/theories/Eq/Shallow.v
+++ b/theories/Eq/Shallow.v
@@ -77,10 +77,10 @@ Lemma unfold_bind {E R S}
 Proof. eauto. Qed.
 
 Instance observing_bind {E R S} :
-  Proper (observing eq ==> eq ==> observing eq) (@ITree.bind E R S).
+  Proper (eq ==> observing eq ==> observing eq) (@ITree.bind' E R S).
 Proof.
   repeat intro; subst.
-  do 2 rewrite unfold_bind; rewrite H.
+  do 2 rewrite unfold_bind; rewrite H0.
   reflexivity.
 Qed.
 

--- a/theories/Eq/UpToTaus.v
+++ b/theories/Eq/UpToTaus.v
@@ -416,13 +416,13 @@ Arguments eutt_clo_bind : clear implicits.
 Hint Constructors eutt_bind_clo.
 
 Global Instance eutt_bind {E U R} :
-  Proper (eutt eq ==>
-          pointwise_relation _ (eutt eq) ==>
-          eutt eq) (@ITree.bind E U R).
+  Proper (pointwise_relation _ (eutt eq) ==>
+          eutt eq ==>
+          eutt eq) (@ITree.bind' E U R).
 Proof.
   repeat intro.
   pupto2_init. pupto2 eutt_clo_bind. econstructor; eauto.
-  intros. subst. pupto2_final. apply H0.
+  intros. subst. pupto2_final. apply H.
 Qed.
 
 Section EUTT_nested.
@@ -664,11 +664,7 @@ Proof.
   pfold. pupto2_init. revert_until CIH. pcofix CIH'. intros.
   rewrite !unfold_aloop'. unfold ITree._aloop.
   destruct (f x) as [t | b]; cbn.
-  - match goal with
-    | [ |- context [ITree.bind' ?k ?t] ] =>
-      replace (ITree.bind' k t) with (ITree.bind t k); [ | reflexivity ]
-    end.
-    unfold id. rewrite 2 bind_bind.
+  - unfold id. rewrite 2 bind_bind.
     pfold; constructor.
     pupto2 eutt_nested_clo_bind. econstructor.
     { reflexivity. }

--- a/theories/Eq/UpToTausExplicit.v
+++ b/theories/Eq/UpToTausExplicit.v
@@ -426,10 +426,10 @@ Inductive euttE_bind_clo {E R1 R2} (r: itree E R1 -> itree E R2 -> Prop) : itree
 Hint Constructors euttE_bind_clo.
 
 Lemma bind_clo_finite_taus {E U1 U2 RU R1 R2}  t1 t2 k1 k2
-    (FT: finite_taus (@ITree.bind E U1 R1 t1 k1))
+    (FT: finite_taus (@ITree.bind' E U1 R1 k1 t1))
     (FTk: forall v1 v2 (RELv: RU v1 v2 : Prop), finite_taus (k1 v1) -> finite_taus (k2 v2))
     (EQV: euttE RU t1 t2):
-  finite_taus (@ITree.bind E U2 R2 t2 k2).
+  finite_taus (@ITree.bind' E U2 R2 k2 t2).
 Proof.
   punfold EQV. destruct EQV as [[FTt _] EQV].
   assert (FT1 := FT). apply finite_taus_bind_fst in FT1.

--- a/theories/Simple.v
+++ b/theories/Simple.v
@@ -150,8 +150,8 @@ Declare Instance eutt_VisF {E R X} (e: E X) :
   Proper (pointwise_relation _ (@eutt E R) ==> going eutt) (VisF e).
 
 Declare Instance eutt_bind {E R S} :
-  Proper (eutt ==> pointwise_relation _ eutt ==> eutt)
-         (@ITree.bind E R S).
+  Proper (pointwise_relation _ eutt ==> eutt ==> eutt)
+         (@ITree.bind' E R S).
 
 Declare Instance eutt_map {E R S} :
   Proper (pointwise_relation _ eq ==> eutt ==> eutt)

--- a/tutorial/AsmCombinators.v
+++ b/tutorial/AsmCombinators.v
@@ -145,12 +145,14 @@ Proof.
   induction b as [i b | br]; intros f.
   - simpl.
     unfold ITree.map; rewrite bind_bind.
-    eapply eq_itree_eq_bind; [reflexivity | intros []; apply IHb].
+    eapply eq_itree_eq_bind; try reflexivity.
+    intros []; apply IHb.
   - simpl.
     destruct br; simpl.
     + unfold ITree.map; rewrite ret_bind; reflexivity.
     + unfold ITree.map; rewrite bind_bind. 
-      eapply eq_itree_eq_bind; [reflexivity | intros ?].
+      eapply eq_itree_eq_bind; try reflexivity.
+      intros ?.
       flatten_goal; rewrite ret_bind; reflexivity.
     + rewrite (itree_eta (ITree.map _ _)).
       cbn. apply eq_itree_Vis. intros [].
@@ -174,7 +176,8 @@ Proof.
   induction instrs as [| i instrs IH]; intros b.
   - simpl; rewrite ret_bind; reflexivity.
   - simpl; rewrite bind_bind.
-    eapply eq_itree_eq_bind; [reflexivity | intros []; apply IH].
+    eapply eq_itree_eq_bind; try reflexivity.
+    intros []; apply IH.
 Qed.
 
 Lemma denote_list_app:

--- a/tutorial/Imp2AsmCorrectness.v
+++ b/tutorial/Imp2AsmCorrectness.v
@@ -452,8 +452,8 @@ Section Correctness.
     rewrite after_correct.
     simpl.
     repeat setoid_rewrite bind_bind.
-    apply eutt_bind; [reflexivity | intros ?].
-    apply eutt_bind; [reflexivity | intros []].
+    apply eutt_bind; try reflexivity. intros [].
+    apply eutt_bind; try reflexivity. intros [].
     - rewrite ret_bind_.
       rewrite (relabel_asm_correct _ _ _ (inr tt)).
       unfold CategoryOps.cat, Cat_ktree, ITree.cat; simpl.
@@ -462,7 +462,7 @@ Section Correctness.
       setoid_rewrite (app_asm_correct tp fp (inr tt)).
       setoid_rewrite bind_bind.
       rewrite <- (bind_ret (denote_asm fp tt)) at 2.
-      eapply eutt_bind; [ reflexivity | intros ? ].
+      eapply eutt_bind; try reflexivity. intros ?.
       unfold inr_, Inr_ktree, lift_ktree; rewrite ret_bind_; reflexivity.
     - rewrite ret_bind_.
       rewrite (relabel_asm_correct _ _ _ (inl tt)).
@@ -472,7 +472,7 @@ Section Correctness.
       setoid_rewrite (app_asm_correct tp fp (inl tt)).
       setoid_rewrite bind_bind.
       rewrite <- (bind_ret (denote_asm tp tt)) at 2.
-      eapply eutt_bind; [reflexivity | intros ?].
+      eapply eutt_bind; try reflexivity. intros ?.
       unfold inl_, Inl_ktree, lift_ktree;
         rewrite ret_bind_; reflexivity.
   Qed.
@@ -507,9 +507,9 @@ Section Correctness.
     - unfold ITree.cat. 
       simpl; setoid_rewrite bind_bind.
       rewrite bind_bind.
-      apply eutt_bind; [reflexivity | intros []].
+      apply eutt_bind; try reflexivity. intros [].
       rewrite bind_bind.
-      apply eutt_bind; [reflexivity | intros []].
+      apply eutt_bind; try reflexivity. intros [].
       + rewrite (pure_asm_correct _ tt).
         unfold inl_, Inl_ktree, lift_ktree.
         repeat rewrite ret_bind_.
@@ -518,7 +518,7 @@ Section Correctness.
         unfold CategoryOps.cat, Cat_ktree, ITree.cat.
         simpl; repeat setoid_rewrite bind_bind.
         unfold inl_, Inl_ktree, lift_ktree; rewrite ret_bind_.
-        apply eutt_bind; [reflexivity | intros []].
+        apply eutt_bind; try reflexivity. intros [].
         repeat rewrite ret_bind_; reflexivity.
     - rewrite itree_eta; cbn; reflexivity.
   Qed.
@@ -540,7 +540,8 @@ Section Correctness.
     end;
       [intros [[]|[]]; simpl |]; try reflexivity.
     unfold ITree.map.
-    apply eutt_bind; [reflexivity | intros []; reflexivity].
+    apply eutt_bind; try reflexivity.
+    intros []; reflexivity.
   Qed.
 
   Definition env_lookupDefault_is_lift {K V : Type} {E: Type -> Type} `{envE K V -< E} (x: K) (v: V):


### PR DESCRIPTION
Remove the definition of `bind` from ITree.v and replace it with notation.  This simplifies certain rewriting proofs since there's no longer a distinction between `bind` and `bind'`.