### PR TITLE
Enable rewriting under interp

### DIFF
--- a/_CoqConfig
+++ b/_CoqConfig
@@ -31,6 +31,7 @@ theories/Eq/EqAxiom.v
 theories/Indexed/Sum.v
 theories/Indexed/Relation.v
 theories/Indexed/Function.v
+theories/Indexed/FunctionFacts.v
 theories/Indexed/OpenSum.v
 
 theories/Interp/Interp.v

--- a/_CoqConfig
+++ b/_CoqConfig
@@ -29,6 +29,7 @@ theories/Eq/SimUpToTaus.v
 theories/Eq/EqAxiom.v
 
 theories/Indexed/Sum.v
+theories/Indexed/Relation.v
 theories/Indexed/Function.v
 theories/Indexed/OpenSum.v
 

--- a/tests/_CoqProject
+++ b/tests/_CoqProject
@@ -1,6 +1,6 @@
 -Q ../theories ITree
 -Q extraction/ TestExtraction
--Q rewriting/ TestRewriting
+-Q unit/ TestUnit
 
 # Test to ensure extracted code is compilable
 # - MetaModule.v is a module that depends on the
@@ -11,3 +11,7 @@
 
 extraction/MetaModule.v
 extraction/Extract.v
+
+# Unit tests
+
+unit/Unit.v

--- a/tests/unit/Unit.v
+++ b/tests/unit/Unit.v
@@ -1,0 +1,17 @@
+From ITree Require Import
+     ITree ITreeFacts.
+
+Import CatNotations.
+Local Open Scope cat.
+
+(* Test that we can indeed rewrite handlers under interp.  *)
+Lemma interp_id_id {E R} (t : itree E R) :
+  interp (id_ E >>> id_ E) t ≈ t.
+Proof.
+  rewrite (@fold_apply_IFun (itree E) (itree E)). (* TODO: don't require type annotations *)
+  rewrite cat_id_r. (* Works *)
+  rewrite <- fold_apply_IFun.
+  rewrite interp_id_h.
+  reflexivity.
+  all: typeclasses eauto.
+Qed.

--- a/theories/Basics/Basics.v
+++ b/theories/Basics/Basics.v
@@ -79,7 +79,7 @@ End Monads.
     an output [B]. It's an Asymmetric variant of [loop], and it looks
     similar to an Anamorphism, hence the name [aloop].
  *)
-Class ALoop (M : Type -> Type) : Type :=
+Polymorphic Class ALoop (M : Type -> Type) : Type :=
   aloop : forall {R I: Type}, (I -> M I + R) -> I -> M R.
 
 (* TODO: try this one.
@@ -108,7 +108,7 @@ Instance ALoop_stateT {M S} {AM : ALoop M} : ALoop (stateT S M) :=
       | inr r => inr (r, s)
       end) (i, s)).
 
-Instance ALoop_stateT0 {M S} {AM : ALoop M} : ALoop (Monads.stateT S M) :=
+Polymorphic Instance ALoop_stateT0 {M S} {AM : ALoop M} : ALoop (Monads.stateT S M) :=
   fun _ _ step i s =>
     aloop (fun si =>
       let s := fst si in
@@ -163,4 +163,4 @@ Inductive aloop_Prop {R I : Type} (step : I -> (I -> Prop) + R) (i : I) (r : R)
     aloop_Prop step i r
 .
 
-Instance ALoop_Prop : ALoop Ensembles.Ensemble := @aloop_Prop.
+Polymorphic Instance ALoop_Prop : ALoop Ensembles.Ensemble := @aloop_Prop.

--- a/theories/Basics/Function.v
+++ b/theories/Basics/Function.v
@@ -16,7 +16,7 @@ Local Open Scope cat_scope.
 Definition Fun (A B : Type) : Type := A -> B.
 
 (** The identity function, but can sometimes help type inference. *)
-Definition applyFun {A B : Type} (f : Fun A B) : A -> B := f.
+Definition apply_Fun {A B : Type} (f : Fun A B) : A -> B := f.
 
 (** Extensional function equality *)
 Instance eeq : Eq2 Fun :=

--- a/theories/Basics/FunctionFacts.v
+++ b/theories/Basics/FunctionFacts.v
@@ -9,7 +9,6 @@ From ITree Require Import
 
 Import CatNotations.
 Local Open Scope cat_scope.
-
 (* end hide *)
 
 Instance subrelation_eeq_eqeq {A B} :

--- a/theories/Effects/StateFacts.v
+++ b/theories/Effects/StateFacts.v
@@ -39,7 +39,7 @@ Definition _interp_state {E F S R}
   end.
 
 Lemma unfold_interp_state {E F S R} (h : E ~> Monads.stateT S (itree F))
-      (t : _ R) s :
+      (t : itree E R) s :
     eq_itree eq
       (interp_state h t s)
       (_interp_state h (observe t) s).
@@ -82,7 +82,7 @@ Proof.
 Qed.
 
 Lemma interp_state_vis {E F : Type -> Type} {S T U : Type}
-      (e : E T) (k : T -> _ U) (h : E ~> Monads.stateT S (itree F)) (s : S)
+      (e : E T) (k : T -> itree E U) (h : E ~> Monads.stateT S (itree F)) (s : S)
   : interp_state h (Vis e k) s
   ≅ Tau (h T e s >>= fun sx => interp_state h (k (snd sx)) (fst sx)).
 Proof.

--- a/theories/ITreeFacts.v
+++ b/theories/ITreeFacts.v
@@ -4,6 +4,7 @@ From ITree Require Export
      Basics.FunctionFacts
      Core.ITreeDefinition
      Core.KTreeFacts
+     Indexed.FunctionFacts
      Interp.TranslateFacts
      Interp.InterpFacts
      Interp.HandlerFacts

--- a/theories/Indexed/Function.v
+++ b/theories/Indexed/Function.v
@@ -8,6 +8,7 @@
 From ITree Require Import
      Basics.Basics
      Basics.Category
+     Indexed.Relation
      Indexed.Sum.
 (* end hide *)
 
@@ -15,11 +16,11 @@ From ITree Require Import
 Definition IFun (E F : Type -> Type) : Type := E ~> F.
 
 (** Unwrap [IFun], potentially useful for type inference. *)
-Definition applyIFun {E F} (f : IFun E F) : E ~> F := f.
+Definition apply_IFun {E F T} (f : IFun E F) : E T -> F T := f T.
 
 (** Equivalence of indexed functions is extensional equality. *)
 Instance Eq2_IFun : Eq2 IFun :=
-  fun E F f1 f2 => forall R (e : E R), f1 _ e = f2 _ e.
+  fun E F => i_pointwise (fun T => @eq (F T)).
 
 (** The identity function. *)
 Instance Id_IFun : Id_ IFun :=

--- a/theories/Indexed/FunctionFacts.v
+++ b/theories/Indexed/FunctionFacts.v
@@ -1,0 +1,15 @@
+From Coq Require Import
+     Setoid
+     Morphisms.
+
+From ITree Require Import
+     Indexed.Function
+     Indexed.Relation.
+
+Instance Proper_apply_IFun {E F : Type -> Type} {T : Type}
+         (RE : forall T, E T -> E T -> Prop)
+         (RF : forall T, F T -> F T -> Prop)
+  : Proper (i_respectful RE RF ==> RE T ==> RF T) apply_IFun.
+Proof.
+  repeat red; eauto.
+Qed.

--- a/theories/Indexed/FunctionFacts.v
+++ b/theories/Indexed/FunctionFacts.v
@@ -3,6 +3,7 @@ From Coq Require Import
      Morphisms.
 
 From ITree Require Import
+     Basics.Basics
      Indexed.Function
      Indexed.Relation.
 
@@ -12,4 +13,11 @@ Instance Proper_apply_IFun {E F : Type -> Type} {T : Type}
   : Proper (i_respectful RE RF ==> RE T ==> RF T) apply_IFun.
 Proof.
   repeat red; eauto.
+Qed.
+
+Lemma fold_apply_IFun {E F : Type -> Type} {T : Type}
+  : forall (f : E ~> F) (t : E T),
+    f _ t = apply_IFun f t.
+Proof.
+  reflexivity.
 Qed.

--- a/theories/Indexed/Relation.v
+++ b/theories/Indexed/Relation.v
@@ -1,0 +1,74 @@
+(** * Relations on indexed types *)
+
+(* begin hide *)
+From Coq Require Import
+     Relations
+     Setoid.
+
+From ITree Require Import
+     Basics.Basics.
+
+Set Universe Polymorphism.
+(* end hide *)
+
+(** This is an indexed generalization of the standard [respectful]
+    relation ([==>]). *)
+Definition i_respectful {A B : Type -> Type}
+           (RA : forall T, A T -> A T -> Prop)
+           (RB : forall T, B T -> B T -> Prop)
+           (f1 f2 : A ~> B)
+  : Prop
+  := forall T (a1 a2 : A T), RA T a1 a2 -> (RB T) (f1 T a1) (f2 T a2).
+
+Definition i_pointwise {A B : Type -> Type}
+           (RB : forall T, B T -> B T -> Prop)
+           (f1 f2 : A ~> B)
+  : Prop
+  := forall T (a : A T), (RB T) (f1 T a) (f2 T a).
+
+Instance Reflexive_i_pointwise {A B : Type -> Type}
+         (RB : forall T, B T -> B T -> Prop)
+         {Reflexive_R : forall T, Reflexive (RB T)}
+  : Reflexive (@i_pointwise A B RB).
+Proof.
+  repeat red; intros; red in Reflexive_R; eauto.
+Qed.
+
+Instance Symmetric_i_pointwise {A B : Type -> Type}
+         (RB : forall T, B T -> B T -> Prop)
+         {Symmetric_R : forall T, Symmetric (RB T)}
+  : Symmetric (@i_pointwise A B RB).
+Proof.
+  repeat red; intros; red in Symmetric_R; eauto.
+Qed.
+
+Instance Transitive_i_pointwise {A B : Type -> Type}
+         (RB : forall T, B T -> B T -> Prop)
+         {Transitive_R : forall T, Transitive (RB T)}
+  : Transitive (@i_pointwise A B RB).
+Proof.
+  repeat red; intros; red in Transitive_R; eauto.
+Qed.
+
+Instance Equivalence_i_pointwise {A B : Type -> Type}
+         (RB : forall T, B T -> B T -> Prop)
+         {Equivalence_R : forall T, Equivalence (RB T)}
+  : Equivalence (@i_pointwise A B RB).
+Proof.
+  split; try typeclasses eauto.
+Qed.
+
+Instance subrelation_i_pointwise_i_respectful {A B : Type -> Type}
+           (RB : forall T, B T -> B T -> Prop)
+  : subrelation (i_pointwise RB) (i_respectful (fun T => @eq (A T)) RB).
+Proof.
+  repeat red; intros; subst; auto.
+Qed.
+
+(* This is not an instance, to avoid instance resolution loops. *)
+Definition subrelation_i_respectful_i_pointwise {A B : Type -> Type}
+           (RB : forall T, B T -> B T -> Prop)
+  : subrelation (i_respectful (fun T => @eq (A T)) RB) (i_pointwise RB).
+Proof.
+  repeat red; auto.
+Qed.

--- a/theories/Interp/Handler.v
+++ b/theories/Interp/Handler.v
@@ -15,6 +15,7 @@ From ITree Require Import
      Eq.UpToTaus
      Indexed.Sum
      Indexed.Function
+     Indexed.Relation
      Interp.Interp.
 
 Import ITree.Basics.Basics.Monads.
@@ -67,23 +68,19 @@ End Handler.
 
 (** ** Category instances *)
 
-(** This is an indexed generalization of the standard [respectful]
-    relation ([==>]). *)
-(* TODO: should also take a relation on [A]. *)
-Definition i_respectful {A B : Type -> Type} (R : forall t, B t -> B t -> Prop)
-           (f g : A ~> B) : Prop :=
-  forall X (a : A X), (R X) (f X a) (g X a).
-
 Definition Handler (E F : Type -> Type) := E ~> itree F.
 
 Definition eq_Handler {E F : Type -> Type}
   : Handler E F -> Handler E F -> Prop
-  := @i_respectful E (itree F) (fun R => @eq_itree _ _ R eq).
+  := i_pointwise (fun R => eq_itree eq).
+
+Definition eutt_Handler {E F : Type -> Type}
+  : Handler E F -> Handler E F -> Prop
+  := i_pointwise (fun R => eutt eq).
 
 (** The default handler equivalence is [eutt]. *)
 Instance Eq2_Handler : Eq2 Handler
-  := fun E F
-     => @i_respectful E (itree F) (fun R => @eutt _ _ R eq).
+  := @eutt_Handler.
 
 Instance Id_Handler : Id_ Handler
   := @Handler.id_.

--- a/theories/Interp/HandlerFacts.v
+++ b/theories/Interp/HandlerFacts.v
@@ -25,21 +25,10 @@ Open Scope itree_scope.
 
 (* end hide *)
 
-Lemma eh_cmp_id_left_strong {A R} (t : itree A R)
-  : interp (id_ A) t ≈ t.
-Proof.
-  revert t. ucofix CIH. red. ucofix CIH'. intros.
-  rewrite unfold_interp. unfold _interp. repeat red.
-  destruct (observe t); cbn; eauto 8 with paco.
-  unfold id_, Id_Handler, Handler.id_, ITree.send. eutt0_fold. rewrite bind_vis_.
-  do 2 constructor.
-  left; rewrite bind_ret; auto with paco.
-Qed.
-
 Instance CatIdR_Handler : CatIdR Handler.
 Proof.
   red; intros A B f X e.
-  apply eh_cmp_id_left_strong.
+  apply interp_id_h.
 Qed.
 
 Instance CatIdL_Handler : CatIdL Handler.

--- a/theories/Interp/Interp.v
+++ b/theories/Interp/Interp.v
@@ -49,7 +49,8 @@ From ExtLib Require Import
 
 From ITree Require Import
      Basics.Basics
-     Core.ITreeDefinition.
+     Core.ITreeDefinition
+     Indexed.Relation.
 
 (* end hide *)
 

--- a/theories/Interp/InterpFacts.v
+++ b/theories/Interp/InterpFacts.v
@@ -7,6 +7,7 @@ From Coq Require Import
 From Paco Require Import paco.
 
 From ITree Require Import
+     Basics.Category
      Basics.Basics
      Core.ITreeDefinition
      Core.KTree
@@ -14,34 +15,57 @@ From ITree Require Import
      Eq.UpToTausEquivalence
      Indexed.Sum
      Indexed.OpenSum
+     Indexed.Function
+     Indexed.Relation
      Interp.Interp
      Interp.Handler
      Interp.TranslateFacts.
 
 Import ITreeNotations.
 
+Definition respectful_eq_itree {E F : Type -> Type}
+  : (itree E ~> itree F) -> (itree E ~> itree F) -> Prop
+  := i_respectful (fun _ => eq_itree eq) (fun _ => eq_itree eq).
 
+Definition respectful_eutt {E F : Type -> Type}
+  : (itree E ~> itree F) -> (itree E ~> itree F) -> Prop
+  := i_respectful (fun _ => eutt eq) (fun _ => eutt eq).
+
+Instance eq_itree_apply_IFun {E F : Type -> Type} {T : Type}
+  : Proper (respectful_eq_itree ==> eq_itree eq ==> eq_itree eq)
+           (@apply_IFun (itree E) (itree F) T).
+Proof.
+  repeat red; eauto.
+Qed.
+
+Instance eutt_apply_IFun {E F : Type -> Type} {T : Type}
+  : Proper (respectful_eutt ==> eutt eq ==> eutt eq)
+           (@apply_IFun (itree E) (itree F) T).
+Proof.
+  repeat red; eauto.
+Qed.
+
+Instance Equivalence_eq_Handler {E F : Type -> Type}
+  : Equivalence (@eq_Handler E F).
+Proof.
+  unfold eq_Handler.
+  apply (Equivalence_i_pointwise (fun R => eq_itree eq)).
+Qed.
+
+Instance Equivalence_eutt_Handler {E F : Type -> Type}
+  : Equivalence (@eutt_Handler E F).
+Proof.
+  unfold eutt_Handler.
+  apply (Equivalence_i_pointwise (fun R => eutt eq)).
+Qed.
+
+Instance Equivalence_eq2_Handler {E F : Type -> Type}
+  : @Equivalence (Handler E F) eq2.
+Proof.
+  exact Equivalence_eutt_Handler.
+Qed.
 
 (** * [interp] *)
-
-(* Proof of
-   [interp f (t >>= k) ~ (interp f t >>= fun r => interp f (k r))]
-
-   "By coinduction", case analysis on t:
-
-    - [t = Ret r] or [t = Vis e k] (...)
-
-    - [t = Tau t]:
-          interp f (Tau t >>= k)
-        = interp f (Tau (t >>= k))
-        = Tau (interp f (t >>= k))
-        { by "coinductive hypothesis" }
-        ~ Tau (interp f t >>= fun ...)
-        = Tau (interp f t) >>= fun ...
-        = interp f (Tau t) >>= fun ...
-        (QED)
-
- *)
 
 (* Unfolding of [interp]. *)
 Definition _interp {E F R} (f : E ~> itree F) (ot : itreeF E R _)
@@ -79,12 +103,13 @@ Lemma interp_vis {E F R} {f : E ~> itree F} U (e: E U) (k: U -> itree E R) :
 Proof. rewrite unfold_interp. reflexivity. Qed.
 
 (** ** [interp] properness *)
-Instance eq_itree_interp {E F R}:
-  Proper (i_respectful (fun _ => eq_itree eq) ==> eq_itree eq ==> eq_itree eq)
-         (fun f => @interp E (itree F) _ _ _ f R).
+Instance eq_itree_interp {E F}
+  : @Proper (Handler E F -> (itree E ~> itree F))
+            (eq_Handler ==> respectful_eq_itree)
+            interp.
 Proof.
   intros f g Hfg.
-  intros l r Hlr.
+  intros T l r Hlr.
   revert l r Hlr; ucofix CIH.
   rename r into rr; intros l r Hlr.
   rewrite 2 unfold_interp.
@@ -99,18 +124,21 @@ Proof.
     auto with paco.
 Qed.
 
-Global Instance Proper_interp_eq_itree {E F R f}
-: Proper (eq_itree eq ==> eq_itree eq) (@interp E (itree F) _ _ _ f R).
+Instance eq_itree_interp' {E F R f}
+  : Proper (eq_itree eq ==> eq_itree eq) (@interp E (itree F) _ _ _ f R).
 Proof.
+  repeat red.
   eapply eq_itree_interp.
-  red. reflexivity.
+  reflexivity.
 Qed.
 
-(* Note that this allows rewriting of handlers. *)
-Definition eutt_interp_gen (E F : Type -> Type) (R : Type) :
-  Proper (i_respectful (fun _ => eutt eq) ==> eutt eq ==> eutt eq)
-         (fun f => @interp E (itree F) _ _ _ f R).
+Definition eutt_interp (E F : Type -> Type)
+  : @Proper (Handler E F -> (itree E ~> itree F))
+            (eq2 ==> respectful_eutt)
+            interp.
 Proof.
+  repeat red.
+  intros until T.
   ucofix CIH. red. ucofix CIH'. intros.
 
   rewrite !unfold_interp. do 2 uunfold H1.
@@ -118,7 +146,7 @@ Proof.
   - econstructor. eauto.
   - constructor.
     uclo eutt0_clo_bind.
-    econstructor; [apply H0|].
+    econstructor; [apply H|].
     intros; subst.
     ubase. eapply CIH'; edestruct (EUTTK v2); eauto with paco.
   - econstructor. eauto 7 with paco.
@@ -126,13 +154,33 @@ Proof.
   - constructor. eutt0_fold. rewrite unfold_interp. auto.
 Qed.
 
-Instance eutt_interp (E F : Type -> Type) f (R : Type) :
+Instance eutt_interp' {E F : Type -> Type} {R : Type} (f : E ~> itree F) :
   Proper (eutt eq ==> eutt eq)
          (@interp E (itree F) _ _ _ f R).
 Proof.
-  apply eutt_interp_gen.
-  red; reflexivity.
+  repeat red.
+  apply eutt_interp.
+  reflexivity.
 Qed.
+
+(* Proof of
+   [interp f (t >>= k) ~ (interp f t >>= fun r => interp f (k r))]
+
+   "By coinduction", case analysis on t:
+
+    - [t = Ret r] or [t = Vis e k] (...)
+
+    - [t = Tau t]:
+          interp f (Tau t >>= k)
+        = interp f (Tau (t >>= k))
+        = Tau (interp f (t >>= k))
+        { by "coinductive hypothesis" }
+        ~ Tau (interp f t >>= fun ...)
+        = Tau (interp f t) >>= fun ...
+        = interp f (Tau t) >>= fun ...
+        (QED)
+
+ *)
 
 Lemma interp_bind {E F R S}
       (f : E ~> itree F) (t : itree E R) (k : R -> itree E S) :

--- a/theories/Interp/InterpFacts.v
+++ b/theories/Interp/InterpFacts.v
@@ -52,6 +52,8 @@ Proof.
   apply (Equivalence_i_pointwise (fun R => eq_itree eq)).
 Qed.
 
+Require ITree.Core.KTreeFacts. (* TODO: only needed to avoid a universe inconsistency right around here (errors if you try to move this to the end of the file, or just under the next instance)... *)
+
 Instance Equivalence_eutt_Handler {E F : Type -> Type}
   : Equivalence (@eutt_Handler E F).
 Proof.

--- a/theories/Interp/InterpFacts.v
+++ b/theories/Interp/InterpFacts.v
@@ -134,7 +134,7 @@ Proof.
   reflexivity.
 Qed.
 
-Definition eutt_interp (E F : Type -> Type)
+Instance eutt_interp (E F : Type -> Type)
   : @Proper (Handler E F -> (itree E ~> itree F))
             (eq2 ==> respectful_eutt)
             interp.

--- a/theories/Interp/InterpFacts.v
+++ b/theories/Interp/InterpFacts.v
@@ -214,10 +214,20 @@ Proof.
   reflexivity.
 Qed.
 
+(** *** Identities for [interp] *)
 
-(** ** Composition of [interp] *)
+Lemma interp_id_h {A R} (t : itree A R)
+  : interp (id_ A) t ≈ t.
+Proof.
+  revert t. ucofix CIH. red. ucofix CIH'. intros.
+  rewrite unfold_interp. unfold _interp. repeat red.
+  destruct (observe t); cbn; eauto 8 with paco.
+  unfold id_, Id_Handler, Handler.id_, ITree.send. eutt0_fold. rewrite bind_vis_.
+  do 2 constructor.
+  left; rewrite bind_ret; auto with paco.
+Qed.
 
-Lemma interp_id_send {E R} (t : itree E R) :
+Lemma interp_send_h {E R} (t : itree E R) :
   interp (fun _ e => ITree.send e) t ≈ t.
 Proof.
   revert t. ucofix CIH. red. ucofix CIH'. intros.
@@ -229,6 +239,7 @@ Proof.
   auto with paco.
 Qed.
 
+(** ** Composition of [interp] *)
 
 Theorem interp_interp {E F G R} (f : E ~> itree F) (g : F ~> itree G) :
   forall t : itree E R,
@@ -248,8 +259,6 @@ Proof.
     + intros ? _ [].
       auto with paco.
 Qed.
-
-(* Commuting interpreters --------------------------------------------------- *)
 
 Lemma interp_translate {E F G} (f : E ~> F) (g : F ~> itree G) {R} (t : itree E R) :
   interp g (translate f t) ≅ interp (fun _ e => g _ (f _ e)) t.

--- a/theories/Simple.v
+++ b/theories/Simple.v
@@ -469,7 +469,7 @@ Proof. apply ITree.Eq.UpToTausEquivalence.eutt_map. Qed.
 
 Instance eutt_interp (E F : Type -> Type) f (R : Type) :
   Proper (eutt ==> eutt) (@interp E (itree F) _ _ _ f R).
-Proof. apply ITree.Interp.InterpFacts.eutt_interp. Qed.
+Proof. apply ITree.Interp.InterpFacts.eutt_interp'. Qed.
 
 Ltac tau_steps :=
   repeat (


### PR DESCRIPTION
Fix #101.

The key idea is to change the `eutt_interp` lemma. (The old one, which only allows rewriting the last argument is now called `eutt_interp'`), viewing `interp` as a higher-order morphism between handlers and itree morphisms. Then it should be possible to fold `interp h t` as `apply_IFun (interp h) t`, and then the proper lemma for `apply_IFun` (`Indexed.FunctionFacts.Proper_apply_IFun`) should allow you to rewrite `h`.

The idea suggested at the end of #101 goes a bit farther, to make `apply_IFun` the only way to apply `interp h`. Not sure whether that's worth the trouble.