### PR TITLE
WIP: compiler with "MTL-style" semantics

### DIFF
--- a/theories/Basics/Basics.v
+++ b/theories/Basics/Basics.v
@@ -153,7 +153,7 @@ Polymorphic Class MonadIter (M : Type -> Type) : Type :=
     Quite easily in fact, no [Monad] assumption needed.
  *)
 
-Instance MonadIter_stateT {M S} {MM : Monad M} {AM : MonadIter M}
+Polymorphic Instance MonadIter_stateT {M S} {MM : Monad M} {AM : MonadIter M}
   : MonadIter (stateT S M) :=
   fun _ _ step i => mkStateT (fun s =>
     iter (fun is =>

--- a/theories/Basics/CategorySub.v
+++ b/theories/Basics/CategorySub.v
@@ -111,7 +111,7 @@ Qed.
 Global Instance Proper_subm {a b} : Proper (eq2 ==> eq2) (subm a b).
 Proof. hnf; auto. Qed.
 
-Global Instance Proper_unsubm {a b} : Proper (eq2 ==> eq2) (subm a b).
+Global Instance Proper_unsubm {a b} : Proper (eq2 ==> eq2) (unsubm a b).
 Proof. hnf; auto. Qed.
 
 Global Instance Functor_unsubm : Functor sub C Embed unsubm.

--- a/theories/Basics/MonadTheory.v
+++ b/theories/Basics/MonadTheory.v
@@ -42,6 +42,7 @@ Section Laws.
     ; bind_bind :> forall a b c (x : m a) (f : a -> m b) (g : b -> m c), bind (bind x f) g ≈ bind x (fun y => bind (f y) g)
     }.                                             
 
+  (* This should be just a notation *)
   Class MonadProperOps :=
       Proper_bind :> forall {a b},
           (@Proper (m a%type -> (a -> m b) -> m b)

--- a/tutorial/KTreeFin.v
+++ b/tutorial/KTreeFin.v
@@ -88,14 +88,20 @@ Qed.
 End CocartesianFunctor.
 
 Notation Fun_fin := (sub Fun fin).
-Notation ktree_fin E := (sub (ktree E) fin).
+Notation Kleisli_fin m := (sub (Kleisli m) fin).
 
 Section PureKF.
 
-Context {E : Type -> Type}.
+Context {M : Type -> Type} {MM : Monad.Monad M}.
 
-Definition subpure {n m} (f : Fun_fin n m) : ktree_fin E n m :=
+Definition subpure {n m} (f : Fun_fin n m) : Kleisli_fin M n m :=
   subm (pure (unsubm f)).
+
+Context
+  {EM : EqM M}
+  {EEM : EqMProps M}
+  {ML : MonadLaws M}
+  {MPO : MonadProperOps M}.
 
 Global Instance Functor_pure : Functor _ _ _ (@subpure).
 Proof.
@@ -110,12 +116,15 @@ Proof.
   constructor; intros.
   - intros []; cbn.
     unfold unsubm, case_, CoprodCase_Kleisli, case_sum, CoprodCase_sub, case_.
-    unfold cat, Cat_sub, Cat_Fun.
-    unfold to_bif, ToBifunctor_ktree_fin, ToBifunctor_Fun_fin.
-    rewrite bind_ret.
+    unfold cat, Cat_sub, Cat_Fun, Cat_Kleisli.
+    unfold to_bif, ToBifunctor_Kleisli_fin, ToBifunctor_Fun_fin.
+    rewrite MonadTheory.bind_ret.
+    unfold subpure, subm, pure, unsubm.
     destruct split_fin_sum; reflexivity.
-  - intros ?; cbn. rewrite bind_ret. reflexivity.
-  - intros ?; cbn; rewrite bind_ret; reflexivity.
+  - intros ?; cbn. unfold subpure, pure, subm, inl_, CoprodInl_sub, cat, Cat_Kleisli, Cat_Fun, inl_, CoprodInl_Kleisli, pure.
+    rewrite MonadTheory.bind_ret. reflexivity.
+  - intros ?; cbn. unfold subpure, pure, subm, inr_, CoprodInr_sub, cat, Cat_Kleisli, Cat_Fun, inr_, CoprodInr_Kleisli, pure.
+    rewrite MonadTheory.bind_ret; reflexivity.
 Qed.
 
 End PureKF.


### PR DESCRIPTION
The semantics now have type

```
denote_imp : forall m `{Monad m} ..., imp -> m unit
denote_asm : forall m `{Monad m} ..., asm -> m unit
```
