### PR TITLE
[WIP] Fixes for compatibility with Coq v8.10 and master

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 **.vo
+*.vos
+*.vok
 **.v.d
 **.glob
 *.v#
@@ -25,6 +27,7 @@ deps.jpg
 deps.dot
 
 .coqdeps.d
+.Makefile.coq.d
 Makefile.coq
 Makefile.coq.conf
 _CoqProject

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ env:
   matrix:
   - OCAML_VERSION=4.07 COQ_VERSION="8.8.2"
   - OCAML_VERSION=4.07 COQ_VERSION="8.9.0"
+  - OCAML_VERSION=4.07 COQ_VERSION="8.10"
+  - OCAML_VERSION=4.07 COQ_VERSION="dev"
 os:
   - linux
     # - osx

--- a/theories/Basics/CategoryFacts.v
+++ b/theories/Basics/CategoryFacts.v
@@ -47,7 +47,7 @@ Context {Eq2C : Eq2 C} {IdC : Id_ C} {CatC : Cat C}.
 Context {CatIdL_C : CatIdL C}.
 
 (** [id_] is an isomorphism. *)
-Global Instance SemiIso_Id {a} : SemiIso C (id_ a) (id_ a) := {}.
+Global Instance SemiIso_Id {a} : SemiIso C (id_ a) (id_ a).
 Proof. apply cat_id_l. Qed.
 
 Context {Equivalence_Eq2_C : forall a b, @Equivalence (C a b) eq2}.
@@ -62,8 +62,9 @@ Context {Proper_Cat_C : forall a b c,
 Global Instance SemiIso_Cat {a b c}
        (f : C a b) {f' : C b a} {SemiIso_f : SemiIso C f f'}
        (g : C b c) {g' : C c b} {SemiIso_g : SemiIso C g g'}
-  : SemiIso C (f >>> g) (g' >>> f') := {}.
+  : SemiIso C (f >>> g) (g' >>> f').
 Proof.
+  red.
   rewrite cat_assoc, <- (cat_assoc g), (semi_iso g _), cat_id_l,
   (semi_iso f _).
   reflexivity.
@@ -84,8 +85,9 @@ Context {Proper_Bimap_bif : forall a b c d,
 Global Instance SemiIso_Bimap {a b c d} (f : C a b) (g : C c d)
          {f' : C b a} {SemiIso_f : SemiIso C f f'}
          {g' : C d c} {SemiIso_g : SemiIso C g g'} :
-  SemiIso C (bimap f g) (bimap f' g') := {}.
+  SemiIso C (bimap f g) (bimap f' g').
 Proof.
+  red.
   rewrite bimap_cat, (semi_iso f _), (semi_iso g _), bimap_id.
   reflexivity.
 Qed.

--- a/theories/Basics/FunctionFacts.v
+++ b/theories/Basics/FunctionFacts.v
@@ -14,7 +14,7 @@ Local Open Scope cat_scope.
 (* end hide *)
 
 Instance subrelation_eeq_eqeq {A B} :
-  @subrelation (A -> B) eq2 (@eq A ==> @eq B)%signature := {}.
+  @subrelation (A -> B) eq2 (@eq A ==> @eq B)%signature.
 Proof. congruence. Qed.
 
 Instance Equivalence_eeq {A B} : @Equivalence (Fun A B) eq2.

--- a/theories/Core/ITreeDefinition.v
+++ b/theories/Core/ITreeDefinition.v
@@ -241,13 +241,13 @@ Module ITreeNotations.
 Notation "t1 >>= k2" := (ITree.bind t1 k2)
   (at level 50, left associativity) : itree_scope.
 Notation "x <- t1 ;; t2" := (ITree.bind t1 (fun x => t2))
-  (at level 60, t1 at next level, right associativity) : itree_scope.
+  (at level 61, t1 at next level, right associativity) : itree_scope.
 Notation "t1 ;; t2" := (ITree.bind t1 (fun _ => t2))
-  (at level 60, right associativity) : itree_scope.
+  (at level 61, right associativity) : itree_scope.
 Notation "' p <- t1 ;; t2" :=
   (ITree.bind t1 (fun x_ => match x_ with p => t2 end))
-  (at level 60, t1 at next level, p pattern, right associativity) : itree_scope.
-Infix ">=>" := ITree.cat (at level 60, right associativity) : itree_scope.
+  (at level 61, t1 at next level, p pattern, right associativity) : itree_scope.
+Infix ">=>" := ITree.cat (at level 61, right associativity) : itree_scope.
 End ITreeNotations.
 
 (** ** Instances *)

--- a/theories/Core/ITreeMonad.v
+++ b/theories/Core/ITreeMonad.v
@@ -12,13 +12,13 @@ From ITree Require Import
 
 Instance EqM_ITree {E} : EqM (itree E) := fun a => eutt eq.
 
-Instance EqMProps_ITree {E} : EqMProps (itree E) := _.
+Instance EqMProps_ITree {E} : EqMProps (itree E).
 repeat red.
 intros a.
 typeclasses eauto.
 Qed.
 
-Instance MonadLaws_ITree {E} : MonadLaws (itree E) := _.
+Instance MonadLaws_ITree {E} : MonadLaws (itree E).
 constructor.
 - intros a b f x. 
   unfold Monad.bind, Monad.ret, Monad_itree.
@@ -29,7 +29,7 @@ constructor.
   unfold eqm, EqM_ITree. rewrite bind_bind. reflexivity.
 Qed.  
 
-Instance MonadProperOps_ITree {E} : MonadProperOps (itree E) := _.
+Instance MonadProperOps_ITree {E} : MonadProperOps (itree E).
 unfold MonadProperOps.
 unfold Monad.bind, Monad_itree.
 intros.

--- a/theories/Eq/Shallow.v
+++ b/theories/Eq/Shallow.v
@@ -46,7 +46,7 @@ Inductive observing {E R1 R2}
            (eq_ : itree' E R1 -> itree' E R2 -> Prop)
            (t1 : itree E R1) (t2 : itree E R2) : Prop :=
 | observing_intros :
-    eq_ t1.(observe) t2.(observe) -> observing eq_ t1 t2.
+    eq_ (observe t1) (observe t2) -> observing eq_ t1 t2.
 Hint Constructors observing.
 
 Section observing_relations.

--- a/theories/Eq/UpToTaus.v
+++ b/theories/Eq/UpToTaus.v
@@ -323,6 +323,12 @@ Proof.
   intros. destruct PR. econstructor; eauto. reflexivity. auto_ctrans.
 Qed.
 
+Theorem eqit_tau_l R (m: itree E R) : eqit eq true true (Tau m) m.
+Proof.
+  apply euttge_sub_eutt.
+  apply tau_eutt.
+Qed.
+
 Lemma transL_closed vclo r
       (MON: monotone2 vclo)
       (COMP: wcompatible2 (eqit_ RR true true vclo) (transD RR))
@@ -366,10 +372,10 @@ Proof.
     + gstep. red. simpobs. econstructor. gbase.
       destruct REL.
       * eapply CIH. econstructor; [|eauto using paco2_mon with paco|].
-        -- eapply eqit_trans; [apply REL0|]. rewrite tau_eutt. reflexivity.
+        -- eapply eqit_trans; [apply REL0|]. rewrite eqit_tau_l; reflexivity.
         -- auto_ctrans.
       * eapply CIH0. apply CLOL. econstructor; [|eauto|].
-        -- eapply eqit_trans; [apply REL0|]. rewrite tau_eutt. reflexivity.
+        -- eapply eqit_trans; [apply REL0|]. rewrite eqit_tau_l; reflexivity.
         -- auto_ctrans.
     + punfold REL0. red in REL0. simpl in *.
       remember (VisF e k1) as ot. genobs m1 ot2.
@@ -386,7 +392,7 @@ Proof.
         econstructor; try reflexivity; auto_ctrans.
         gfinal. destruct PR; eauto.
     + eapply IHREL0; try eapply eqit_trans; auto_ctrans_eq.
-      rewrite <-itree_eta, tau_eutt. reflexivity.
+      rewrite <-itree_eta, eqit_tau_l. reflexivity.
     + gclo; econstructor; auto_ctrans_eq; try reflexivity.
       rewrite (simpobs Heqot2), tau_eutt. reflexivity.
   - remember (VisF e k2) as ot. genobs t2 ot2.

--- a/theories/Events/Concurrency.v
+++ b/theories/Events/Concurrency.v
@@ -47,7 +47,7 @@ Definition rr_match {E} (rr : list (itree ((spawnE E) +' E) unit) -> itree E uni
     match q with
     | [] => Ret tt
     | t::ts =>
-      match t.(observe) with
+      match (observe t) with
       | RetF _ => Tau (rr ts)
       | TauF u => Tau (rr (ts ++ [u]))
       | @VisF _ _ _ X o k =>

--- a/theories/Events/State.v
+++ b/theories/Events/State.v
@@ -123,7 +123,7 @@ Section eff_hom_e.
 
   Definition interp_e (h : eff_hom_e) : itree E ~> itree F := fun R t =>
     ITree.iter (fun '(s, t) =>
-      match t.(observe) with
+      match (observe t) with
       | RetF r => Ret (inr r)
       | TauF t => Ret (inl (s, t))
       | VisF e k => ITree.map (fun '(s, x) => inl (s, k x)) (h.(eval) _ e)

--- a/theories/Events/StateKleisli.v
+++ b/theories/Events/StateKleisli.v
@@ -35,7 +35,7 @@ Section Kleisli.
   Global Instance EqM_stateTM : EqM (stateT S m) :=
     fun a => pointwise_relation _ eqm.
 
-  Global Instance EqMProps_stateTM : @EqMProps (stateT S m) _ EqM_stateTM := _.
+  Global Instance EqMProps_stateTM : @EqMProps (stateT S m) _ EqM_stateTM.
   constructor.
   - repeat red.
     reflexivity.
@@ -43,7 +43,7 @@ Section Kleisli.
   - repeat red. intros. etransitivity; eauto. apply H.  apply H0.
   Qed.
 
-  Global Instance MonadProperOps_stateTM : @MonadProperOps (stateT S m) _ _ := _.
+  Global Instance MonadProperOps_stateTM : @MonadProperOps (stateT S m) _ _.
   Proof.
     repeat red. intros a b x y H x0 y0 H0 s. 
     apply eqm_bind.
@@ -53,7 +53,7 @@ Section Kleisli.
       apply H0.
   Qed.
 
-  Instance MonadLaws_stateTM : @MonadLaws (stateT S m) _ _ := _.
+  Instance MonadLaws_stateTM : @MonadLaws (stateT S m) _ _.
   constructor.
   - cbn. intros a b f x. 
     repeat red.  intros s.
@@ -151,7 +151,7 @@ Section Kleisli.
     - repeat red. destruct a2 as [s' [x1|y1]]; reflexivity.
  Qed.
 
-  Global Instance IterUnfold_stateTM : IterUnfold (Kleisli (stateT S m)) sum := _.
+  Global Instance IterUnfold_stateTM : IterUnfold (Kleisli (stateT S m)) sum.
   Proof.
   destruct CM.
   unfold IterUnfold.
@@ -173,7 +173,7 @@ Section Kleisli.
       reflexivity.
   Qed.
 
-  Global Instance IterNatural_stateTM : IterNatural (Kleisli (stateT S m)) sum := _.
+  Global Instance IterNatural_stateTM : IterNatural (Kleisli (stateT S m)) sum.
   Proof.
     destruct CM.
     unfold IterNatural.
@@ -249,7 +249,7 @@ Section Kleisli.
   Qed.
 
     
-  Global Instance IterDinatural_stateTM : IterDinatural (Kleisli (stateT S m)) sum := _.
+  Global Instance IterDinatural_stateTM : IterDinatural (Kleisli (stateT S m)) sum.
   Proof.
     destruct CM.
     unfold IterDinatural.
@@ -290,7 +290,7 @@ Section Kleisli.
     Qed.
         
 
-  Global Instance IterCodiagonal_stateTM : IterCodiagonal (Kleisli (stateT S m)) sum := _.
+  Global Instance IterCodiagonal_stateTM : IterCodiagonal (Kleisli (stateT S m)) sum.
   Proof.
     destruct CM.
     unfold IterCodiagonal.

--- a/theories/Interp/HandlerFacts.v
+++ b/theories/Interp/HandlerFacts.v
@@ -204,7 +204,7 @@ Context {R : Type}.
 
 Context (f := fun T e => Tau (f0 T e)) (g := fun T e => Tau (g0 T e)).
 
-Local Inductive interleaved
+Inductive interleaved
   : itree (A +' C) R -> itree (B +' C) R -> Prop :=
 | interleaved_Ret r : interleaved (Ret r) (Ret r)
 | interleaved_Left {U} (t : itree _ U) k1 k2 :

--- a/tutorial/Utils_tutorial.v
+++ b/tutorial/Utils_tutorial.v
@@ -621,7 +621,7 @@ Section nat_Show.
   Fixpoint nat_to_string (n: nat): string :=
     match n with
     | O => ""
-    | S n => String (ascii_of_nat 49) (nat_to_string n)
+    | S n => String (Ascii.ascii_of_nat 49) (nat_to_string n)
     end.
 
   Lemma nat_to_string_inj:


### PR DESCRIPTION
I've tested this on Coq v8.9.1, v8.10.1, and the current Coq master.

An incomplete list of changes needed:

- Coq now generates slightly different files, which requires new gitignore rules.
- Instances can no longer be partially provided with `:=` (so that it's syntactically obvious whether or not we're in proof mode). The relevant change to Coq for InteractionTrees is https://github.com/coq/coq/pull/9270.
- The projection syntax now only supports record projections (see https://github.com/coq/coq/pull/8829). This is a bit sad since it would be nice for the user to think of `observe` as a projection; hopefully Coq supports that in some way.

There was one mysterious breakage in `Eq/UpToTaus.v`. The rewrite previously there now goes into an infinite loop while resolving typeclasses for setoid rewriting. I managed to fix it by essentially manually giving the right instance, but it would be nice to fix the underlying issue.