### PR TITLE
Remove aloop

### DIFF
--- a/examples/Nimp.v
+++ b/examples/Nimp.v
@@ -155,7 +155,7 @@ Qed.
 (* SAZ: the [~] notation for eutt wasn't working here. *)
 Lemma eval_one_loop : eval one_loop ≈ one_loop_tree.
 Proof.
-  einit. ecofix CIH.
+  einit. ecofix CIH. edrop.
   setoid_rewrite rec_as_interp.
   setoid_rewrite interp_bind.
   setoid_rewrite interp_vis.
@@ -164,13 +164,12 @@ Proof.
   setoid_rewrite bind_bind.
   setoid_rewrite bind_ret.
   setoid_rewrite bind_vis.
-  evis. intros. 
+  evis. intros.
   setoid_rewrite bind_ret.
   destruct v.
   - setoid_rewrite interp_ret. apply reflexivity.
   - setoid_rewrite interp_bind.
     setoid_rewrite interp_recursive_call.
-    setoid_rewrite tau_eutt.
     setoid_rewrite eval_skip.
     setoid_rewrite bind_ret.
     eauto with paco.

--- a/examples/ReadmeExample.v
+++ b/examples/ReadmeExample.v
@@ -32,7 +32,7 @@ Proof.
   intros n.              (*   echoed n *)
   unfold echoed, echo.   (* ≈ interp (handler n) (x <- trigger Input ;; Ret x) *)
   rewrite interp_bind.   (* ≈ x <- interp (handler n) Input ;; interp (handler n) (Ret x) *)
-  rewrite interp_trigger, tau_eutt.
+  rewrite interp_trigger.
                          (* ≈ x <- handler n _ Input ;; interp (handler n) (Ret x) *)
   cbn.                   (* ≈ x <- Ret n ;; interp (handler n) (Ret x) *)
   rewrite bind_ret.      (* ≈ interp (handler n) (Ret n) *)

--- a/theories/Basics/CategoryFacts.v
+++ b/theories/Basics/CategoryFacts.v
@@ -626,7 +626,7 @@ Context {Proper_case_ : forall a b c,
             @Proper (C a c -> C b c -> C _ c) (eq2 ==> eq2 ==> eq2) case_}.
 
 Context {Iter_bif : Iter C bif}.
-Context {Conway_C : Conway C bif}.
+Context {Iterative_C : Iterative C bif}.
 
 Global Instance Proper_loop {a b c}
   : @Proper (C (bif c a) (bif c b) -> C a b) (eq2 ==> eq2) loop.
@@ -669,7 +669,7 @@ Proof.
     unfold bimap, Bimap_Coproduct. (* TODO: by naturality of inr_ *)
     rewrite case_inr, cat_assoc.
     repeat (apply Proper_cat; try reflexivity).
-    apply conway_proper_iter.
+    apply iterative_proper_iter.
     rewrite cat_assoc.
     apply Proper_cat; try reflexivity.
     rewrite !cat_id_l.
@@ -706,7 +706,7 @@ Proof.
   rewrite cat_assoc.
   apply Proper_cat; try reflexivity.
   rewrite iter_natural.
-  apply conway_proper_iter; try reflexivity.
+  apply iterative_proper_iter; try reflexivity.
   rewrite !cat_assoc, !bimap_cat, !cat_id_l, !cat_id_r.
   reflexivity.
 Qed.
@@ -856,7 +856,7 @@ Proof.
 
     + rewrite cat_assoc, iter_natural.
       apply Proper_cat; try reflexivity.
-      apply conway_proper_iter.
+      apply iterative_proper_iter.
       rewrite !cat_assoc.
       rewrite case_inl.
       rewrite <- (cat_assoc inl_), inl_assoc_r.

--- a/theories/Basics/CategoryKleisli.v
+++ b/theories/Basics/CategoryKleisli.v
@@ -54,14 +54,7 @@ Section Instances.
   Global Instance CoprodInr_Kleisli : CoprodInr (Kleisli m) sum :=
     fun _ _ => pure inr.
 
-  (* SAZ: Maybe get rid of the Aloop constraint and move to Iter *)
-  (*
-  Global Instance Iter_Kleisli `{ALoop m} : Iter (Kleisli m) sum :=
-    fun a b (f : Kleisli m a (a + b)) (a0 : a) =>
-      aloop (fun ar =>
-               match ar with
-               | inl a => inl (f a)
-               | inr r => inr r
-               end) (inl a0) : m b.
-  *)
+  Global Instance Iter_Kleisli `{MonadIter m} : Iter (Kleisli m) sum :=
+    fun a b => Basics.iter.
+
 End Instances.

--- a/theories/Basics/CategoryOps.v
+++ b/theories/Basics/CategoryOps.v
@@ -298,7 +298,7 @@ Definition loop (a b c : obj)
 (**  For our purposes, [loop] and [iter] are mutually derivable.
   [loop] is a definition instead of another class to prevent the interface
   from growing too much. We originally started with traced categories but
-  iterative/Conway categories seem to provide more of the theory we need. *)
+  iterative categories seem to provide more of the theory we need. *)
 
 End Iteration.
 

--- a/theories/Basics/CategoryTheory.v
+++ b/theories/Basics/CategoryTheory.v
@@ -414,12 +414,12 @@ Class IterCodiagonal : Prop :=
 
 (* TODO: also define uniformity, requires a "purity" assumption. *)
 
-Class Conway : Prop :=
-  { conway_unfold :> IterUnfold
-  ; conway_natural :> IterNatural
-  ; conway_dinatural :> IterDinatural
-  ; conway_codiagonal :> IterCodiagonal
-  ; conway_proper_iter
+Class Iterative : Prop :=
+  { iterative_unfold :> IterUnfold
+  ; iterative_natural :> IterNatural
+  ; iterative_dinatural :> IterDinatural
+  ; iterative_codiagonal :> IterCodiagonal
+  ; iterative_proper_iter
       :> forall a b, @Proper (C a (bif a b) -> C a b) (eq2 ==> eq2) iter
   }.
 
@@ -440,4 +440,4 @@ Arguments iter_unfold {obj C Eq2_C Id_C Cat_C bif CoprodCase_C Iter_C IterUnfold
 Arguments iter_natural {obj C Eq2_C Id_C Cat_C bif CoprodCase_C CoprodInl_C CoprodInr_C Iter_C IterNatural} [a b c] f.
 Arguments iter_dinatural {obj C Eq2_C Id_C Cat_C bif CoprodCase_C CoprodInr_C Iter_C IterDinatural} [a b c] f.
 Arguments iter_codiagonal {obj C Eq2_C Id_C Cat_C bif CoprodCase_C CoprodInl_C Iter_C IterCodiagonal} [a b] f.
-Arguments conway_proper_iter {obj C Eq2_C Id_C Cat_C bif CoprodCase_C CoprodInl_C CoprodInr_C Iter_C Conway}.
+Arguments iterative_proper_iter {obj C Eq2_C Id_C Cat_C bif CoprodCase_C CoprodInl_C CoprodInr_C Iter_C Iterative}.

--- a/theories/Core/ITreeDefinition.v
+++ b/theories/Core/ITreeDefinition.v
@@ -105,7 +105,7 @@ Notation Vis e k := (go (VisF e k)).
 (** *** How to write cofixpoints *)
 
 (** We define cofixpoints in two steps: first a plain definition
-    (prefixed with an [_], e.g., [_bind], [_aloop]) defines the body
+    (prefixed with an [_], e.g., [_bind], [_iter]) defines the body
     of the function:
 
     - it takes the recursive call ([bind]) as a parameter;
@@ -182,20 +182,20 @@ Definition cat {E T U V}
   T -> itree E V :=
   fun t => bind' h (k t).
 
-(** [aloop]: See [Basics.Basics.ALoop]. *)
+(** [iter]: See [Basics.Basics.MonadIter]. *)
 
-Definition _aloop {E : Type -> Type} {R I : Type}
+Definition _iter {E : Type -> Type} {R I : Type}
            (tau : _)
-           (aloop_ : I -> itree E R)
-           (step_i : itree E I + R) : itree E R :=
+           (iter_ : I -> itree E R)
+           (step_i : I + R) : itree E R :=
   match step_i with
-  | inl cont => tau (ITree.bind cont aloop_)
+  | inl i => tau (iter_ i)
   | inr r => Ret r
   end.
 
-Definition aloop {E : Type -> Type} {R I: Type}
-           (step : I -> itree E I + R) : I -> itree E R :=
-  cofix aloop_ i := _aloop (fun t => Tau t) aloop_ (step i).
+Definition iter {E : Type -> Type} {R I: Type}
+           (step : I -> itree E (I + R)) : I -> itree E R :=
+  cofix iter_ i := bind (step i) (_iter (fun t => Tau t) iter_).
 
 (* note(gmm): There needs to be generic automation for monads to simplify
  * using the monad laws up to a setoid.
@@ -269,8 +269,8 @@ Instance Monad_itree {E} : Monad (itree E) :=
 ;  bind := fun T U t k => @ITree.bind' E T U k t
 |}.
 
-Instance ALoop_itree {E} : ALoop (itree E) :=
-  fun _ _ => ITree.aloop.
+Instance MonadIter_itree {E} : MonadIter (itree E) :=
+  fun _ _ => ITree.iter.
 
 (** ** Tactics *)
 

--- a/theories/Core/KTree.v
+++ b/theories/Core/KTree.v
@@ -4,9 +4,9 @@
 
 (* begin hide *)
 From ITree Require Import
+     Basics.Basics
      Basics.CategoryOps
      Basics.CategoryKleisli
-     Basics.Basics
      Basics.MonadTheory
      Basics.CategoryKleisli
      Basics.Function
@@ -47,14 +47,6 @@ Context {E : Type -> Type}.
 Local Notation ktree := (ktree E).
 
 (** *** Traced monoidal category *)
-
-Global Instance Iter_ktree : Iter ktree sum :=
-  fun a b (f : ktree a (a + b)) (x0 : a) =>
-    ITree.aloop (fun xr =>
-      match xr with
-      | inl x => inl (f x)
-      | inr r => inr r
-      end) (inl x0) : itree E b.
 
 (** The trace operator here is [loop].
 

--- a/theories/Core/KTreeFacts.v
+++ b/theories/Core/KTreeFacts.v
@@ -29,66 +29,78 @@ Local Open Scope itree.
 
 (** ** [ITree.aloop] *)
 
-Lemma bind_aloop {E A B C} (f : A -> itree E A + B) (g : B -> itree E B + C): forall x,
-    (ITree.aloop f x >>= ITree.aloop g)
-  ≈ ITree.aloop (fun ab =>
+Lemma bind_iter {E A B C} (f : A -> itree E (A + B)) (g : B -> itree E (B + C))
+  : forall x,
+    (ITree.iter f x >>= ITree.iter g)
+  ≈ ITree.iter (fun ab =>
        match ab with
-       | inl a => inl (ITree._aloop id (fun a => Ret (inl a))
-                                    (bimap (id_ _) inr (f a)))
-       | inr b => apply_Fun (bimap (ITree.map inr) (id_ _)) (g b)
+       | inl a => ITree.map inl (f a)
+       | inr b => ITree.map (bimap inr (id_ _)) (g b)
        end) (inl x).
 Proof.
   einit. ecofix CIH. intros.
-  rewrite !unfold_aloop. unfold ITree._aloop.
-  destruct (f x) as [t | b]; cbn.
-  - unfold id. rewrite bind_tau. etau. rewrite !bind_bind.
-    ebind. econstructor; try reflexivity.
-    intros. subst. rewrite bind_ret. eauto with paco.
-  - rewrite bind_ret, tau_eutt, bind_ret.
+  rewrite !unfold_iter. unfold ITree._iter.
+  rewrite bind_map, bind_bind.
+  ebind; econstructor; try reflexivity.
+  intros [a | b] _ [].
+  - rewrite bind_tau. etau.
+  - rewrite bind_ret, tau_eutt.
     revert b. ecofix CIH'. intros.
-    rewrite !unfold_aloop. unfold ITree._aloop.
-    destruct (g b) as [t' | c]; cbn; eauto with paco.
-    rewrite bind_map. etau.
-    ebind. econstructor; try reflexivity.
-    intros. subst. eauto with paco.
+    rewrite !unfold_iter. unfold ITree._iter.
+    rewrite bind_map.
+    ebind; econstructor; try reflexivity.
+    intros [b' | c] _ []; cbn.
+    + etau.
+    + reflexivity.
 Qed.
 
-Lemma eq_itree_aloop' {E I1 I2 R1 R2}
+Lemma eq_itree_iter' {E I1 I2 R1 R2}
       (RI : I1 -> I2 -> Prop)
       (RR : R1 -> R2 -> Prop)
-      (body1 : I1 -> itree E I1 + R1)
-      (body2 : I2 -> itree E I2 + R2)
+      (body1 : I1 -> itree E (I1 + R1))
+      (body2 : I2 -> itree E (I2 + R2))
       (eutt_body
-       : forall j1 j2, RI j1 j2 -> sum_rel (eq_itree RI) RR (body1 j1) (body2 j2))
+       : forall j1 j2, RI j1 j2 -> eq_itree (sum_rel RI RR) (body1 j1) (body2 j2))
   : forall (i1 : I1) (i2 : I2) (RI_i : RI i1 i2),
-    @eq_itree E _ _ RR (ITree.aloop body1 i1) (ITree.aloop body2 i2).
+    @eq_itree E _ _ RR (ITree.iter body1 i1) (ITree.iter body2 i2).
 Proof.
   ginit. gcofix CIH. intros.
   specialize (eutt_body i1 i2 RI_i).
-  do 2 rewrite unfold_aloop.
-  destruct eutt_body; cbn; eauto with paco.
-  gstep. econstructor. guclo eqit_clo_bind.
-  gstep. constructor; eauto.
+  do 2 rewrite unfold_iter.
+  guclo eqit_clo_bind; econstructor; eauto.
+  intros ? ? []; gstep; econstructor; auto with paco.
 Qed.
 
-Lemma eutt_aloop' {E I1 I2 R1 R2}
+Lemma eutt_iter' {E I1 I2 R1 R2}
       (RI : I1 -> I2 -> Prop)
       (RR : R1 -> R2 -> Prop)
-      (body1 : I1 -> itree E I1 + R1)
-      (body2 : I2 -> itree E I2 + R2)
+      (body1 : I1 -> itree E (I1 + R1))
+      (body2 : I2 -> itree E (I2 + R2))
       (eutt_body
-       : forall j1 j2, RI j1 j2 -> sum_rel (eutt RI) RR (body1 j1) (body2 j2))
+       : forall j1 j2, RI j1 j2 -> eutt (sum_rel RI RR) (body1 j1) (body2 j2))
   : forall (i1 : I1) (i2 : I2) (RI_i : RI i1 i2),
-    @eutt E _ _ RR (ITree.aloop body1 i1) (ITree.aloop body2 i2).
+    @eutt E _ _ RR (ITree.iter body1 i1) (ITree.iter body2 i2).
 Proof.
   einit. ecofix CIH. intros.
   specialize (eutt_body i1 i2 RI_i).
-  do 2 rewrite unfold_aloop.
-  destruct eutt_body; cbn; eauto with paco.
-  etau. ebind. econstructor; eauto with paco.
+  do 2 rewrite unfold_iter.
+  ebind; econstructor; eauto with paco.
+  intros ? ? [].
+  - etau.
+  - eauto with paco.
 Qed.
 
 (** ** [iter] *)
+
+Lemma eqit_mon {E R1 R2} (RR RR' : R1 -> R2 -> Prop) b1 b2 :
+  (RR <2= RR') ->
+  (eqit RR b1 b2 <2= @eqit E _ _ RR' b1 b2).
+Proof.
+  intros.
+  eapply paco2_mon_bot; eauto.
+  intros ? ? ?. red.
+  induction 1; auto.
+Qed.
 
 Instance eq_itree_iter {E A B} :
   @Proper ((A -> itree E (A + B)) -> A -> itree E B)
@@ -96,9 +108,10 @@ Instance eq_itree_iter {E A B} :
           iter.
 Proof.
   intros body1 body2 EQ_BODY a. repeat red in EQ_BODY.
-  unfold iter, Iter_ktree.
-  eapply (eq_itree_aloop' eq).
-  intros [] ? []; constructor; auto. reflexivity.
+  unfold iter, Iter_Kleisli.
+  eapply (eq_itree_iter' eq); auto.
+  intros; eapply eqit_mon, EQ_BODY; auto.
+  intros [] _ []; auto.
 Qed.
 
 Instance eutt_iter {E A B} :
@@ -107,9 +120,10 @@ Instance eutt_iter {E A B} :
           iter.
 Proof.
   intros body1 body2 EQ_BODY a. repeat red in EQ_BODY.
-  unfold iter, Iter_ktree.
-  eapply (eutt_aloop' eq).
-  intros [] ? []; constructor; auto. reflexivity.
+  unfold iter, Iter_Kleisli.
+  eapply (eutt_iter' eq); auto.
+  intros ? _ []; eapply eqit_mon, EQ_BODY; auto.
+  intros [] _ []; auto.
 Qed.
 
 Definition eutt_iter_gen {F A B R S} :
@@ -119,10 +133,7 @@ Definition eutt_iter_gen {F A B R S} :
 Proof.
   do 3 red;
   intros body1 body2 EQ_BODY x y Hxy. red in EQ_BODY.
-  unfold iter, Iter_ktree.
-  eapply (eutt_aloop' (sum_rel R S)); intros.
-  - destruct H; constructor; auto.
-  - constructor; auto.
+  eapply eutt_iter'; eauto.
 Qed.
 
 Instance eq2_ktree_iter {E A B} :
@@ -131,31 +142,28 @@ Instance eq2_ktree_iter {E A B} :
           iter.
 Proof. apply eutt_iter. Qed.
 
-Section KTreeConway.
+Section KTreeIterative.
 
 Lemma unfold_iter_ktree {E A B} (f : ktree E A (A + B)) (a0 : A) :
-  iter f a0 ≅ Tau (
+  iter f a0 ≅
     ab <- f a0 ;;
     match ab with
-    | inl a => iter f a
+    | inl a => Tau (iter f a)
     | inr b => Ret b
-    end).
+    end.
 Proof.
-  unfold iter, Iter_ktree, cat.
-  rewrite unfold_aloop; cbn.
-  pstep; constructor; left.
+  unfold iter, Iter_Kleisli, Basics.iter, MonadIter_itree, cat.
+  rewrite unfold_iter; cbn.
   eapply eqit_bind; try reflexivity.
-  intros [].
-  reflexivity.
-  rewrite unfold_aloop; cbn.
-  reflexivity.
 Qed.
 
 Instance IterUnfold_ktree {E} : IterUnfold (ktree E) sum.
 Proof.
   repeat intro.
-  rewrite unfold_iter_ktree, tau_eutt.
-  reflexivity.
+  rewrite unfold_iter_ktree.
+  do 2 red. unfold cat, Cat_Kleisli; cbn.
+  eapply eutt_clo_bind; try reflexivity.
+  intros [] ? []; try rewrite tau_eutt; reflexivity.
 Qed.
 
 Instance IterNatural_ktree {E} : IterNatural (ktree E) sum.
@@ -166,17 +174,12 @@ Proof.
   revert a0.
   einit. ecofix CIH. intros.
   rewrite 2 unfold_iter_ktree.
-  rewrite bind_tau.
-  estep; econstructor.
   rewrite !bind_bind.
   ebind; econstructor; try reflexivity.
   intros [] ? [].
-  rewrite 2 bind_ret.
-  eauto with paco.
-  rewrite bind_bind.
-  setoid_rewrite bind_ret.
-  rewrite bind_ret2.
-  reflexivity.
+  - rewrite bind_tau, 2 bind_ret. etau.
+  - rewrite bind_ret, !bind_bind. setoid_rewrite bind_ret. rewrite bind_ret2.
+    reflexivity.
 Qed.
 
 Lemma iter_dinatural_ktree {E A B C}
@@ -187,22 +190,20 @@ Lemma iter_dinatural_ktree {E A B C}
       | inl c => Tau (g c)
       | inr b => Ret (inr b)
       end) a0
-  ≅ Tau (
-       cb <- f a0 ;;
-       match cb with
-       | inl c0 => iter (fun c =>
+  ≅ cb <- f a0 ;;
+     match cb with
+     | inl c0 => Tau (iter (fun c =>
          ab <- g c ;;
          match ab with
          | inl a => Tau (f a)
          | inr b => Ret (inr b)
-         end) c0
-       | inr b => Ret b
-       end).
+         end) c0)
+     | inr b => Ret b
+     end.
 Proof.
   revert A B C f g a0.
   ginit. gcofix CIH. intros.
   rewrite unfold_iter_ktree.
-  gstep; econstructor.
   rewrite bind_bind.
   guclo eqit_clo_bind. econstructor. try reflexivity.
   intros [] ? [].
@@ -211,16 +212,14 @@ Proof.
     rewrite unfold_iter_ktree.
     gstep; econstructor.
     rewrite bind_bind.
-    guclo eqit_clo_bind. econstructor. try reflexivity.
+    guclo eqit_clo_bind; econstructor; try reflexivity.
     intros [] ? [].
-    { rewrite bind_tau.
+    * rewrite bind_tau.
+      gstep; constructor.
       eauto with paco.
-    }
-    { rewrite bind_ret. gstep; econstructor; auto.
-    }
+    * rewrite bind_ret. gstep; econstructor; auto.
   }
-  { rewrite bind_ret. gstep; constructor; auto.
-  }
+  { rewrite bind_ret. gstep; constructor; auto. }
 Qed.
 
 Instance IterDinatural_ktree {E} : IterDinatural (ktree E) sum.
@@ -241,11 +240,11 @@ Proof.
     rewrite tau_eutt; reflexivity.
     reflexivity.
   - rewrite iter_dinatural_ktree.
-    rewrite tau_eutt.
     eapply eutt_clo_bind.
     reflexivity.
     intros [] ? [].
-    + apply eutt_iter; intros x.
+    + rewrite tau_eutt.
+      apply eutt_iter; intros x.
       eapply eutt_clo_bind.
       reflexivity.
       intros [] ? [].
@@ -256,32 +255,35 @@ Qed.
 
 Lemma iter_codiagonal_ktree {E A B} (f : ktree E A (A + (A + B))) (a0 : A)
   : iter (iter f) a0
-  ≅ Tau (iter (fun a =>
+  ≅ iter (fun a =>
        r <- f a ;;
        match r with
        | inl a' => Ret (inl a')
-       | inr (inl a') => Tau (Ret (inl a'))
+       | inr (inl a') => Ret (inl a')
        | inr (inr b) => Ret (inr b)
-       end) a0).
+       end) a0.
 Proof.
   revert a0.
   ginit. gcofix CIH. intros.
   rewrite unfold_iter_ktree.
   rewrite (unfold_iter_ktree (fun _ => _ _ _)).
-  gstep; constructor.
-  revert a0.
-  gcofix CIH'. intros.
-  rewrite bind_bind.
-  rewrite unfold_iter_ktree.
-  rewrite bind_tau, bind_bind.
-  gstep; constructor.
+  rewrite unfold_iter_ktree, !bind_bind.
   guclo eqit_clo_bind. econstructor. reflexivity.
   intros [| []] ? [].
-  - rewrite bind_ret.
+  - rewrite bind_ret, bind_tau.
+    gstep. constructor.
+    revert a.
+    gcofix CIH'. intros.
+    rewrite unfold_iter_ktree.
     rewrite (unfold_iter_ktree (fun _ => _ _ _)).
-    auto with paco.
-  - rewrite bind_tau, 2 bind_ret.
-    auto with paco.
+    rewrite !bind_bind.
+    guclo eqit_clo_bind. econstructor. reflexivity.
+    intros [| []] ? [].
+    + rewrite bind_tau, bind_ret. gstep; constructor; auto with paco.
+    + rewrite 2 bind_ret. gstep; constructor; auto with paco.
+    + rewrite 2 bind_ret. gstep; constructor; auto.
+  - rewrite 2 bind_ret.
+    gstep; constructor; auto with paco.
   - rewrite 2 bind_ret.
     gstep; reflexivity.
 Qed.
@@ -292,7 +294,6 @@ Proof.
   unfold bimap, Bimap_Coproduct, case_, CoprodCase_Kleisli, case_sum, cat, Cat_Kleisli.
   cbn.
   rewrite iter_codiagonal_ktree.
-  rewrite tau_eutt.
   apply eutt_iter.
   intros a1.
   eapply eutt_clo_bind.
@@ -300,9 +301,9 @@ Proof.
   intros [| []] ? []; rewrite ?tau_eutt; reflexivity.
 Qed.
 
-Global Instance Conway_ktree {E} : Conway (ktree E) sum.
+Global Instance Iterative_ktree {E} : Iterative (ktree E) sum.
 Proof.
   split; typeclasses eauto.
 Qed.
 
-End KTreeConway.
+End KTreeIterative.

--- a/theories/Core/SubKTreeFacts.v
+++ b/theories/Core/SubKTreeFacts.v
@@ -839,7 +839,7 @@ Section Facts.
       reflexivity.
     Qed.
 
-    Global Instance Conway_sktree : Conway sktree isum.
+    Global Instance Iterative_sktree : Iterative sktree isum.
     Proof.
       split; typeclasses eauto.
     Qed.

--- a/theories/Eq/Eq.v
+++ b/theories/Eq/Eq.v
@@ -359,7 +359,7 @@ Proof.
 Qed.
 
 Global Instance eq_sub_euttge:
-  subrelation (@eqit E _ _ RR false false) (eqit RR true false).
+  subrelation (@eq_itree E _ _ RR) (euttge RR).
 Proof.
   ginit. gcofix CIH. intros.
   punfold H0. gstep. red in H0 |- *.
@@ -367,7 +367,7 @@ Proof.
 Qed.  
 
 Global Instance euttge_sub_eutt:
-  subrelation (@eqit E _ _ RR true false) (eqit RR true true).
+  subrelation (@euttge E _ _ RR) (eutt RR).
 Proof.
   ginit. gcofix CIH. intros.
   punfold H0. gstep. red in H0 |- *.
@@ -375,7 +375,7 @@ Proof.
 Qed.
 
 Global Instance eq_sub_eutt:
-  subrelation (@eqit E _ _ RR false false) (eqit RR true true).
+  subrelation (@eq_itree E _ _ RR) (eutt RR).
 Proof.
   red; intros. eapply euttge_sub_eutt. eapply eq_sub_euttge. apply H.
 Qed.
@@ -760,8 +760,8 @@ Proof.
   apply Reflexive_eqit; eauto.
 Qed.
 
-Lemma unfold_aloop {E A B} (f : A -> itree E A + B) (x : A) :
-  (ITree.aloop f x) ≅ (ITree._aloop (fun t => Tau t) (ITree.aloop f) (f x)).
+Lemma unfold_iter {E A B} (f : A -> itree E (A + B)) (x : A) :
+  (ITree.iter f x) ≅ (f x >>= ITree._iter (fun t => Tau t) (ITree.iter f)).
 Proof.
   rewrite unfold_aloop_. reflexivity.
 Qed.

--- a/theories/Eq/Shallow.v
+++ b/theories/Eq/Shallow.v
@@ -96,10 +96,10 @@ Proof. apply @unfold_bind_. Qed.
 
 (** Unfolding lemma for [aloop]. There is also a variant [unfold_aloop]
     without [Tau]. *)
-Lemma unfold_aloop_ {E A B} (f : A -> itree E A + B) (x : A) :
+Lemma unfold_aloop_ {E A B} (f : A -> itree E (A + B)) (x : A) :
   observing eq
-    (ITree.aloop f x)
-    (ITree._aloop (fun t => Tau t) (ITree.aloop f) (f x)).
+    (ITree.iter f x)
+    (ITree.bind (f x) (ITree._iter (fun t => Tau t) (ITree.iter f))).
 Proof.
   constructor; reflexivity.
 Qed.

--- a/theories/Events/MapDefaultFacts.v
+++ b/theories/Events/MapDefaultFacts.v
@@ -191,8 +191,7 @@ Section MapFacts.
     destruct (observe t).
     - gstep. constructor. constructor; auto.
     - gstep. constructor. gbase. apply CH. assumption.
-    - gstep. constructor.
-      guclo eqit_clo_bind. econstructor.
+    - guclo eqit_clo_bind. econstructor.
       unfold pure_state.
       destruct e.
       + cbn. eapply eqit_mon. 4 : { apply handle_map_eq. assumption. }
@@ -200,6 +199,7 @@ Section MapFacts.
       + cbn. apply eqit_Vis. intros.  apply eqit_Ret. constructor; auto.
       + intros. destruct u1. destruct u2. cbn.
         inversion H. subst.
+        gstep; constructor.
         gbase. apply CH. assumption.
   Qed.
  
@@ -218,8 +218,7 @@ Section MapFacts.
     induction H0; intros; subst; simpl; pclearbot.
     - eret.
     - etau.
-    - etau.
-      ebind.
+    - ebind.
       apply pbc_intro_h with (RU := prod_rel (@eq_map _ _ _ _ d) eq).
       { (* SAZ: I must be missing some lemma that should solve this case *)
         unfold case_. unfold Case_sum1, case_sum1.
@@ -229,8 +228,7 @@ Section MapFacts.
       } 
       intros.
       inversion H. subst.
-      simpl.
-      ebase.
+      estep; constructor. ebase.
     - rewrite tau_eutt, unfold_interp_state.
       eauto.
     - rewrite tau_eutt, unfold_interp_state.

--- a/theories/Events/State.v
+++ b/theories/Events/State.v
@@ -29,10 +29,10 @@ Open Scope itree_scope.
 
 Definition interp_state {E M S}
            {FM : Functor M} {MM : Monad M}
-           {LM : ALoop M} (h : E ~> stateT S M) :
+           {IM : MonadIter M} (h : E ~> stateT S M) :
   itree E ~> stateT S M := interp h.
 
-Arguments interp_state {E M S FM MM LM} h [T].
+Arguments interp_state {E M S FM MM IM} h [T].
 
 Section State.
 
@@ -122,11 +122,11 @@ Section eff_hom_e.
   { eval : forall t, E t -> itree F (eff_hom_e * t) }.
 
   Definition interp_e (h : eff_hom_e) : itree E ~> itree F := fun R t =>
-    ITree.aloop (fun '(s, t) =>
+    ITree.iter (fun '(s, t) =>
       match t.(observe) with
-      | RetF r => inr r
-      | TauF t => inl (Ret (s, t))
-      | VisF e k => inl (ITree.map (fun '(s, x) => (s, k x)) (h.(eval) _ e))
+      | RetF r => Ret (inr r)
+      | TauF t => Ret (inl (s, t))
+      | VisF e k => ITree.map (fun '(s, x) => inl (s, k x)) (h.(eval) _ e)
       end) (h, t).
 
 End eff_hom_e.

--- a/theories/Events/StateFacts.v
+++ b/theories/Events/StateFacts.v
@@ -39,7 +39,7 @@ Definition _interp_state {E F S R}
   match ot with
   | RetF r => Ret (s, r)
   | TauF t => Tau (interp_state f t s)
-  | VisF e k => Tau (f _ e s >>= (fun sx => interp_state f (k (snd sx)) (fst sx)))
+  | VisF e k => f _ e s >>= (fun sx => Tau (interp_state f (k (snd sx)) (fst sx)))
   end.
 
 Lemma unfold_interp_state {E F S R} (h : E ~> Monads.stateT S (itree F))
@@ -48,14 +48,14 @@ Lemma unfold_interp_state {E F S R} (h : E ~> Monads.stateT S (itree F))
       (interp_state h t s)
       (_interp_state h (observe t) s).
 Proof.
-  unfold interp_state, interp, aloop, ALoop_stateT0, aloop, ALoop_itree.
-  rewrite unfold_aloop.
+  unfold interp_state, interp, Basics.iter, MonadIter_stateT0, Basics.iter, MonadIter_itree; cbn.
+  rewrite unfold_iter; cbn.
   destruct observe; cbn.
-  - reflexivity.
-  - rewrite bind_ret.
+  - rewrite 2 bind_ret. reflexivity.
+  - rewrite 2 bind_ret.
     reflexivity.
-  - rewrite bind_map. pstep. econstructor. left.
-    eapply eqit_bind; reflexivity.
+  - rewrite bind_map, bind_bind; cbn. setoid_rewrite bind_ret.
+    apply eqit_bind; reflexivity.
 Qed.
 
 Instance eq_itree_interp_state {E F S R} (h : E ~> Monads.stateT S (itree F)) :
@@ -63,14 +63,15 @@ Instance eq_itree_interp_state {E F S R} (h : E ~> Monads.stateT S (itree F)) :
          (@interp_state _ _ _ _ _ _ h R).
 Proof.
   revert_until R.
-  ginit. gcofix CIH. intros h x y H0 x2 y0 H1.
+  ginit. gcofix CIH. intros h x y H0 x2 _ [].
   rewrite !unfold_interp_state.
-  unfold _interp_state.
   punfold H0; repeat red in H0.
-  gstep. destruct (observe x); dependent destruction H0; try discriminate; simpobs; subst; pclearbot; constructor; eauto with paco.
-  guclo eqit_clo_bind. econstructor.
-  + reflexivity.
-  + intros [] _ []. auto with paco.
+  destruct H0; subst; pclearbot; try discriminate; cbn.
+  - gstep; constructor; auto.
+  - gstep; constructor; auto with paco.
+  - guclo eqit_clo_bind. econstructor.
+    + reflexivity.
+    + intros [] _ []. gstep; constructor; auto with paco.
 Qed.
 
 Lemma interp_state_ret {E F : Type -> Type} {R S : Type}
@@ -84,7 +85,7 @@ Qed.
 Lemma interp_state_vis {E F : Type -> Type} {S T U : Type}
       (e : E T) (k : T -> itree E U) (h : E ~> Monads.stateT S (itree F)) (s : S)
   : interp_state h (Vis e k) s
-  ≅ Tau (h T e s >>= fun sx => interp_state h (k (snd sx)) (fst sx)).
+  ≅ h T e s >>= fun sx => Tau (interp_state h (k (snd sx)) (fst sx)).
 Proof.
   rewrite unfold_interp_state; reflexivity.
 Qed.
@@ -98,14 +99,11 @@ Qed.
 
 Lemma interp_state_trigger {E F : Type -> Type} {R S : Type}
       (e : E R) (f : E ~> Monads.stateT S (itree F)) (s : S)
-  : (interp_state f (ITree.trigger e) s) ≅ Tau (f _ e s).
+  : (interp_state f (ITree.trigger e) s) ≅ (f _ e s >>= fun x => Tau (Ret x)).
 Proof.
   unfold ITree.trigger. rewrite interp_state_vis.
-  pstep. econstructor. left.
-  rewrite <- (bind_ret2 (f R e s)) at 2.
-  eapply eqit_bind.
-  - intros []; rewrite interp_state_ret; reflexivity.
-  - reflexivity.
+  eapply eqit_bind; try reflexivity.
+  intros []. rewrite interp_state_ret. reflexivity.
 Qed.
 
 Lemma interp_state_bind {E F : Type -> Type} {A B S : Type}
@@ -126,11 +124,12 @@ Proof.
     apply reflexivity.
   - cbn. rewrite !bind_tau, interp_state_tau.
     gstep. econstructor. gbase. apply CIH.
-  - cbn. rewrite interp_state_vis, bind_tau, bind_bind.
-    gstep. constructor.
+  - cbn. rewrite interp_state_vis, bind_bind.
     guclo eqit_clo_bind. econstructor.
     + reflexivity.
-    + intros u2 ? []. specialize (CIH _ (k0 (snd u2)) k (fst u2)).
+    + intros u2 ? [].
+      rewrite bind_tau.
+      gstep; constructor.
       auto with paco.
 Qed.
 
@@ -145,39 +144,37 @@ Proof.
   induction H0; intros; subst; simpl; pclearbot.
   - eret.
   - etau.
-  - etau. ebind. econstructor; [reflexivity|].
-    intros; subst. ebase.
-  - rewrite tau_eutt, unfold_interp_state. eauto.
-  - rewrite tau_eutt, unfold_interp_state. eauto.
+  - ebind. econstructor; [reflexivity|].
+    intros; subst.
+    etau. ebase.
+  - rewrite tau_eutt, unfold_interp_state; eauto.
+  - rewrite tau_eutt, unfold_interp_state; eauto.
 Qed.
 
 Lemma eutt_interp_state_aloop {E F S I I' A A'}
       (RA : A -> A' -> Prop) (RI : I -> I' -> Prop)
       (RS : S -> S -> Prop)
       (h : E ~> Monads.stateT S (itree F))
-      (t1 : I -> itree E I + A)
-      (t2 : I' -> itree E I' + A'):
+      (t1 : I -> itree E (I + A))
+      (t2 : I' -> itree E (I' + A')):
   (forall i i' s1 s2, RS s1 s2 -> RI i i' ->
-     sum_rel (fun u1 u2 =>
-                eutt (fun a b => RS (fst a) (fst b) /\ RI (snd a) (snd b))
-                     (interp_state h u1 s1)
-                     (interp_state h u2 s2))
-             RA (t1 i) (t2 i')) ->
+     eutt (prod_rel RS (sum_rel RI RA))
+                     (interp_state h (t1 i) s1)
+                     (interp_state h (t2 i') s2)) ->
   (forall i i' s1 s2, RS s1 s2 -> RI i i' ->
      eutt (fun a b => RS (fst a) (fst b) /\ RA (snd a) (snd b))
-          (interp_state h (ITree.aloop t1 i) s1)
-          (interp_state h (ITree.aloop t2 i') s2)).
+          (interp_state h (ITree.iter t1 i) s1)
+          (interp_state h (ITree.iter t2 i') s2)).
 Proof.
   intro Ht.
   einit. ecofix CIH. intros.
-  rewrite 2 unfold_aloop.
-  destruct (Ht i i' s1 s2); cbn; auto.
-  - rewrite 2 interp_state_tau, 2 interp_state_bind.
-    etau. constructor.
-    ebind. econstructor; eauto.
-    intros [s1' i1'] [s2' i2'] [? ?]; cbn.
-    auto with paco.
-  - rewrite 2 interp_state_ret. eret.
+  rewrite 2 unfold_iter.
+  rewrite 2 interp_state_bind.
+  ebind; econstructor.
+  - eapply Ht; auto.
+  - intros [s1' i1'] [s2' i2'] [? ? ? ? ? []]; cbn.
+    + rewrite 2 interp_state_tau. auto with paco.
+    + rewrite 2 interp_state_ret. auto with paco.
 Qed.
 
 Lemma eutt_interp_state_iter {E F S A A' B B'}
@@ -188,7 +185,7 @@ Lemma eutt_interp_state_iter {E F S A A' B B'}
       (t2 : A' -> itree E (A' + B')) :
   (forall ca ca' s1 s2, RS s1 s2 ->
                         RA ca ca' ->
-     eutt (fun a b => RS (fst a) (fst b) /\ sum_rel RA RB (snd a) (snd b))
+     eutt (prod_rel RS (sum_rel RA RB))
           (interp_state h (t1 ca) s1)
           (interp_state h (t2 ca') s2)) ->
   (forall a a' s1 s2, RS s1 s2 -> RA a a' ->
@@ -196,11 +193,7 @@ Lemma eutt_interp_state_iter {E F S A A' B B'}
           (interp_state h (KTree.iter t1 a) s1)
           (interp_state h (KTree.iter t2 a') s2)).
 Proof.
-  intros.
-  unfold iter, Iter_ktree.
-  eapply (eutt_interp_state_aloop _ (sum_rel _ _)); auto.
-  - intros ? ? ? ? ? []; constructor; auto.
-  - constructor; auto.
+  apply eutt_interp_state_aloop.
 Qed.
 
 Lemma eutt_interp_state_loop {E F S A B C} (RS : S -> S -> Prop)
@@ -238,24 +231,25 @@ Definition state_eq {E S X}
   : (stateT S (itree E) X) -> (stateT S (itree E) X) -> Prop :=
   fun t1 t2 => forall s, eq_itree eq (t1 s) (t2 s).
 
-Lemma interp_state_aloop {E F } S (f : E ~> stateT S (itree F)) {I A}
-      (t  : I -> itree E I + A)
-      (t' : I -> stateT S (itree F) I + A)
-      (EQ_t : forall i, sum_rel (fun u u' => state_eq (State.interp_state f u) u') eq (t i) (t' i))
-  : forall i, state_eq (State.interp_state f (ITree.aloop t i))
-                  (aloop t' i).
+Lemma interp_state_iter {E F } S (f : E ~> stateT S (itree F)) {I A}
+      (t  : I -> itree E (I + A))
+      (t' : I -> stateT S (itree F) (I + A))
+      (EQ_t : forall i, state_eq (State.interp_state f (t i)) (t' i))
+  : forall i, state_eq (State.interp_state f (ITree.iter t i))
+                  (Basics.iter t' i).
 Proof.
+  unfold Basics.iter, MonadIter_stateT0, Basics.iter, MonadIter_itree in *; cbn.
   ginit. gcofix CIH; intros i s.
-  unfold aloop, ALoop_stateT0, aloop, ALoop_itree in *.
-  rewrite 2 unfold_aloop. simpl.
-  destruct (EQ_t i); cbn.
-  - rewrite interp_state_tau, interp_state_bind.
-    gstep.
-    constructor.
-    guclo eqit_clo_bind; econstructor; eauto.
-    apply H.
-    intros [s' i'] _ []. simpl.
-    auto with paco.
-  - rewrite interp_state_ret. gstep. constructor; auto. subst; auto.
+  rewrite 2 unfold_iter; cbn.
+  rewrite !bind_bind.
+  setoid_rewrite bind_ret.
+  rewrite interp_state_bind.
+  guclo eqit_clo_bind; econstructor; eauto.
+  - apply EQ_t.
+  - intros [s' []] _ []; cbn.
+    + rewrite interp_state_tau.
+      gstep; constructor.
+      auto with paco.
+    + rewrite interp_state_ret; apply reflexivity.
 Qed.
 

--- a/theories/Events/StateKleisli.v
+++ b/theories/Events/StateKleisli.v
@@ -73,7 +73,7 @@ Section Kleisli.
   Qed.
       
   Context {IM: Iter (Kleisli m) sum}.
-  Context {CM: Conway (Kleisli m) sum}.
+  Context {CM: Iterative (Kleisli m) sum}.
 
   Definition iso {a b:Type} (sab : S * (a + b)) : (S * a) + (S * b) :=
     match sab with
@@ -142,7 +142,7 @@ Section Kleisli.
     destruct CM.
     repeat red.
     intros a b x y H a0 s.
-    apply conway_proper_iter.
+    apply iterative_proper_iter.
     repeat red.
     destruct a1.
     cbn.
@@ -160,7 +160,7 @@ Section Kleisli.
   intros a0 s.
   unfold cat, Cat_Kleisli.
   unfold iter, Iter_stateTM.
-  rewrite conway_unfold.  (* SAZ: why isn't iter_unfold exposed here? *)
+  rewrite iterative_unfold.  (* SAZ: why isn't iter_unfold exposed here? *)
   unfold cat, Cat_Kleisli.
   simpl.
   rewrite bind_bind.
@@ -180,8 +180,8 @@ Section Kleisli.
     intros a b c f g.
     repeat red.
     intros a0 s.
-    setoid_rewrite conway_natural.
-    apply conway_proper_iter.
+    setoid_rewrite iterative_natural.
+    apply iterative_proper_iter.
     repeat red.
     destruct a1. 
     unfold cat, Cat_Kleisli.
@@ -257,9 +257,9 @@ Section Kleisli.
     intros a b c f g a0 a1. 
     unfold iter, Iter_stateTM.
     eapply transitivity.
-    eapply conway_proper_iter.
+    eapply iterative_proper_iter.
     apply iter_dinatural_helper.
-    rewrite conway_dinatural.
+    rewrite iterative_dinatural.
     cbn.
     unfold cat, Cat_Kleisli.
     rewrite bind_bind.
@@ -271,7 +271,7 @@ Section Kleisli.
       + unfold pure.
         rewrite bind_ret.
         cbn.
-        eapply conway_proper_iter.
+        eapply iterative_proper_iter.
         repeat red.
         destruct a2.
         cbn. rewrite! bind_bind.
@@ -299,7 +299,7 @@ Section Kleisli.
     repeat red.
     intros.
     eapply transitivity.
-    eapply conway_proper_iter.
+    eapply iterative_proper_iter.
     eapply Proper_cat_Kleisli.
 
     assert (internalize (fun (x:a) (s:S) => iter (internalize f >>> pure iso) (s, x))
@@ -314,10 +314,10 @@ Section Kleisli.
    reflexivity.
    eapply transitivity.
    
-   eapply conway_proper_iter.
-   apply conway_natural.
-   rewrite conway_codiagonal.
-   eapply conway_proper_iter.
+   eapply iterative_proper_iter.
+   apply iterative_natural.
+   rewrite iterative_codiagonal.
+   eapply iterative_proper_iter.
    rewrite internalize_cat.
    (* SAZ This proof can probably use less unfolding *)
    repeat red.
@@ -355,7 +355,7 @@ Section Kleisli.
         reflexivity.
   Qed.
 
-  Global Instance Conway_stateTM : Conway (Kleisli (stateT S m)) sum.
+  Global Instance Iterative_stateTM : Iterative (Kleisli (stateT S m)) sum.
   constructor; 
   typeclasses eauto.
   Qed.

--- a/theories/Interp/Interp.v
+++ b/theories/Interp/Interp.v
@@ -76,17 +76,17 @@ Arguments translate {E F} h [T].
     [itree E ~> M] for any monad [M] with a loop operator. *)
 
 Definition interp {E M : Type -> Type}
-           {FM : Functor M} {MM : Monad M} {LM : ALoop M}
+           {FM : Functor M} {MM : Monad M} {IM : MonadIter M}
            (h : E ~> M) :
   itree E ~> M := fun R =>
-  aloop (fun t =>
+  iter (fun t =>
     match observe t with
-    | RetF r => inr r
-    | TauF t => inl (ret t)
-    | VisF e k => inl (fmap k (h _ e))
+    | RetF r => ret (inr r)
+    | TauF t => ret (inl t)
+    | VisF e k => fmap (fun x => inl (k x)) (h _ e)
     end).
 (* TODO: this does a map, and aloop does a bind. We could fuse those
    by giving aloop a continuation to compose its bind with.
    (coyoneda...) *)
 
-Arguments interp {E M FM MM LM} h [T].
+Arguments interp {E M FM MM IM} h [T].

--- a/theories/Interp/Recursion.v
+++ b/theories/Interp/Recursion.v
@@ -71,12 +71,12 @@ Open Scope itree_scope.
 Definition interp_mrec {D E : Type -> Type}
            (ctx : D ~> itree (D +' E)) : itree (D +' E) ~> itree E :=
   fun R =>
-    ITree.aloop (fun t : itree (D +' E) R =>
+    ITree.iter (fun t : itree (D +' E) R =>
       match observe t with
-      | RetF r => inr r
-      | TauF t => inl (Ret t)
-      | VisF (inl1 d) k => inl (Ret (ctx _ d >>= k))
-      | VisF (inr1 e) k => inl (Vis e (fun x => Ret (k x)))
+      | RetF r => Ret (inr r)
+      | TauF t => Ret (inl t)
+      | VisF (inl1 d) k => Ret (inl (ctx _ d >>= k))
+      | VisF (inr1 e) k => Vis e (fun x => Ret (inl (k x)))
       end).
 
 Arguments interp_mrec {D E} ctx [T].

--- a/theories/Interp/RecursionFacts.v
+++ b/theories/Interp/RecursionFacts.v
@@ -39,10 +39,10 @@ Definition _interp_mrec {R : Type} (ot : itreeF (D +' E) R _) : itree E R :=
   match ot with
   | RetF r => Ret r
   | TauF t => Tau (interp_mrec ctx t)
-  | VisF e k => Tau
+  | VisF e k =>
     match e with
-    | inl1 d => interp_mrec ctx (ctx _ d >>= k)
-    | inr1 e => Vis e (fun x => interp_mrec ctx (k x))
+    | inl1 d => Tau (interp_mrec ctx (ctx _ d >>= k))
+    | inr1 e => Vis e (fun x => Tau (interp_mrec ctx (k x)))
     end
   end.
 
@@ -50,13 +50,13 @@ Lemma unfold_interp_mrec R (t : itree (D +' E) R) :
   interp_mrec ctx t ≅ _interp_mrec (observe t).
 Proof.
   unfold interp_mrec.
-  rewrite unfold_aloop.
+  rewrite unfold_iter.
   destruct observe; cbn.
-  - reflexivity.
-  - rewrite bind_ret; reflexivity. (* TODO: bind_ret, bind_vis are sloooow *)
+  - rewrite bind_ret; reflexivity.
+  - rewrite bind_ret; reflexivity.
   - destruct e; cbn.
     + rewrite bind_ret; reflexivity.
-    + rewrite bind_vis. pstep; constructor. left.
+    + rewrite bind_vis.
       pstep; constructor. intros. left.
       rewrite bind_ret.
       apply reflexivity.
@@ -77,7 +77,7 @@ Proof.
   - apply reflexivity.
   - econstructor. eauto with paco.
   - econstructor. gbase. eapply CIH. apply eqit_bind; auto; reflexivity.
-  - econstructor. gstep; constructor. red. auto with paco.
+  - econstructor. gstep; constructor. auto with paco.
 Qed.
 
 Theorem interp_mrec_bind {U T} (t : itree _ U) (k : U -> itree _ T) :
@@ -94,35 +94,48 @@ Proof.
   all: rewrite unfold_interp_mrec.
   all: try (gstep; econstructor; eauto with paco).
   - rewrite <- bind_bind; eauto with paco.
-  - gstep; constructor; auto with paco.
+  - intros. red. rewrite bind_tau. gstep; constructor; auto with paco.
+Qed.
+
+Theorem interp_mrec_trigger {U} (a : (D +' E) U) :
+    interp_mrec ctx (ITree.trigger a)
+  ≳ mrecursive ctx _ a.
+Proof.
+  rewrite unfold_interp_mrec; unfold mrecursive.
+  destruct a; cbn.
+  rewrite tau_eutt, bind_ret2.
+  reflexivity.
+  pstep; constructor. intros; left. rewrite tau_eutt, unfold_interp_mrec; cbn.
+  apply reflexivity.
 Qed.
 
 Theorem interp_mrec_as_interp {T} (c : itree _ T) :
-  interp_mrec ctx c ≅ interp (mrecursive ctx) c.
+  interp_mrec ctx c ≈ interp (mrecursive ctx) c.
 Proof.
+  rewrite <- (tau_eutt (interp _ _)).
   revert_until T. ginit. gcofix CIH. intros.
   rewrite unfold_interp_mrec, unfold_interp.
   destruct (observe c); [| |destruct e]; simpl; eauto with paco.
-  - gstep. econstructor. eauto.
-  - gstep. econstructor. eauto with paco.
-  - rewrite interp_mrec_bind.
-    gstep. constructor.
+  - gstep; repeat econstructor; eauto.
+  - gstep; constructor; eauto with paco.
+  - rewrite interp_mrec_bind. unfold mrec.
+    gstep; constructor.
     guclo eqit_clo_bind; econstructor; [reflexivity|].
     intros ? _ []; eauto with paco.
-  - unfold ITree.trigger, case_; simpl. rewrite bind_vis.
+  - rewrite tau_eutt. unfold ITree.trigger, case_; simpl. rewrite bind_vis.
     gstep. constructor.
-    gstep; econstructor. intros. red.
-    rewrite bind_ret. auto with paco.
+    intros; red.
+    rewrite bind_ret. rewrite tau_eutt. auto with paco.
 Qed.
 
 Theorem mrec_as_interp {T} (d : D T) :
-  mrec ctx d ≅ interp (mrecursive ctx) (ctx _ d).
+  mrec ctx d ≈ interp (mrecursive ctx) (ctx _ d).
 Proof.
   apply interp_mrec_as_interp.
 Qed.
 
 Lemma interp_mrecursive {T} (d : D T) :
-  interp (mrecursive ctx) (trigger_inl1 d) ≅ Tau (mrec ctx d).
+  interp (mrecursive ctx) (trigger_inl1 d) ≈ mrec ctx d.
 Proof.
   unfold mrecursive. unfold trigger_inl1.
   rewrite interp_trigger. cbn. reflexivity.
@@ -130,22 +143,26 @@ Qed.
 
 Theorem unfold_interp_mrec_h {T} (t : itree _ T)
   : interp_mrec ctx (interp (case_ ctx inr_) t)
-  ≳ interp_mrec ctx t.
+  ≈ interp_mrec ctx t.
 Proof.
+  rewrite <- tau_eutt.
   revert t. ginit; gcofix CIH. intros.
   rewrite (itree_eta t); destruct (observe t);
-    rewrite 2 unfold_interp_mrec; cbn; gstep; constructor.
-  - auto.
-  - rewrite bind_ret; auto with paco.
-  - rewrite bind_map.
-    destruct e.
-    + rewrite 2 interp_mrec_bind.
-      guclo eqit_clo_bind; econstructor; [reflexivity|].
-      intros ? _ []; auto with paco.
-    + cbn. unfold inr_, Handler.Inr_sum1_Handler, Handler.Handler.inr_, Handler.Handler.htrigger.
-      rewrite bind_trigger, unfold_interp_mrec; cbn.
-      rewrite tau_eutt.
-      gstep; constructor. auto with paco.
+    try (rewrite 2 unfold_interp_mrec; cbn; gstep; repeat constructor; auto with paco; fail).
+  rewrite interp_vis.
+  rewrite (unfold_interp_mrec _ (Vis _ _)).
+  destruct e; cbn.
+  - rewrite 2 interp_mrec_bind.
+    gstep; constructor.
+    guclo eqit_clo_bind; econstructor; [reflexivity|].
+    intros ? _ []; rewrite unfold_interp_mrec; cbn; auto with paco.
+  - unfold inr_, Handler.Inr_sum1_Handler, Handler.Handler.inr_, Handler.Handler.htrigger.
+    rewrite bind_trigger, unfold_interp_mrec; cbn.
+    rewrite tau_eutt.
+    gstep; constructor.
+    intros; red. gstep; constructor.
+    rewrite unfold_interp_mrec; cbn.
+    auto with paco.
 Qed.
 
 End Facts.
@@ -162,11 +179,11 @@ Proof.
   ginit; gcofix CIH; intros t1 t2 Ht.
   rewrite 2 unfold_interp_mrec.
   punfold Ht; induction Ht; cbn; pclearbot.
-  3: { gstep; constructor; destruct e.
+  3: { destruct e; gstep; constructor.
     + gfinal; left. apply CIH.
       eapply eutt_clo_bind; eauto.
       intros ? _ []. auto.
-    + gstep; constructor. red; auto with paco.
+    + gstep; constructor. auto with paco.
   }
   1,2: gstep; constructor; auto with paco.
   1,2: rewrite unfold_interp_mrec, tau_eutt; auto.
@@ -178,18 +195,47 @@ Definition recursive {E A B} (f : A -> itree (callE A B +' E) B) : (callE A B +'
   case_ (calling' (rec f)) ITree.trigger.
 
 Lemma rec_as_interp {E A B} (f : A -> itree (callE A B +' E) B) (x : A) :
-  rec f x ≅ interp (recursive f) (f x).
+  rec f x ≈ interp (recursive f) (f x).
 Proof.
   unfold rec.
   rewrite mrec_as_interp.
+  apply eq_sub_eutt.
   eapply eq_itree_interp.
   - red. unfold case_; intros ? [[] | ]; reflexivity.
   - reflexivity.
 Qed.
 
 Lemma interp_recursive_call {E A B} (f : A -> itree (callE A B +' E) B) (x:A) :
-   interp (recursive f) (call x) ≅ Tau (rec f x).
+   interp (recursive f) (call x) ≈ rec f x.
 Proof.
   unfold recursive. unfold call.
-  rewrite interp_trigger. cbn. reflexivity.
+  rewrite interp_trigger. cbn.
+  reflexivity.
+Qed.
+
+
+Global Instance euttge_interp_mrec {D E} :
+  @Proper ((D ~> itree (D +' E)) -> (itree (D +' E) ~> itree E))
+          (Relation.i_pointwise (fun _ => euttge eq) ==>
+           Relation.i_respectful (fun _ => euttge eq) (fun _ => euttge eq))
+          interp_mrec.
+Proof.
+  intros f g Hfg R.
+  ginit; gcofix CIH; intros t1 t2 Ht.
+  rewrite 2 unfold_interp_mrec.
+  punfold Ht; induction Ht; cbn; pclearbot.
+  3: { destruct e; gstep; constructor.
+    + gfinal; left. apply CIH.
+      eapply eqit_bind; auto. apply Hfg.
+    + gstep; constructor. auto with paco.
+  }
+  1,2: gstep; constructor; auto with paco.
+  1: rewrite unfold_interp_mrec, tau_eutt; auto.
+  discriminate.
+Qed.
+
+Global Instance euttge_interp_mrec' {E D R} (ctx : D ~> itree (D +' E)) :
+  Proper (euttge eq ==> euttge eq) (@interp_mrec _ _ ctx R).
+Proof.
+  do 4 red. eapply euttge_interp_mrec. reflexivity.
 Qed.

--- a/theories/Simple.v
+++ b/theories/Simple.v
@@ -151,7 +151,7 @@ Definition _interp {E F R} (f : E ~> itree F) (ot : itreeF E R _)
   := match ot with
      | RetF r => Ret r
      | TauF t => Tau (interp f t)
-     | VisF e k => Tau (f _ e >>= (fun x => interp f (k x)))
+     | VisF e k => f _ e >>= (fun x => Tau (interp f (k x)))
      end.
 
 Parameter unfold_interp
@@ -166,7 +166,7 @@ Parameter interp_ret
 Parameter interp_vis
   : forall {E F R} {f : E ~> itree F} U (e: E U) (k: U -> itree E R),
     interp f (Vis e k)
-  ≈ Tau (ITree.bind (f _ e) (fun x => interp f (k x))).
+  ≈ ITree.bind (f _ e) (fun x => interp f (k x)).
 
 Parameter interp_trigger : forall {E F : Type -> Type} {R : Type}
       (f : E ~> (itree F)) (e : E R),
@@ -371,7 +371,7 @@ Definition _interp {E F R} (f : E ~> itree F) (ot : itreeF E R _)
   := match ot with
      | RetF r => Ret r
      | TauF t => Tau (interp f t)
-     | VisF e k => Tau (f _ e >>= (fun x => interp f (k x)))
+     | VisF e k => f _ e >>= (fun x => Tau (interp f (k x)))
      end.
 
 Lemma unfold_interp
@@ -393,16 +393,16 @@ Qed.
 Lemma interp_vis
   : forall {E F R} {f : E ~> itree F} U (e: E U) (k: U -> itree E R),
     interp f (Vis e k)
-  ≈ Tau (ITree.bind (f _ e) (fun x => interp f (k x))).
+  ≈ ITree.bind (f _ e) (fun x => interp f (k x)).
 Proof.
-  intros; rewrite unfold_interp; reflexivity.
+  intros; rewrite InterpFacts.interp_vis; setoid_rewrite tau_eutt; reflexivity.
 Qed.
 
 Lemma interp_trigger : forall {E F : Type -> Type} {R : Type}
       (f : E ~> (itree F)) (e : E R),
     interp f (ITree.trigger e) ≈ f _ e.
 Proof.
-  intros; rewrite ITree.Interp.InterpFacts.interp_trigger, tau_eutt.
+  intros; rewrite ITree.Interp.InterpFacts.interp_trigger.
   reflexivity.
 Qed.
 
@@ -441,7 +441,8 @@ Lemma interp_recursive_call
     interp (recursive f) (call x)
   ≈ rec f x.
 Proof.
-  intros. rewrite ITree.Interp.RecursionFacts.interp_recursive_call. apply tau_eutt.
+  intros. rewrite ITree.Interp.RecursionFacts.interp_recursive_call.
+  reflexivity.
 Qed.
 
 (** [mrec ctx] is equivalent to [interp (mrecursive ctx)],
@@ -463,7 +464,8 @@ Lemma interp_mrecursive
     interp (mrecursive ctx) (trigger_inl1 d)
   ≈ mrec ctx d.
 Proof.
-  intros; rewrite ITree.Interp.RecursionFacts.interp_mrecursive. apply tau_eutt.
+  intros; rewrite ITree.Interp.RecursionFacts.interp_mrecursive.
+  reflexivity.
 Qed.
 
 Hint Rewrite @interp_recursive_call : itree.

--- a/tutorial/Imp.v
+++ b/tutorial/Imp.v
@@ -214,7 +214,7 @@ Section Denote.
   (* SAZ + LX - for some reason typeclass resolution can't see the instance for 
      Iter_ktree, even though it seems to be in scope. *)
   Definition while (step : itree eff (unit + unit)) : itree eff unit :=
-    @iter _ _ _ Iter_ktree _ _ (fun _ => step) tt.
+    @iter _ _ _ Iter_Kleisli _ _ (fun _ => step) tt.
     
   (** Casting values into [bool]:  [0] corresponds to [false] and any nonzero
       value corresponds to [true].  *)


### PR DESCRIPTION
Removes the weirdly typed `aloop` with a more normal-looking `iter` + some renaming.

The problem I'm running into is that it breaks strong bisimulations about `interp` and `mrec`. I managed to fix them for `interp`, but now `mrec` is giving me trouble, in particular with the "unfolding equations" which reexpress `mrec` as `interp` (`interp_mrec_as_interp`, `mrec_as_interp`). I'm not sure yet how much work that will take.

The best outcome would be to come up with a variant of `mrecursive` with a few more taus here and there so that these equations hold up to strong bisimulation.

In the current state of things, I made those into weak bisimulations instead to see what happens. It turns out that the `HandlerFacts` proofs for the properties of `iter` operation are coinduction proofs, which require those equations to be strong bisimulations (and the extra taus for that would be dealt with in the coinduction proofs themselves).

Some ideas to try to get taus in different places so that strong bisimulations may be easier to establish:

- Make `ITree.iter` smarter about taus, in particular so that `interp trigger : itree E ~> itree E` is strongly bisimilar to the identity function. A useful thing for this would be a version of `bind` which guards the continuation, but without inserting a `Tau` if its first argument is already a `Vis`.

- Define `ITree.ana : (A -> itreeF E R A) -> A -> itree E R` and `mrec` using it.