### PR TITLE
Make some rewrites faster

### DIFF
--- a/theories/Effects/StateFacts.v
+++ b/theories/Effects/StateFacts.v
@@ -5,9 +5,6 @@ From Coq Require Import
      Morphisms
      RelationClasses.
 
-From ExtLib Require Import
-     Structures.Monoid.
-
 From Paco Require Import paco.
 
 From ITree Require Import
@@ -122,9 +119,9 @@ Proof.
   revert A t k s.
   ucofix CIH.
   intros A t k s.
-  rewrite unfold_bind, (unfold_interp_state f t).
+  rewrite unfold_bind. (* TODO: slow *)
+  rewrite (unfold_interp_state f t).
   destruct (observe t).
-  (* TODO: performance issues with [ret|tau|vis_bind] here too. *)
   - cbn. rewrite !bind_ret. simpl.
     apply reflexivity.
   - cbn. rewrite !bind_tau, interp_state_tau.

--- a/theories/Eq/Eq.v
+++ b/theories/Eq/Eq.v
@@ -199,12 +199,12 @@ Proof.
   ucompat. econstructor; [pmonauto|].
   intros. dependent destruction PR.
   uunfold EQVl. uunfold EQVr. unfold_eq_itree.
-  inversion EQVl; clear EQVl;
+  destruct EQVl;
     inversion EQVr; clear EQVr;
     inversion RELATED; clear RELATED;
       subst; simpobs; try discriminate.
 
-  - inversion H0; inversion H3; auto.
+  - inversion H0; inversion H1; auto.
   - inversion H; inversion H3; subst; eauto with rclo.
   - inversion H; inversion H3; subst; auto_inj_pair2; subst.
     econstructor. intros. specialize (REL v). specialize (REL0 v).
@@ -225,7 +225,7 @@ Proof.
   ucompat. econstructor; [pmonauto|].
   intros. dependent destruction PR.
   uunfold EQV. unfold_eq_itree.
-  rewrite !unfold_bind; inv EQV; simpobs.
+  rewrite !unfold_bind; destruct EQV; simpobs.
   - eapply eq_itreeF_mono; [eapply REL |]; eauto with rclo.
   - simpl. eauto 8 with rclo.
   - econstructor.
@@ -450,18 +450,32 @@ Proof.
   intros; subst; auto.
 Qed.
 
-Instance eq_itree_cpn {E R1 R2 RS} r:
-  Proper (eq_itree eq ==> eq_itree eq ==> flip impl)
-         (cpn2 (@eq_itree_ E R1 R2 RS) r).
+Definition eq_itree_cpn_ {E R1 R2 RS} :
+  Proper (eq ==> eq_itree eq ==> eq_itree eq ==> flip impl)
+         (cpn2 (@eq_itree_ E R1 R2 RS)).
 Proof.
-  repeat intro. uclo eq_itree_clo_trans. eauto.
+  repeat intro; subst. uclo eq_itree_clo_trans. eauto.
 Qed.
 
-Instance eq_itree_gcpn {E R1 R2 RS} r:
-  Proper (eq_itree eq ==> eq_itree eq ==> flip impl)
-         (gcpn2 (@eq_itree_ E R1 R2 RS) r).
+Definition eq_itree_gcpn_ {E R1 R2 RS} :
+  Proper (eq ==> eq_itree eq ==> eq_itree eq ==> flip impl)
+         (gcpn2 (@eq_itree_ E R1 R2 RS)).
 Proof.
-  repeat intro. uclo eq_itree_clo_trans. eauto.
+  repeat intro; subst. uclo eq_itree_clo_trans. eauto.
+Qed.
+
+Instance eq_itree_cpn {E R1 R2 RS} :
+  Proper (eq ==> eq_itree eq ==> eq_itree eq ==> iff)
+         (cpn2 (@eq_itree_ E R1 R2 RS)).
+Proof.
+  split; apply eq_itree_cpn_; auto using symmetry.
+Qed.
+
+Instance eq_itree_gcpn {E R1 R2 RS}:
+  Proper (eq ==> eq_itree eq ==> eq_itree eq ==> iff)
+         (gcpn2 (@eq_itree_ E R1 R2 RS)).
+Proof.
+  split; apply eq_itree_gcpn_; auto using symmetry.
 Qed.
 
 Lemma bind_ret2 {E R} :
@@ -479,7 +493,7 @@ Lemma bind_bind {E R S T} :
 Proof.
   ucofix CIH. intros.
   unfold_eq_itree.
-  rewrite !unfold_bind. (* TODO: this is a bit slow (0.5s). *)
+  rewrite !unfold_bind.
   repeat red. genobs s os; destruct os; simpl; eauto with paco.
   apply Reflexive_eq_itreeF. eauto with reflexivity.
 Qed.

--- a/theories/Eq/UpToTaus.v
+++ b/theories/Eq/UpToTaus.v
@@ -246,6 +246,29 @@ Qed.
 
 End EUTT_hetero.
 
+Section EUTT_eq.
+
+Context {E : Type -> Type} {R : Type}.
+
+Local Notation eutt := (@eutt E R R eq).
+
+Global Instance subrelation_observing_eutt:
+  @subrelation (itree E R) (observing eq) eutt.
+Proof.
+  repeat intro. eapply subrelation_eq_eutt, observing_eq_itree_eq. eauto.
+Qed.
+
+Global Instance Reflexive_eutt: Reflexive eutt.
+Proof. apply Reflexive_eutt_param; eauto. Qed.
+
+Global Instance Symmetric_eutt: Symmetric eutt.
+Proof.
+  repeat intro. eapply Symmetric_eutt_hetero, H.
+  intros; subst. eauto.
+Qed.
+
+End EUTT_eq.
+
 Section EUTT_upto.
 
 Context {E : Type -> Type} {R1 R2 : Type} (RR : R1 -> R2 -> Prop).
@@ -380,28 +403,50 @@ Proof.
   - econstructor. rewrite unfold_bind. eapply IHEQV. eauto.
 Qed.
 
-Global Instance eutt_cong_cpn r :
-  Proper (eutt eq ==> eutt eq ==> flip impl)
-         (cpn2 (@eutt0 E R1 R2 RR) r).
+Definition eutt_cong_cpn_ :
+  Proper (eq ==> eutt eq ==> eutt eq ==> impl)
+         (cpn2 (@eutt0 E R1 R2 RR)).
 Proof.
-  repeat intro.
-  uclo eutt_clo_trans_left. econstructor; eauto.
-  uclo eutt_clo_trans_right. econstructor; eauto.
+  repeat intro; subst.
+  uclo eutt_clo_trans_left. econstructor; [ symmetry; eauto | ].
+  uclo eutt_clo_trans_right. econstructor; [ symmetry; eauto | ].
+  auto.
 Qed.
 
-Global Instance eutt_cong_gcpn r :
-  Proper (eutt eq ==> eutt eq ==> flip impl)
-         (gcpn2 (@eutt0 E R1 R2 RR) r).
+Definition eutt_cong_gcpn_ :
+  Proper (eq ==> eutt eq ==> eutt eq ==> impl)
+         (gcpn2 (@eutt0 E R1 R2 RR)).
 Proof.
-  repeat intro.
-  uclo eutt_clo_trans_left. econstructor; eauto.
-  uclo eutt_clo_trans_right. econstructor; eauto.
+  repeat intro; subst.
+  uclo eutt_clo_trans_left. econstructor; [ symmetry; eauto |].
+  uclo eutt_clo_trans_right. econstructor; [ symmetry; eauto |].
+  auto.
+Qed.
+
+Global Instance eutt_cong_cpn :
+  Proper (eq ==> eutt eq ==> eutt eq ==> iff)
+         (cpn2 (@eutt0 E R1 R2 RR)).
+Proof.
+  split; apply eutt_cong_cpn_; auto using symmetry.
+Qed.
+
+Global Instance eutt_cong_gcpn :
+  Proper (eq ==> eutt eq ==> eutt eq ==> iff)
+         (gcpn2 (@eutt0 E R1 R2 RR)).
+Proof.
+  split; apply eutt_cong_gcpn_; auto using symmetry.
+Qed.
+
+Definition eutt_eq_under_rr_impl_ :
+  Proper (@eutt E _ _ eq ==> @eutt _ _ _ eq ==> flip impl) (eutt RR).
+Proof.
+  repeat intro. red. rewrite H, H0. eauto with paco.
 Qed.
 
 Global Instance eutt_eq_under_rr_impl :
-  Proper (@eutt E _ _ eq ==> @eutt _ _ _ eq ==> flip impl) (eutt RR).
+  Proper (@eutt E _ _ eq ==> @eutt _ _ _ eq ==> iff) (eutt RR).
 Proof.
-  repeat red. intros. rewrite H, H0. eauto with paco.
+  split; apply eutt_eq_under_rr_impl_; auto using symmetry.
 Qed.
 
 End EUTT_upto.
@@ -457,20 +502,34 @@ Proof.
   - dependent destruction EQVr. uunfold REL0. simpobs. eauto.
 Qed.
 
-Global Instance eq_cong_eutt0 r r0 :
-  Proper (eq_itree eq ==> eq_itree eq ==> flip impl)
-         (cpn2 (@eutt0_ E R1 R2 RR (cpn2 (eutt0 RR) r)) r0).
+Definition eq_cong_eutt0_ r :
+  Proper (eq ==> eq_itree eq ==> eq_itree eq ==> flip impl)
+         (cpn2 (@eutt0_ E R1 R2 RR (cpn2 (eutt0 RR) r))).
 Proof.
   repeat intro. destruct H, H0.
   uclo eutt0_clo_trans. econstructor; eauto.
 Qed.
 
-Global Instance eq_cong_eutt0_guard r r0 :
-  Proper (eq_itree eq ==> eq_itree eq ==> flip impl)
-         (gcpn2 (@eutt0_ E R1 R2 RR (cpn2 (eutt0 RR) r)) r0).
+Definition eq_cong_eutt0_guard_ r :
+  Proper (eq ==> eq_itree eq ==> eq_itree eq ==> flip impl)
+         (gcpn2 (@eutt0_ E R1 R2 RR (cpn2 (eutt0 RR) r))).
 Proof.
-  repeat intro. destruct H, H0.
+  repeat intro; subst. destruct H0, H1.
   uclo eutt0_clo_trans. econstructor; eauto.
+Qed.
+
+Global Instance eq_cong_eutt0 r :
+  Proper (eq ==> eq_itree eq ==> eq_itree eq ==> iff)
+         (cpn2 (@eutt0_ E R1 R2 RR (cpn2 (eutt0 RR) r))).
+Proof.
+  split; apply eq_cong_eutt0_; auto; symmetry; auto.
+Qed.
+
+Global Instance eq_cong_eutt0_guard r :
+  Proper (eq ==> eq_itree eq ==> eq_itree eq ==> iff)
+         (gcpn2 (@eutt0_ E R1 R2 RR (cpn2 (eutt0 RR) r))).
+Proof.
+  split; apply eq_cong_eutt0_guard_; auto; symmetry; auto.
 Qed.
 
 Inductive eutt0_bind_clo (r: itree E R1 -> itree E R2 -> Prop) : itree E R1 -> itree E R2 -> Prop :=
@@ -507,26 +566,11 @@ Hint Constructors eutt0_trans_clo.
 Arguments eutt0_clo_bind : clear implicits.
 Hint Constructors eutt0_bind_clo.
 
-Section EUTT_eq.
+Section EUTT_eq2.
 
 Context {E : Type -> Type} {R : Type}.
 
 Local Notation eutt := (@eutt E R R eq).
-
-Global Instance subrelation_observing_eutt:
-  @subrelation (itree E R) (observing eq) eutt.
-Proof.
-  repeat intro. eapply subrelation_eq_eutt, observing_eq_itree_eq. eauto.
-Qed.
-
-Global Instance Reflexive_eutt: Reflexive eutt.
-Proof. apply Reflexive_eutt_param; eauto. Qed.
-
-Global Instance Symmetric_eutt: Symmetric eutt.
-Proof.
-  repeat intro. eapply Symmetric_eutt_hetero, H.
-  intros; subst. eauto.
-Qed.
 
 Global Instance Transitive_eutt : Transitive eutt.
 Proof.
@@ -557,7 +601,7 @@ Proof.
   intros. specialize (H x0). uunfold H. eauto.
 Qed.
 
-End EUTT_eq.
+End EUTT_eq2.
 
 (**)
 
@@ -690,8 +734,12 @@ Qed.
     (assumed to be of the form [lhs ≈ rhs]). *)
 Ltac tau_steps :=
   repeat (
-      rewrite itree_eta at 1; cbn;
+      (* Only rewrite the LHS, even if it also occurs in the RHS *)
+      rewrite itree_eta at 1;
+      cbn;
       match goal with
-      | [ |- go (observe _) ≈ _ ] => fail 1
+      | [ |- go (observe _) ≈ _ ] =>
+        (* Cancel [itree_eta] if no progress was made. *)
+        fail 1
       | _ => try rewrite tau_eutt
       end).

--- a/theories/Eq/UpToTausExplicit.v
+++ b/theories/Eq/UpToTausExplicit.v
@@ -238,7 +238,7 @@ Section EUTT_rel.
 
 Context {E : Type -> Type} {R : Type} (RR : R -> R -> Prop).
 
-Global Instance subrelation_eq_euttE :
+Definition subrelation_eq_euttE :
   @subrelation (itree E R) (eq_itree RR) (euttE RR).
 Proof.
   ucofix CIH. intros.

--- a/theories/Interp/MorphismsFacts.v
+++ b/theories/Interp/MorphismsFacts.v
@@ -139,9 +139,8 @@ Lemma interp_bind {E F R S}
   ≅ ITree.bind (interp f t) (fun r => interp f (k r)).
 Proof.
   revert R t k; ucofix CIH; intros.
-  rewrite unfold_bind, (unfold_interp t).
+  rewrite unfold_bind, (unfold_interp t). (* TODO: slow *)
   destruct (observe t); cbn.
-  (* TODO: [ret_bind] (0.8s) is much slower than [ret_bind_] (0.02s) *)
   - rewrite bind_ret. apply reflexivity.
   - rewrite bind_tau, !interp_tau.
     econstructor. eauto with paco.

--- a/theories/Interp/RecursionFacts.v
+++ b/theories/Interp/RecursionFacts.v
@@ -17,7 +17,6 @@ From ITree Require Import
      Core.KTreeFacts
      Eq.Eq
      Eq.UpToTaus
-     Eq.SimUpToTaus
      Indexed.Sum
      Indexed.Function
      Indexed.OpenSum
@@ -101,7 +100,8 @@ Theorem interp_mrec_bind {U T} (t : itree _ U) (k : U -> itree _ T) :
   ITree.bind (interp_mrec ctx t) (fun x => interp_mrec ctx (k x)).
 Proof.
   revert t k; ucofix CIH; intros.
-  rewrite (unfold_interp_mrec _ t), (unfold_bind t).
+  rewrite (unfold_interp_mrec _ t).
+  rewrite (unfold_bind t). (* TODO: slow *)
   destruct (observe t); cbn;
     [| |destruct e];
     autorewrite with itree;


### PR DESCRIPTION
```
(* slower *)
Instance eq_f r : Proper (sig) (f r).

(* faster *)
Instance eq_f : Proper (eq ==> sig) f. 
```

(It seems `Proper` instance resolution is designed to peel off arguments first)

```
(* slower *)
Instance Proper_eutt : Proper (sig ==> flip impl) eutt.

(* faster *)
Instance Proper_eutt : Proper (sig ==> iff) eutt.
```

(`impl` and `flip impl` are obvious subrelations of `iff`, whereas deriving a `Proper` instance for `impl` from a `flip impl` take more work.)

There are still quite a few slow places. e.g., `unfold_bind` in `Effects.StateFacts`.