### PR TITLE
Clarify instructions in Introduction.v

### DIFF
--- a/tutorial/Introduction.v
+++ b/tutorial/Introduction.v
@@ -104,6 +104,11 @@ Definition interpreted_write_one : itree void1 (list nat * unit)
     [T (itree F)] (above, [T := stateT (list nat)]). (The library is
     currently missing some theory about the monads we can instantiate
     [interp] with.)
+
+    The proof of [interp_write_one] will require us to rewrite an
+    expression under a binder#&mdash;#i.e. on the right side of a
+    [;;]. The [rewrite] tactic will fail in this situation; instead,
+    we can use [setoid_rewrite], which works under binders.
  *)
 Lemma interp_write_one F (handle_io : forall R, ioE R -> itree F R)
   : interp handle_io write_one


### PR DESCRIPTION
Several of the lemmas in tutorial/Introduction.v require the use of the `setoid_rewrite` tactic in order to rewrite expressions under binders. This first occurs in the proof of `interp_write_one`. Users of the tutorial with a basic Coq background will not necessarily have encountered `setoid_rewrite` and are likely to get stuck on the proofs which require it.

This PR adds a few sentences to Introduction.v in order to explain that `setoid_rewrite` must be used in these cases.