### PR TITLE
Rename 'lift' to 'send'

### DIFF
--- a/examples/Introduction.v
+++ b/examples/Introduction.v
@@ -54,13 +54,13 @@ Inductive ioE : Type -> Type :=
   (** Send a list of [nat]. *)
 .
 
-(** Effects are wrapped as ITrees using [ITree.lift], and
+(** Effects are wrapped as ITrees using [ITree.send], and
     composed using monadic operations [bind] and [ret]. *)
 
 (** Read some input, and echo it back, appending [1] to it. *)
 Definition write_one : itree ioE unit :=
-  xs <- ITree.lift Input;;
-  ITree.lift (Output (xs ++ [1])).
+  xs <- ITree.send Input;;
+  ITree.send (Output (xs ++ [1])).
 
 (** We can _interpret_ interaction trees by giving semantics
     to their effects individually, as a _handler_: a function
@@ -96,7 +96,7 @@ Definition interp_io
 Definition interpreted_write_one : itree void1 (list nat * unit)
   := interp_io _ write_one.
 
-(** Intuitively, [interp_io] replaces every [ITree.lift] in the
+(** Intuitively, [interp_io] replaces every [ITree.send] in the
     definition of [write_one] with [handle_io]:
 [[
   interpreted_write_one =
@@ -119,8 +119,8 @@ Proof.
   (* Use lemmas from [ITree.Simple] ([theories/Simple.v]). *)
   (* ADMITTED *)
   rewrite interp_bind.
-  rewrite interp_lift.
-  setoid_rewrite interp_lift.
+  rewrite interp_send.
+  setoid_rewrite interp_send.
   reflexivity.
 Qed. (* /ADMITTED *)
 

--- a/examples/MultiThreadedPrinting.v
+++ b/examples/MultiThreadedPrinting.v
@@ -16,7 +16,7 @@ Variant printE : Type -> Type :=
 
 (* A thread that loops, printing [s] forever. *)
 Definition thread {E} `{printE -< E} (s:string) : itree E unit :=
-  ITree.forever (lift (Print s)).
+  ITree.forever (send (Print s)).
 
 (* Run three threads. *)
 Definition main_thread : itree (spawnE printE +' printE) unit :=

--- a/examples/Nimp.v
+++ b/examples/Nimp.v
@@ -117,7 +117,7 @@ Definition or {R : Type} (t1 t2 : itree nd R) : itree nd R :=
   Vis Or (fun b : bool => if b then t1 else t2).
 
 (* Flip a coin *)
-Definition choice {E} `{nd -< E} : itree E bool := lift Or.
+Definition choice {E} `{nd -< E} : itree E bool := send Or.
 
 Definition eval_def := (fun (c : com) =>
     match c with
@@ -125,13 +125,13 @@ Definition eval_def := (fun (c : com) =>
       (b <- choice;;
       if b : bool
       then Ret tt
-      else (lift (Call c);; lift (Call (loop c))))%itree
+      else (send (Call c);; send (Call (loop c))))%itree
     | choose c1 c2 =>
       (b <- choice;;
       if b : bool
-      then lift (Call c1)
-      else lift (Call c2))%itree
-    | (t1 ;; t2)%com => (lift (Call t1);; lift (Call t2))%itree
+      then send (Call c1)
+      else send (Call c2))%itree
+    | (t1 ;; t2)%com => (send (Call t1);; send (Call t2))%itree
     | skip => Ret tt
     end
   ).
@@ -145,7 +145,7 @@ Definition one_loop_tree : itree nd unit :=
     if b : bool then
       Ret tt
     else
-      lift (Call tt))%itree tt.
+      send (Call tt))%itree tt.
 
 Import Coq.Classes.Morphisms.
 
@@ -164,7 +164,7 @@ Proof.
   left. rewrite !bind_ret, !interp_ret, !bind_ret.
   destruct x.
   - rewrite !interp_ret. apply reflexivity.
-  - rewrite !lift_is_vis_ret, interp_bind.
+  - rewrite !send_is_vis_ret, interp_bind.
     setoid_rewrite interp_recursive_call.
     rewrite eval_skip. rewrite bind_tau, bind_ret.
     rewrite !tau_eutt. eauto with paco.

--- a/examples/stlc.v
+++ b/examples/stlc.v
@@ -62,12 +62,12 @@ Definition big_step : term -> itree void1 value :=
     match t with
     | Var n => ret (VHead (VVar n))
     | App t1 t2 =>
-      t2' <- lift (Call t2);;
-      t1' <- lift (Call t1);;
+      t2' <- send (Call t2);;
+      t1' <- send (Call t1);;
       match t1' with
       | VHead hv => ret (VHead (VApp hv t2'))
       | VLam t1'' =>
-        lift (Call (subst O (to_term t2') t1''))
+        send (Call (subst O (to_term t2') t1''))
       end
     | Lam t => ret (VLam t)
     end).

--- a/experiments/MoreEffects.v
+++ b/experiments/MoreEffects.v
@@ -21,7 +21,7 @@ Section Tagged.
   {| unTag := e |}.
 
   Definition eval_tagged {tag} : eff_hom (Tagged tag) E :=
-    fun _ e => lift e.(unTag).
+    fun _ e => send e.(unTag).
 
 End Tagged.
 
@@ -41,7 +41,7 @@ Section Counter.
   | Incr : counterE N N.
 
   Definition incr {N E} `{counterE N -< E} : itree E N :=
-    lift Incr.
+    send Incr.
 
   Definition eval_counter {N E} `{Countable N}
   : eff_hom_s N (counterE N) E :=

--- a/experiments/Reasoning.v
+++ b/experiments/Reasoning.v
@@ -58,7 +58,7 @@ End State.
   Arguments Put {S} _.
 
   Global Instance MS_itree {E S} : MonadState S (itree (stateE S +' E)) :=
-    Build_MonadState S _ (ITree.lift (inl1 Get)) (fun s => ITree.lift (inl1 (Put s))).
+    Build_MonadState S _ (ITree.send (inl1 Get)) (fun s => ITree.send (inl1 (Put s))).
 
   Definition eval_state' {E S} : stateE S ~> Monads.stateT S (itree E) :=
     fun _ e =>
@@ -99,7 +99,7 @@ Lemma interp1_state_get : forall {E:Type -> Type} S s,
 Proof.
   intros E S s.
   unfold get. unfold MS_itree. 
-  rewrite interp1_state_lift1.
+  rewrite interp1_state_send1.
   simpl.
   reflexivity.
 Qed.
@@ -109,7 +109,7 @@ Lemma interp1_state_put : forall {E :Type -> Type} S s s',
 Proof.
   intros E S s s'.
   unfold put. unfold MS_itree.
-  rewrite interp1_state_lift1.
+  rewrite interp1_state_send1.
   simpl.
   reflexivity.
 Qed.
@@ -118,20 +118,20 @@ Lemma interp1_state_E : forall {E F:Type -> Type} S (s:S) (f : E ~> Monads.state
     interp1_state f X (embed e) s ≅ (Vis e (fun x => ret (s, x))).
 Proof.
   intros E F S s f X e.
-  unfold embed. unfold Embeddable_itree. unfold lift. simpl.
-  rewrite interp1_state_lift2.
+  unfold embed. unfold Embeddable_itree. unfold send. simpl.
+  rewrite interp1_state_send2.
   reflexivity.
 Qed.  
 
 
 Lemma run_state_E_right : forall {E} S (s:S) (R T:Type) (e:E R) (k : R -> itree (stateE S +' E) T),
-    run_state (x <- (ITree.lift (inr1 e)) ;; k x) s ≅ (x <- (ITree.lift e) ;; run_state (k x) s).
+    run_state (x <- (ITree.send (inr1 e)) ;; k x) s ≅ (x <- (ITree.send e) ;; run_state (k x) s).
 Proof.
   intros E S s R T e k. 
   unfold run_state.
-  rewrite interp1_state_bind. cbn. rewrite interp1_state_lift2.
+  rewrite interp1_state_bind. cbn. rewrite interp1_state_send2.
   cbn.
-  rewrite bind_vis. unfold ITree.lift. rewrite bind_vis.
+  rewrite bind_vis. unfold ITree.send. rewrite bind_vis.
   apply itree_eq_vis.
   intros.
   rewrite !bind_ret. cbn. reflexivity.
@@ -139,7 +139,7 @@ Qed.
 
 
 Lemma run_state_E0_right : forall {E:Type -> Type} S (s:S) (T:Type) (e:E unit) (k : itree (stateE S +' E) T),
-    run_state ((ITree.lift (inr1 e)) ;; k) s ≅ ((ITree.lift e) ;; run_state k s).
+    run_state ((ITree.send (inr1 e)) ;; k) s ≅ ((ITree.send e) ;; run_state k s).
 Proof.
   intros E S s T e k.
   apply run_state_E_right.
@@ -248,8 +248,8 @@ Definition state2E := ((stateE S1) +' ((stateE S2) +' E)).
 
 Definition get1 : itree state2E S1 := get.
 Definition put1 (s:S1) : itree state2E unit := (put s).
-Definition get2 : itree state2E S2 := ITree.lift (inr1 (inl1 Get)).
-Definition put2 (s:S2) : itree state2E unit := ITree.lift (inr1 (inl1 (Put s))).
+Definition get2 : itree state2E S2 := ITree.send (inr1 (inl1 Get)).
+Definition put2 (s:S2) : itree state2E unit := ITree.send (inr1 (inl1 (Put s))).
 
 End TwoStates.
 
@@ -275,7 +275,7 @@ Proof.
   unfold runboth.
   unfold put2.
   rewrite run_state_E0_right.
-  replace (ITree.lift (inl1 (Put s2'))) with (put s2') by reflexivity.
+  replace (ITree.send (inl1 (Put s2'))) with (put s2') by reflexivity.
   rewrite run_state_put. reflexivity.
 Qed.
 
@@ -297,7 +297,7 @@ Proof.
   unfold runboth.
   unfold get2.
   rewrite run_state_E_right.
-  replace (ITree.lift (inl1 Get)) with (get (T:=S2)) by reflexivity.
+  replace (ITree.send (inl1 Get)) with (get (T:=S2)) by reflexivity.
   rewrite run_state_get.
   reflexivity.
 Qed.

--- a/theories/Core/ITree.v
+++ b/theories/Core/ITree.v
@@ -84,7 +84,7 @@ Definition observe {E R} (t : itree E R) : itree' E R := @_observe E R t.
 
     Using this notation means that we occasionally have to eta expand, e.g.
     writing [Vis e (fun x => Ret x)] instead of [Vis e Ret]. (In this
-    particular case, this is [ITree.lift].)
+    particular case, this is [ITree.send].)
 *)
 Notation Ret x := (go (RetF x)).
 Notation Tau t := (go (TauF t)).
@@ -200,7 +200,7 @@ Definition map {E R S} (f : R -> S)  (t : itree E R) : itree E S :=
   bind t (fun x => Ret (f x)).
 
 (** Atomic itrees performing a single effect. *)
-Definition lift {E : Type -> Type} : E ~> itree E :=
+Definition send {E : Type -> Type} : E ~> itree E :=
   fun R e => Vis e (fun x => Ret x).
 
 (** Ignore the result of a tree. *)

--- a/theories/Effects/Concurrency.v
+++ b/theories/Effects/Concurrency.v
@@ -19,7 +19,7 @@ Inductive spawnE E : Type -> Type :=
 | Spawn : forall (t: itree (spawnE E +' E) unit), spawnE E unit.
 
 Definition spawn {F E} `{(spawnE F) -< E} (t:itree (spawnE F +' F) unit) : itree E unit :=
-    lift (Spawn t).
+    send (Spawn t).
 
 (* A simple round-robin scheduler:
 

--- a/theories/Effects/Dependent.v
+++ b/theories/Effects/Dependent.v
@@ -27,7 +27,7 @@ Variant depE {I : Type} (F : I -> Type) : Type -> Type :=
 Arguments Dep {I F}.
 
 Definition dep {I F E} `{depE F -< E} (i : I) : itree E (F i) :=
-  lift (Dep i).
+  send (Dep i).
 
 Definition undep {I F} (f : forall i : I, F i) :
   depE F ~> identity :=

--- a/theories/Effects/Reader.v
+++ b/theories/Effects/Reader.v
@@ -29,7 +29,7 @@ Variant readerE : Type -> Type :=
 | Ask : readerE Env.
 
 Definition ask {E} `{readerE -< E} : itree E Env :=
-  lift Ask.
+  send Ask.
 
 Definition eval_reader {E} : Env -> Handler readerE E :=
   fun r _ e =>

--- a/theories/Effects/StateFacts.v
+++ b/theories/Effects/StateFacts.v
@@ -98,12 +98,12 @@ Proof.
   rewrite unfold_interp_state; reflexivity.
 Qed.
 
-Lemma interp_state_lift {E F : Type -> Type} {R S : Type}
+Lemma interp_state_send {E F : Type -> Type} {R S : Type}
       (f : E ~> Monads.stateT S (itree F))
       (s : S) (e : E R) :
-  (interp_state f _ (ITree.lift e) s) ≅ Tau (f _ e s >>= fun i => Ret i).
+  (interp_state f _ (ITree.send e) s) ≅ Tau (f _ e s >>= fun i => Ret i).
 Proof.
-  unfold ITree.lift. rewrite interp_state_vis.
+  unfold ITree.send. rewrite interp_state_vis.
   apply eq_itree_Tau.
   eapply eq_itree_bind.
   - reflexivity.

--- a/theories/Effects/Writer.v
+++ b/theories/Effects/Writer.v
@@ -34,7 +34,7 @@ Variant writerE (W : Type) : Type -> Type :=
 
 (** Output action. *)
 Definition tell {W E} `{writerE W -< E} : W -> itree E unit :=
-  fun w => lift (Tell w).
+  fun w => send (Tell w).
 
 (** One interpretation is to accumulate outputs in a list. *)
 

--- a/theories/Indexed/OpenSum.v
+++ b/theories/Indexed/OpenSum.v
@@ -95,13 +95,13 @@ Local Open Scope sum_scope.
 Notation vis e k := (Vis (subeffect _ e) k).
 
 (* Called [send] in Haskell freer. *)
-Definition lift {E F} `{E -< F} : E ~> itree F :=
-  fun T e => ITree.lift (subeffect _ e).
+Definition send {E F} `{E -< F} : E ~> itree F :=
+  fun T e => ITree.send (subeffect _ e).
 
-Arguments lift {E F _ T}.
+Arguments send {E F _ T}.
 
-Lemma lift_is_vis_ret {E F R} `{E -< F} (e : E R) :
-  lift e = vis e (fun r => Ret r).
+Lemma send_is_vis_ret {E F R} `{E -< F} (e : E R) :
+  send e = vis e (fun r => Ret r).
 Proof. reflexivity. Qed.
 
 (* Embedding effects into trees.
@@ -124,4 +124,4 @@ Instance Embeddable_forall {A : Type} {U : A -> Type} {V : A -> Type}
 Instance Embeddable_itree {E F : Type -> Type} {R : Type}
          `(E -< F) :
   Embeddable (E R) (itree F R) :=
-  lift.
+  send.

--- a/theories/Interp/Handler.v
+++ b/theories/Interp/Handler.v
@@ -28,12 +28,12 @@ Open Scope itree_scope.
 Module Handler.
 
 (** Lift an _effect morphism_ into an _effect handler_. *)
-Definition hlift {A B} (m : A ~> B) : A ~> itree B :=
-  fun _ e => ITree.lift (m _ e).
+Definition hsend {A B} (m : A ~> B) : A ~> itree B :=
+  fun _ e => ITree.send (m _ e).
 
 (** This handler just wraps effects back into itrees, which is
     a noop (modulo taus): [interp (id_ E) _ t ≈ t]. *)
-Definition id_ (E : Type -> Type) : E ~> itree E := ITree.lift.
+Definition id_ (E : Type -> Type) : E ~> itree E := ITree.send.
 
 (** Chain handlers: [g] handles the effects produced by [f]. *)
 Definition cat {E F G : Type -> Type}
@@ -43,11 +43,11 @@ Definition cat {E F G : Type -> Type}
 
 (** Wrap effects to the left of a sum. *)
 Definition inl_ {E F : Type -> Type} : E ~> itree (E +' F)
-  := hlift inl1.
+  := hsend inl1.
 
 (** Wrap effects to the right of a sum. *)
 Definition inr_ {E F : Type -> Type} : F ~> itree (E +' F)
-  := hlift inr1.
+  := hsend inr1.
 
 (** Case analysis on sums of effects. *)
 Definition case_ {E F G : Type -> Type}

--- a/theories/Interp/HandlerFacts.v
+++ b/theories/Interp/HandlerFacts.v
@@ -31,7 +31,7 @@ Proof.
   revert t. ucofix CIH. red. ucofix CIH'. intros.
   rewrite unfold_interp. unfold _interp. repeat red.
   destruct (observe t); cbn; eauto 8 with paco.
-  unfold id_, Id_Handler, Handler.id_, ITree.lift. eutt0_fold. rewrite bind_vis_.
+  unfold id_, Id_Handler, Handler.id_, ITree.send. eutt0_fold. rewrite bind_vis_.
   do 2 constructor.
   left; rewrite bind_ret; auto with paco.
 Qed.
@@ -46,7 +46,7 @@ Instance CatIdL_Handler : CatIdL Handler.
 Proof.
   red; intros A B f X e.
   unfold cat, Cat_Handler, Handler.cat, id_, Id_Handler, Handler.id_.
-  rewrite interp_lift, tau_eutt.
+  rewrite interp_send, tau_eutt.
   reflexivity.
 Qed.
 

--- a/theories/Interp/Interp.v
+++ b/theories/Interp/Interp.v
@@ -9,7 +9,7 @@
     conceptually at a different level: translation always yields strong
     bisimulations.  We can relate translation and interpretation via the law:
 
-    translate h t ≈ interp (lift ∘ h) t
+    translate h t ≈ interp (send ∘ h) t
 *)
 
 (** The semantics of an interaction tree [itree E ~> M] can be

--- a/theories/Interp/MFixITree.v
+++ b/theories/Interp/MFixITree.v
@@ -188,9 +188,9 @@ Section EX2.
   Hint Resolve monotone_body.
 
 
-  Definition undef := ITree.lift Undef.
-  Definition store x := ITree.lift (Store x).
-  Definition load := ITree.lift Load.
+  Definition undef := ITree.send Undef.
+  Definition store x := ITree.send (Store x).
+  Definition load := ITree.send Load.
 
   Definition prog1 : itree SIO nat  :=
     x <- undef ;;

--- a/theories/Interp/MorphismsFacts.v
+++ b/theories/Interp/MorphismsFacts.v
@@ -151,12 +151,12 @@ Proof.
     + intros; subst. auto with paco.
 Qed.
 
-Lemma interp_lift {E F : Type -> Type} {R : Type}
+Lemma interp_send {E F : Type -> Type} {R : Type}
       (f : E ~> (itree F))
       (e : E R) :
-  interp f _ (ITree.lift e) ≅ Tau (f _ e).
+  interp f _ (ITree.send e) ≅ Tau (f _ e).
 Proof.
-  unfold ITree.lift. rewrite interp_vis.
+  unfold ITree.send. rewrite interp_vis.
   apply eq_itree_Tau.
   setoid_rewrite interp_ret.
   rewrite bind_ret2.
@@ -166,13 +166,13 @@ Qed.
 
 (** ** Composition of [interp] *)
 
-Lemma interp_id_lift {E R} (t : itree E R) :
-  interp (fun _ e => ITree.lift e) _ t ≈ t.
+Lemma interp_id_send {E R} (t : itree E R) :
+  interp (fun _ e => ITree.send e) _ t ≈ t.
 Proof.
   revert t. ucofix CIH. red. ucofix CIH'. intros.
   rewrite unfold_interp. repeat red.
   destruct (observe t); cbn; eauto with paco.
-  unfold ITree.lift. constructor. rewrite bind_vis.
+  unfold ITree.send. constructor. rewrite bind_vis.
   constructor.
   left. rewrite bind_ret.
   auto with paco.
@@ -218,19 +218,19 @@ Proof.
 Qed.
 
 Lemma translate_to_interp {E F R} (f : E ~> F) (t : itree E R) :
-  translate f t ≈ interp (fun _ e => ITree.lift (f _ e)) _ t.
+  translate f t ≈ interp (fun _ e => ITree.send (f _ e)) _ t.
 Proof.
   revert t. ucofix CIH. red. ucofix CIH'. intros.
   rewrite unfold_translate.
   rewrite unfold_interp.
   unfold translateF, _interp. repeat red.
   destruct (observe t); cbn; simpl in *; eauto 7 with paco.
-  unfold ITree.lift. econstructor. rewrite bind_vis.
+  unfold ITree.send. econstructor. rewrite bind_vis.
   do 2 constructor.
   rewrite bind_ret. auto with paco.
 Qed.
 
 Hint Rewrite @interp_ret : itree.
 Hint Rewrite @interp_vis : itree.
-Hint Rewrite @interp_lift : itree.
+Hint Rewrite @interp_send : itree.
 Hint Rewrite @interp_bind : itree.

--- a/theories/Interp/Recursion.v
+++ b/theories/Interp/Recursion.v
@@ -42,11 +42,11 @@ Open Scope itree_scope.
      match d with
      | Even n => match n with
                  | O => ret true
-                 | S m => lift (Odd m)
+                 | S m => send (Odd m)
                  end
      | Odd n => match n with
                 | O => ret false
-                | S m => lift (Even m)
+                | S m => send (Even m)
                 end
      end.
 ]]
@@ -87,8 +87,8 @@ Definition mrec {D E : Type -> Type}
   fun R d => interp_mrec ctx _ (ctx _ d).
 
 (** Make a recursive call in the handler argument of [mrec]. *)
-Definition lift_inl1 {D E : Type -> Type} : D ~> itree (D +' E)
-  := fun _ d => ITree.lift (inl1 d).
+Definition send_inl1 {D E : Type -> Type} : D ~> itree (D +' E)
+  := fun _ d => ITree.send (inl1 d).
 
 (** Here's some syntactic sugar with a notation [mrec-fix]. *)
 
@@ -98,7 +98,7 @@ Local Notation endo T := (T -> T).
 Definition mrec_fix {D E : Type -> Type} {A B : Type}
            (ctx : endo (D ~> itree (D +' E)))
   : D ~> itree E
-  := mrec (ctx lift_inl1).
+  := mrec (ctx send_inl1).
 
 Notation "'mrec-fix' f d := g" := (mrec_fix (fun f _ d => g))
   (at level 200, f ident, d pattern).
@@ -146,7 +146,7 @@ Definition rec {E : Type -> Type} {A B : Type}
     function might have other effects of type [E], the resulting itree has
     type [(callE A B +' E)].
 *)
-Definition call {E A B} (a:A) : itree (callE A B +' E) B := ITree.lift (inl1 (Call a)).
+Definition call {E A B} (a:A) : itree (callE A B +' E) B := ITree.send (inl1 (Call a)).
 
 (** Here's some syntactic sugar with a notation [mrec-fix]. *)
 

--- a/theories/Interp/RecursionFacts.v
+++ b/theories/Interp/RecursionFacts.v
@@ -116,7 +116,7 @@ Qed.
     where [mrecursive] is defined as follows. *)
 Definition mrecursive (f : D ~> itree (D +' E))
   : (D +' E) ~> itree E :=
-  case_ (mrec f) ITree.lift.
+  case_ (mrec f) ITree.send.
 
 Theorem interp_mrec_as_interp {T} (c : itree _ T) :
   interp_mrec ctx _ c ≅ interp (mrecursive ctx) _ c.
@@ -131,7 +131,7 @@ Proof.
     uclo eq_itree_clo_bind; econstructor; [reflexivity|].
     intros ? _ []; eauto with paco.
 
-  - unfold ITree.lift, case_; simpl. rewrite bind_vis_.
+  - unfold ITree.send, case_; simpl. rewrite bind_vis_.
     constructor.
     ustep; econstructor. intros.
     rewrite bind_ret_. auto with paco.
@@ -144,10 +144,10 @@ Proof.
 Qed.
 
 Lemma interp_mrecursive {T} (d : D T) :
-  interp (mrecursive ctx) _ (lift_inl1 _ d) ≅ Tau (mrec ctx _ d).
+  interp (mrecursive ctx) _ (send_inl1 _ d) ≅ Tau (mrec ctx _ d).
 Proof.
-  unfold mrecursive. unfold lift_inl1.
-  rewrite interp_lift. cbn. reflexivity.
+  unfold mrecursive. unfold send_inl1.
+  rewrite interp_send. cbn. reflexivity.
 Qed.
 
 End Facts.
@@ -155,7 +155,7 @@ End Facts.
 (** [rec body] is equivalent to [interp (recursive body)],
     where [recursive] is defined as follows. *)
 Definition recursive {E A B} (f : A -> itree (callE A B +' E) B) : (callE A B +' E) ~> itree E :=
-  case_ (calling' (rec f)) ITree.lift.
+  case_ (calling' (rec f)) ITree.send.
 
 Lemma rec_as_interp {E A B} (f : A -> itree (callE A B +' E) B) (x : A) :
   rec f x ≅ interp (recursive f) _ (f x).
@@ -171,7 +171,7 @@ Lemma interp_recursive_call {E A B} (f : A -> itree (callE A B +' E) B) (x:A) :
    interp (recursive f) _ (call x) ≅ Tau (rec f x).
 Proof.
   unfold recursive. unfold call.
-  rewrite interp_lift. cbn. reflexivity.
+  rewrite interp_send. cbn. reflexivity.
 Qed.
 
 Lemma interp_loop {E F} (f : E ~> itree F) {A B C}

--- a/theories/Simple.v
+++ b/theories/Simple.v
@@ -21,7 +21,7 @@ Open Scope itree_scope.
    - [Ret], [Tau], [Vis] notations
    - [ITree.bind : itree E R -> (R -> itree E S) -> itree E S]
    - [ITree.map : (R -> S) -> itree E R -> itree E S]
-   - [ITree.lift : E R -> itree E R]
+   - [ITree.send : E R -> itree E R]
    - Notations for [bind t k]: ["t >>= k"], ["x <- t ;; k x"]
  *)
 
@@ -48,7 +48,7 @@ Require Export ITree.Interp.Recursion.
 (**
    - [mrec : (D ~> itree (D +' E)) -> (D ~> itree E)]
      and the notation [mrec-fix]
-   - [lift_inl1 : D ~> itree (D +' E)]
+   - [send_inl1 : D ~> itree (D +' E)]
    - [rec : (A -> itree (callE A B +' E) B -> A -> itree E B]
      and the notation [rec-fix]
    - [call : A -> itree (callE A B +' E) B]
@@ -157,9 +157,9 @@ Parameter interp_vis
     interp f _ (Vis e k)
   ≈ Tau (ITree.bind (f _ e) (fun x => interp f _ (k x))).
 
-Parameter interp_lift : forall {E F : Type -> Type} {R : Type}
+Parameter interp_send : forall {E F : Type -> Type} {R : Type}
       (f : E ~> (itree F)) (e : E R),
-    interp f _ (ITree.lift e) ≈ f _ e.
+    interp f _ (ITree.send e) ≈ f _ e.
 
 Parameter interp_bind : forall {E F R S}
       (f : E ~> itree F) (t : itree E R) (k : R -> itree E S),
@@ -168,7 +168,7 @@ Parameter interp_bind : forall {E F R S}
 
 Hint Rewrite @interp_ret : itree.
 Hint Rewrite @interp_vis : itree.
-Hint Rewrite @interp_lift : itree.
+Hint Rewrite @interp_send : itree.
 Hint Rewrite @interp_bind : itree.
 
 (** *** Simple recursion: [rec] *)
@@ -177,7 +177,7 @@ Hint Rewrite @interp_bind : itree.
     where [recursive] is defined as follows. *)
 Definition recursive {E A B} (f : A -> itree (callE A B +' E) B)
   : (callE A B +' E) ~> itree E
-  := case_ (calling' (rec f)) ITree.lift.
+  := case_ (calling' (rec f)) ITree.send.
 
 Parameter rec_as_interp
   : forall {E A B} (f : A -> itree (callE A B +' E) B) (a : A),
@@ -193,7 +193,7 @@ Parameter interp_recursive_call
     where [mrecursive] is defined as follows. *)
 Definition mrecursive {D E} (f : D ~> itree (D +' E))
   : (D +' E) ~> itree E :=
-  case_ (mrec f) ITree.lift.
+  case_ (mrec f) ITree.send.
 
 Parameter mrec_as_interp
   : forall {D E T} (ctx : D ~> itree (D +' E)) (d : D T),
@@ -202,7 +202,7 @@ Parameter mrec_as_interp
 
 Parameter interp_mrecursive
   : forall {D E T} (ctx : D ~> itree (D +' E)) (d : D T),
-    interp (mrecursive ctx) _ (lift_inl1 _ d)
+    interp (mrecursive ctx) _ (send_inl1 _ d)
   ≈ mrec ctx _ d.
 
 Hint Rewrite @interp_recursive_call : itree.
@@ -368,11 +368,11 @@ Proof.
   intros; rewrite unfold_interp; reflexivity.
 Qed.
 
-Lemma interp_lift : forall {E F : Type -> Type} {R : Type}
+Lemma interp_send : forall {E F : Type -> Type} {R : Type}
       (f : E ~> (itree F)) (e : E R),
-    interp f _ (ITree.lift e) ≈ f _ e.
+    interp f _ (ITree.send e) ≈ f _ e.
 Proof.
-  intros; rewrite ITree.Interp.MorphismsFacts.interp_lift, tau_eutt.
+  intros; rewrite ITree.Interp.MorphismsFacts.interp_send, tau_eutt.
   reflexivity.
 Qed.
 
@@ -387,7 +387,7 @@ Qed.
 
 Hint Rewrite @interp_ret : itree.
 Hint Rewrite @interp_vis : itree.
-Hint Rewrite @interp_lift : itree.
+Hint Rewrite @interp_send : itree.
 Hint Rewrite @interp_bind : itree.
 
 (** **** Simple recursion: [rec] *)
@@ -396,7 +396,7 @@ Hint Rewrite @interp_bind : itree.
     where [recursive] is defined as follows. *)
 Definition recursive {E A B} (f : A -> itree (callE A B +' E) B)
   : (callE A B +' E) ~> itree E
-  := case_ (calling' (rec f)) ITree.lift.
+  := case_ (calling' (rec f)) ITree.send.
 
 Lemma rec_as_interp
   : forall {E A B} (f : A -> itree (callE A B +' E) B) (a : A),
@@ -418,7 +418,7 @@ Qed.
     where [mrecursive] is defined as follows. *)
 Definition mrecursive {D E} (f : D ~> itree (D +' E))
   : (D +' E) ~> itree E :=
-  case_ (mrec f) ITree.lift.
+  case_ (mrec f) ITree.send.
 
 Lemma mrec_as_interp
   : forall {D E T} (ctx : D ~> itree (D +' E)) (d : D T),
@@ -430,7 +430,7 @@ Qed.
 
 Lemma interp_mrecursive
   : forall {D E T} (ctx : D ~> itree (D +' E)) (d : D T),
-    interp (mrecursive ctx) _ (lift_inl1 _ d)
+    interp (mrecursive ctx) _ (send_inl1 _ d)
   ≈ mrec ctx _ d.
 Proof.
   intros; rewrite ITree.Interp.RecursionFacts.interp_mrecursive. apply tau_eutt.

--- a/tutorial/Asm.v
+++ b/tutorial/Asm.v
@@ -141,7 +141,7 @@ Section Denote.
     Definition denote_operand (o : operand) : itree E value :=
       match o with
       | Oimm v => Ret v
-      | Ovar v => lift (GetVar v)
+      | Ovar v => send (GetVar v)
       end.
 
     (** Instructions offer no suprises either. *)
@@ -149,27 +149,27 @@ Section Denote.
       match i with
       | Imov d s =>
         v <- denote_operand s ;;
-        lift (SetVar d v)
+        send (SetVar d v)
       | Iadd d l r =>
-        lv <- lift (GetVar l) ;;
+        lv <- send (GetVar l) ;;
         rv <- denote_operand r ;;
-        lift (SetVar d (lv + rv))
+        send (SetVar d (lv + rv))
       | Isub d l r =>
-        lv <- lift (GetVar l) ;;
+        lv <- send (GetVar l) ;;
         rv <- denote_operand r ;;
-        lift (SetVar d (lv - rv))
+        send (SetVar d (lv - rv))
       | Imul d l r =>
-        lv <- lift (GetVar l) ;;
+        lv <- send (GetVar l) ;;
         rv <- denote_operand r ;;
-        lift (SetVar d (lv * rv))
+        send (SetVar d (lv * rv))
       | Iload d a =>
         addr <- denote_operand a ;;
-        val <- lift (Load addr) ;;
-        lift (SetVar d val)
+        val <- send (Load addr) ;;
+        send (SetVar d val)
       | Istore a v =>
-        addr <- lift (GetVar a) ;;
+        addr <- send (GetVar a) ;;
         val <- denote_operand v ;;
-        lift (Store addr val)
+        send (Store addr val)
       end.
 
     Section with_labels.
@@ -184,7 +184,7 @@ Section Denote.
         match b with
         | Bjmp l => ret l
         | Bbrz v y n =>
-          val <- lift (GetVar v) ;;
+          val <- send (GetVar v) ;;
           if val:nat then ret y else ret n
         | Bhalt => done
         end.

--- a/tutorial/Imp.v
+++ b/tutorial/Imp.v
@@ -161,7 +161,7 @@ Section Denote.
 
   (** _Imp_ expressions are denoted as [itree eff value], where the returned value
       in the tree is the value computed by the expression.
-      In the [Var] case, the [lift] operator smoothly lifts a single effect to
+      In the [Var] case, the [send] operator smoothly lifts a single effect to
       an [itree] by performing the corresponding [Vis] event and returning the
       environment's answer immediately.
       Usual monadic notations are used in the other cases. A constant (literal) is
@@ -170,7 +170,7 @@ Section Denote.
    *)
   Fixpoint denoteExpr (e : expr) : itree eff value :=
     match e with
-    | Var v => lift (GetVar v)
+    | Var v => send (GetVar v)
     | Lit n => ret n
     | Plus a b => l <- denoteExpr a ;; r <- denoteExpr b ;; ret (l + r)
     | Minus a b => l <- denoteExpr a ;; r <- denoteExpr b ;; ret (l - r)
@@ -221,7 +221,7 @@ Section Denote.
     match s with
     | Assign x e =>
       v <- denoteExpr e ;;
-      lift (SetVar x v)
+      send (SetVar x v)
     | Seq a b =>
       denoteStmt a ;; denoteStmt b
     | If i t e =>

--- a/tutorial/Imp2AsmCorrectness.v
+++ b/tutorial/Imp2AsmCorrectness.v
@@ -423,13 +423,13 @@ Section Eq_Locals.
   Lemma sim_rel_get_tmp0:
     forall n g_asm0 g_asm g_imp v,
       sim_rel g_asm0 n (g_asm,tt) (g_imp,v) ->
-      interp_locals (lift (GetVar (gen_tmp n))) g_asm ≈ Ret (g_asm,v).
+      interp_locals (send (GetVar (gen_tmp n))) g_asm ≈ Ret (g_asm,v).
   Proof.
     intros.
     destruct H as [_ [eq _]].
     unfold interp_locals.
-    unfold lift.
-    rewrite interp_lift.
+    unfold send.
+    rewrite interp_send.
     rewrite tau_eutt.
     cbn.
     unfold run_map.
@@ -440,9 +440,9 @@ Section Eq_Locals.
     rewrite map_bind.
     setoid_rewrite bind_ret.
     setoid_rewrite interp_ret.
-    unfold inl_, Inl_sum1_Handler, Handler.inl_, Handler.hlift.
+    unfold inl_, Inl_sum1_Handler, Handler.inl_, Handler.hsend.
     rewrite interp_state_bind.
-    rewrite interp_state_lift.
+    rewrite interp_state_send.
     rewrite bind_ret2.
     cbn.
     rewrite eq.
@@ -491,7 +491,7 @@ Section Linking.
       denote_asm (if_asm e tp fp)
     ⩯ ((fun _ =>
          denote_list e ;;
-         v <- lift (GetVar tmp_if) ;;
+         v <- send (GetVar tmp_if) ;;
          if v : value then denote_asm fp tt else denote_asm tp tt) : ktree _ _ _).
   Proof.
     unfold if_asm.
@@ -536,7 +536,7 @@ Section Linking.
          match l with
          | inl tt =>
            denote_list e ;;
-           v <- ITree.lift (inl1 (GetVar tmp_if)) ;;
+           v <- ITree.send (inl1 (GetVar tmp_if)) ;;
            if v : value then
              Ret (inr tt)
            else
@@ -726,7 +726,7 @@ Section Correctness.
   Lemma compile_assign_correct : forall e x,
       eq_locals eq Renv
                 (denote_list (compile_assign x e))
-                (v <- denoteExpr e ;; lift (SetVar x v)).
+                (v <- denoteExpr e ;; send (SetVar x v)).
   Proof.
     red; intros.
     unfold compile_assign.

--- a/tutorial/Introduction.v
+++ b/tutorial/Introduction.v
@@ -49,13 +49,13 @@ Inductive ioE : Type -> Type :=
   (** Send a list of [nat]. *)
 .
 
-(** Effects are wrapped as ITrees using [ITree.lift], and
+(** Effects are wrapped as ITrees using [ITree.send], and
     composed using monadic operations [bind] and [ret]. *)
 
 (** Read some input, and echo it back, appending [1] to it. *)
 Definition write_one : itree ioE unit :=
-  xs <- ITree.lift Input;;
-  ITree.lift (Output (xs ++ [1])).
+  xs <- ITree.send Input;;
+  ITree.send (Output (xs ++ [1])).
 
 (** We can _interpret_ interaction trees by giving semantics
     to their effects individually, as a _handler_: a function
@@ -91,7 +91,7 @@ Definition interp_io
 Definition interpreted_write_one : itree void1 (list nat * unit)
   := interp_io _ write_one.
 
-(** Intuitively, [interp_io] replaces every [ITree.lift] in the
+(** Intuitively, [interp_io] replaces every [ITree.send] in the
     definition of [write_one] with [handle_io]:
 [[
   interpreted_write_one =


### PR DESCRIPTION
`lift` is already used by monad transformers. `send` is thus named in Oleg Kiselyov's work around Freer monads and Extensible effects.