### PR TITLE
Update tutorial to talk about mapE instead of envE.

### DIFF
--- a/tutorial/Asm.v
+++ b/tutorial/Asm.v
@@ -259,7 +259,7 @@ Definition evalMemory {E : Type -> Type} `{mapE value value -< E} :
 Definition memory := alist value value.
 
 (** We can then define an evaluator for closed assembly programs by
-    interpreting both store and heap events into two instances of [envE],
+    interpreting both store and heap events into two instances of [mapE],
     and running them both.
  *)
 Definition AsmEval (p: asm unit void) :=

--- a/tutorial/Imp.v
+++ b/tutorial/Imp.v
@@ -284,8 +284,8 @@ From ExtLib Require Import
     Recall from [Introduction.v] that a _handler_ for the events [Locals]
     is a function of type [forall R, Locals R -> M R] for some monad [M].
     Here we take for our monad the special case of [M = itree E] for some
-    universe of events [E] required to contain the environment events [envE]
-    provided by the library. It comes with an event handler [run_env]
+    universe of events [E] required to contain the environment events [mapE]
+    provided by the library. It comes with an event handler [run_map]
     interpreting the computation into the state monad.
  *)
 
@@ -314,9 +314,9 @@ Qed.
 
 (** Finally, we can define an evaluator for our statements.
    To do so, we first denote them, leading to an [itree Locals unit].
-   We then [interp]ret [Locals] into [envE] using [evalLocals], leading to
-   an [itree (envE var value) unit].
-   Finally, [run_env] interprets the latter [itree] into the state monad,
+   We then [interp]ret [Locals] into [mapE] using [evalLocals], leading to
+   an [itree (mapE var value) unit].
+   Finally, [run_map] interprets the latter [itree] into the state monad,
    resulting in an [itree] free of any event, but returning an environment.
  *)
 

--- a/tutorial/Imp2AsmCorrectness.v
+++ b/tutorial/Imp2AsmCorrectness.v
@@ -321,7 +321,7 @@ Section Eq_Locals.
   Context {E': Type -> Type}.
   Notation E := (Locals +' E').
 
-  (** [interp_locals] handle [Locals] into the [envE] events, and then
+  (** [interp_locals] handle [Locals] into the [mapE] events, and then
       run these events into the state monad. *)
   Definition interp_locals {R: Type} (t: itree E R) (s: alist var value)
     : itree E' (alist var value * R) :=


### PR DESCRIPTION
Noticed that the tutorial had comments which were slightly out of date.