### PR TITLE
Simplify euttG

### DIFF
--- a/theories/Eq/UpToTaus.v
+++ b/theories/Eq/UpToTaus.v
@@ -45,6 +45,39 @@ Import ITreeNotations.
 Local Open Scope itree.
 (* end hide *)
 
+
+(**** START: taken from Paco-4.0.1 ****)
+
+Lemma gpaco2_gpaco {T0 T1} gf (gf_mon: @monotone2 T0 T1 gf) clo r rg:
+  gpaco2 gf clo (gpaco2 gf clo r rg) (gupaco2 gf clo (rg \2/ r)) <2= gpaco2 gf clo r rg.
+Proof.
+  intros. apply gpaco2_unfold in PR; eauto.
+  econstructor. apply rclo2_rclo. eapply rclo2_mon. apply PR. clear x0 x1 PR. intros.
+  destruct PR; [|destruct H; apply IN].
+  apply rclo2_base. left. pstep.
+  eapply gf_mon. apply H. clear x0 x1 H. intros.
+  cut (@gupaco2 T0 T1 gf clo (rg \2/ r) x0 x1).
+  { intros. destruct H. eapply rclo2_mon. apply IN. intros.
+    destruct PR0; [|right; apply H].
+    left. eapply paco2_mon. apply H. intros. destruct PR0; apply H0.
+  }
+  apply gpaco2_gupaco; eauto. eapply gupaco2_mon. apply PR. intros.
+  destruct PR0; [apply H|].
+  eapply gpaco2_mon; [apply H|right|left]; intros; apply PR0.
+Qed.
+
+(** ** gpaco
+*)
+
+Tactic Notation "gpaco_" :=
+  match goal with
+  | [|- context[gpaco2]] => eapply gpaco2_gpaco; [eauto with paco|]
+  end.
+Ltac gpaco := repeat red; under_forall ltac:(gpaco_).
+
+(**** END ****)
+
+
 Section EUTTG.
 
 Context {E : Type -> Type} {R1 R2 : Type} (RR : R1 -> R2 -> Prop).
@@ -54,14 +87,14 @@ Definition transD := @eqit_trans_clo E R1 R2 true true false false.
 Definition bindC := @eqit_bind_clo E R1 R2 true true.
 
 Definition euttVC gH r :=
-  gupaco2 (eqit_ RR true true id) (eqitC true true) (transU (r \2/ gH)).
+  gupaco2 (eqit_ RR true true id) transD (transU (r \2/ gH)).
 
 Variant euttG rH rL gL gH t1 t2 : Prop :=
 | euttG_intro
     (IN: gpaco2 (@eqit_ E R1 R2 RR true true (euttVC gH))
-                (eqitC true true)
-                (transU rH \2/ transD rL)
-                (transU rH \2/ transD rL \2/ transD gL) t1 t2)
+                transD
+                (transU rH \2/ rL)
+                (transU rH \2/ rL \2/ gL) t1 t2)
 .
 
 Hint Unfold transU transD bindC euttVC.
@@ -435,35 +468,28 @@ Proof.
   revert_until CIH. gcofix CIH. intros.
   apply gpaco2_dist in IN; eauto with paco.
   destruct IN; cycle 1.
-  { gbase. apply rclo2_dist in H0; eauto with paco.
-    destruct H0; apply rclo_transD in H0;
-      eauto using transU_compose, transD_compose, transDleU.
+  { apply rclo_transD in H0; eauto with paco.
+    gclo. eapply transD_mon; eauto with paco.
   }
+  assert (LEM: upaco2 (eqit_ RR true true (euttVC RR (gH \2/ x)))
+                      (rclo2 transD (((transU rH \2/ rL) \2/ (gL \2/ x)) \2/ (transU rH \2/ rL)))
+               <2= gpaco2 (eqit_ RR true true (euttVC RR gH)) transD r r).
+  { intros m1 m2 [REL|REL].
+    - gbase. apply CIH1.
+      gpaco. gfinal. right.
+      eapply paco2_mon; eauto. intros.
+      apply rclo_transD in PR. gclo. eapply transD_mon; eauto. intros. gbase.
+      repeat destruct PR0 as [PR0|PR0]; eauto.
+    - apply rclo_transD in REL. gclo. eapply transD_mon; eauto. intros. gbase.
+      repeat destruct PR as [PR|PR]; eauto.
+  }
+
   punfold H0. gstep. red in H0 |- *.
   induction H0; eauto.
-  - econstructor. destruct REL.
-    + gbase. apply CIH1. gfinal. right.
-      eapply paco2_mon; eauto. intros.
-      repeat (apply rclo2_dist in PR; eauto with paco; destruct PR as [PR|PR]);
-        apply rclo_transD in PR; eauto 7 using transDleU, transU_compose, transD_compose.
-    + repeat (apply rclo2_dist in H0; eauto with paco; destruct H0 as [H0|H0]);
-        apply rclo_transD in H0; eauto 8 using transDleU, transU_compose, transD_compose with paco.
-      apply transD_compose in H0. gclo. eapply transD_mon; eauto. intros.
-      destruct PR; eauto with paco.
-  - red in REL. econstructor. intros. red.
-    eapply gupaco2_mon; eauto. intros.
-    apply transU_dist in PR. destruct PR; eauto; cycle 1.
-    { eapply transU_mon; eauto. intros; destruct PR; eauto with paco. }
-    eapply transU_mon; eauto. intros.
-    left. destruct PR.
-    + gbase. apply CIH1. gfinal. right.
-      eapply paco2_mon; eauto. intros.
-      repeat (apply rclo2_dist in PR; eauto with paco; destruct PR as [PR|PR]);
-        apply rclo_transD in PR; eauto 7 using transDleU, transU_compose, transD_compose.
-    + repeat (apply rclo2_dist in H1; eauto with paco; destruct H1 as [H1|H1]);
-        apply rclo_transD in H1; eauto 8 using transDleU, transU_compose, transD_compose with paco.
-      apply transD_compose in H1. gclo. eapply transD_mon; eauto. intros.
-      destruct PR; eauto with paco.
+  red in REL. econstructor. intros.
+  eapply gupaco2_mon; eauto. intros.
+  apply transU_dist in PR. destruct PR; eauto using transU_mon.
+  eapply transU_mon; eauto. intros; destruct PR; eauto with paco.
 Qed.
 
 End EUTTG_Properties2.
@@ -515,8 +541,8 @@ Lemma euttG_drop rH rL gL gH t1 t2:
 Proof.
   intros. destruct H. econstructor.
   eapply gpaco2_mon; eauto; intros.
-  - destruct PR; eauto using transDleU.
-  - destruct PR as [[]|]; eauto using transDleU.
+  - destruct PR; eauto using transU_id.
+  - destruct PR as [[]|]; eauto using transU_id.
 Qed.
 
 Lemma euttG_transU rH gH t1 t2:
@@ -528,7 +554,7 @@ Proof.
   eapply euttG_transU_aux; eauto using transU_compose.
   eapply transU_mon; eauto. intros. destruct PR.
   eapply gpaco2_mon; eauto; intros;
-    repeat destruct PR as [PR|PR]; eauto using transDleU.
+    repeat destruct PR as [PR|PR]; eauto using transU_id.
 Qed.
 
 (* Make a weakly guarded progress *)
@@ -559,7 +585,7 @@ Lemma euttG_base: forall rH rL gL gH t1 t2,
   rH t1 t2 \/ rL t1 t2 -> euttG rH rL gL gH t1 t2.
 Proof.
   intros. econstructor. gbase.
-  destruct H; [left|right]; econstructor; eauto; reflexivity.
+  destruct H; eauto using transU_id.
 Qed.
 
 (**


### PR DESCRIPTION
I simplified the definition of `euttG` as follows:
- from `gpaco2 ... (transU rH \2/ transD rL) (transU rH \2/ transD rL \2/ transD gL)`
- to `gpaco2 ... (transU rH \2/ rL) gL`