### PR TITLE
Remove the tactic `auto_inj_pair2`

### DIFF
--- a/theories/Eq/Eq.v
+++ b/theories/Eq/Eq.v
@@ -443,7 +443,7 @@ Qed.
 Lemma eq_itree_inv_vis {E R U} (t : itree E R) (e : E U) (k : U -> _) :
   t ≅ Vis e k -> exists k', observe t = VisF e k' /\ forall u, k' u ≅ k u.
 Proof.
-  intros; punfold H; inv H; auto_inj_pair2; subst; try inv CHECK.
+  intros; punfold H; red in H; dependent destruction H.
   eexists; split; eauto.
   intros. destruct (REL u); try contradiction; pclearbot; eauto.
 Qed.
@@ -678,7 +678,7 @@ Lemma eqit_Vis b1 b2 {U} (e : E U)
 Proof.
   split; intros H.
   - pstep. econstructor. left. apply H.
-  - punfold H. inv H; auto_inj_pair2; subst; auto.
+  - punfold H. red in H; dependent destruction H.
     intros. pclearbot. eauto.
 Qed.
 
@@ -687,7 +687,7 @@ Lemma eqit_Ret b1 b2 (r1 : R1) (r2 : R2) :
 Proof.
   split; intros H.
   - pstep. constructor; auto.
-  - punfold H. inversion H; auto_inj_pair2; subst; auto.
+  - punfold H. red in H. dependent destruction H. auto.
 Qed.
 
 (** *** "Up-to" principles for coinduction. *)

--- a/theories/Eq/Shallow.v
+++ b/theories/Eq/Shallow.v
@@ -21,13 +21,6 @@ From Coq Require Import
      ProofIrrelevance.
 (* end hide *)
 
-(** Rewrite all heterogeneous equalities with the axiom
-    [inj_pair2 : existT _ T a = existT _ T b -> a = b]. *)
-Ltac auto_inj_pair2 :=
-  repeat (match goal with
-          | [ H : _ |- _ ] => apply inj_pair2 in H
-          end).
-
 (** ** [observing]: Lift relations through [observe]. *)
 Inductive observing {E R1 R2}
            (eq_ : itree' E R1 -> itree' E R2 -> Prop)

--- a/theories/Eq/SimUpToTaus.v
+++ b/theories/Eq/SimUpToTaus.v
@@ -89,7 +89,7 @@ Lemma suttF_inv_vis {E R1 R2} (RR : R1 -> R2 -> Prop) sutt :
     suttF RR sutt (VisF e k1) (VisF e k2) ->
     forall x, sutt (observe (k1 x)) (observe (k2 x)).
 Proof.
-  intros. inv H. auto_inj_pair2. subst. auto.
+  intros. dependent destruction H. auto.
 Qed.
 
 Lemma sutt_inv_vis {E R1 R2} (RR : R1 -> R2 -> Prop) :
@@ -98,7 +98,7 @@ Lemma sutt_inv_vis {E R1 R2} (RR : R1 -> R2 -> Prop) :
   forall x, sutt RR (k1 x) (k2 x).
 Proof.
   intros. pstep. punfold H. simpl in *.
-  inv H. auto_inj_pair2. subst. specialize (SUTTK x). pclearbot. punfold SUTTK.
+  dependent destruction H. specialize (SUTTK x). pclearbot. punfold SUTTK.
 Qed.
 
 Lemma sutt_tau_right {E R1 R2} (RR : R1 -> R2 -> Prop) :

--- a/theories/Interp/Traces.v
+++ b/theories/Interp/Traces.v
@@ -2,7 +2,7 @@
 
 (* begin hide *)
 From Coq Require Import
-     List.
+     List Program.
 
 Import ListNotations.
 
@@ -97,14 +97,14 @@ Proof.
   - punfold H. rewrite <- Heqi in H.
     remember (VisF _ _). remember (observe t2).
     generalize dependent t2.
-    induction H; intros; try inv Heqi0.
-    + auto_inj_pair2. subst. red. rewrite <- Heqi1. constructor.
+    induction H; intros; try dependent destruction Heqi0.
+    + red. rewrite <- Heqi1. constructor.
     + red. rewrite <- Heqi1. constructor. eapply IHsuttF; eauto.
   - punfold H. rewrite <- Heqi in H.
     remember (VisF _ _). remember (observe t2).
     generalize dependent t2.
-    induction H; intros; try inv Heqi0.
-    + pclearbot. auto_inj_pair2. subst. red. rewrite <- Heqi1. constructor.
+    induction H; intros; try dependent destruction Heqi0.
+    + pclearbot. red. rewrite <- Heqi1. constructor.
       eapply IHis_traceF; auto.
     + red. rewrite <- Heqi1. constructor. apply IHsuttF; auto.
 Qed.
@@ -133,24 +133,24 @@ Proof.
       constructor. eapply IHis_traceF; eauto.
   - constructor. right. apply CIH. intros. apply Hincl. constructor. auto.
   - assert (H: is_traceF (VisF e k) (TEventEnd e)) by constructor.
-    apply Hincl in H. destruct (observe t2); inv H.
+    apply Hincl in H. destruct (observe t2); dependent destruction H.
     + constructor.
       assert (forall tr, is_traceF (VisF e k) tr -> is_traceF (observe t) tr).
       {
         intros. rewrite is_traceF_tau. apply Hincl; auto.
       }
-      clear Hincl. rename H into Hincl.
+      clear Hincl. rename H0 into Hincl.
       remember (observe t). remember (TEventEnd _).
       generalize dependent t.
-      induction H1; intros; try inv Heqt0; auto.
+      induction H; intros; try dependent destruction Heqt0; auto.
       * constructor. eapply IHis_traceF; eauto.
         intros. rewrite is_traceF_tau. apply Hincl; auto.
-      * auto_inj_pair2. subst. constructor. intro. right. apply CIH. intros.
+      * constructor. intro. right. apply CIH. intros.
         assert (is_traceF (VisF e k) (TEventResponse e x tr)) by (constructor; auto).
-        apply Hincl in H0. inv H0. auto_inj_pair2. subst. auto.
-    + auto_inj_pair2. subst. constructor. intro. right. apply CIH. intros.
+        apply Hincl in H0. dependent destruction H0. auto.
+    + constructor. intro. right. apply CIH. intros.
       assert (is_traceF (VisF e k) (TEventResponse e x tr)) by (constructor; auto).
-      apply Hincl in H0. inv H0. auto_inj_pair2. subst. auto.
+      apply Hincl in H0. dependent destruction H0. auto.
 Qed.
 
 Theorem trace_incl_iff_sutt : forall {E R} (t1 t2 : itree E R),


### PR DESCRIPTION
I replaced `inv` by `dependent destruction` when the tactic `auto_inj_pair2` is needed.