### PR TITLE
Denotation of open cfgs in presence of function calls

### DIFF
--- a/theories/Basics/MonadEither.v
+++ b/theories/Basics/MonadEither.v
@@ -1,0 +1,260 @@
+From Coq Require Import
+     Setoid
+     Morphisms.
+
+From ExtLib Require Import
+     Structures.Monad
+     EitherMonad.
+
+From ITree Require Import
+     Basics.Basics
+     Basics.Category
+     Basics.CategoryKleisli
+     Basics.CategoryKleisliFacts
+     Basics.Monad.
+
+Import ITree.Basics.Basics.Monads.
+Import CatNotations.
+Local Open Scope cat_scope.
+Local Open Scope cat.
+
+Section Either.
+  Variable M : Type -> Type.
+  Variable A : Type.
+  Context {EQM : EqM M}.
+  Context {HM: Monad M}.
+  Context {HEQP: @EqMProps M _ EQM}.
+  Context {ML: @MonadLaws M _ HM}.
+
+  Global Instance EqM_eitherTM : EqM (eitherT A M).
+  Proof.
+    intros ? [a] [b].
+    exact (eqm a b).
+  Defined.
+
+  Global Instance EqMProps_eitherTM : @EqMProps (eitherT A M) _ EqM_eitherTM.
+  Proof.
+  constructor.
+  - intros [x]; cbn; reflexivity.
+  - intros [x] [y]; cbn; symmetry; auto.
+  - intros [x] [y] [z]; cbn; etransitivity; eauto.
+  Qed.
+
+  Instance MonadLaws_eitherTM : @MonadLaws (eitherT A M) _ _.
+  Proof.
+  constructor.
+  - cbn. intros a b f x; destruct (f x) eqn:EQ.
+    repeat red.
+    rewrite bind_ret_l, EQ; cbn.
+    reflexivity.
+  - cbn. intros a [x]; cbn.
+    match goal with
+      |- _ ≈ ?h => rewrite <- (bind_ret_r _ h) at 2
+    end.
+    apply Proper_bind; [reflexivity | intros [b | m]; reflexivity].
+  - cbn. intros a b c [x] f g; cbn.
+    rewrite bind_bind.
+    apply Proper_bind; [reflexivity | intros [? | m]].
+    + rewrite bind_ret_l; reflexivity.
+    + reflexivity.
+  - cbn; intros a b [x] [y] EQ x' y' H'; cbn in *.
+    apply Proper_bind; [auto | intros [? | ?]]; [reflexivity |].
+    specialize (H' a0).
+    destruct (x' a0), (y' a0); cbn in *; auto.
+  Qed.
+
+  Context {IM: Iter (Kleisli M) sum}.
+  Context {CM: Iterative (Kleisli M) sum}.
+
+  Definition iso {a b:Type} (Aab : A + (a + b)) : (a  + (A + b)) :=
+    match Aab with
+    | inl A => inr (inl A)
+    | inr (inl a) => inl a
+    | inr (inr b) => inr (inr b)
+    end.
+
+  (* Definition iso_inv {a b:Type} (sab : (S * a) + (S * b)) : S * (a + b) := *)
+  (*   match sab with *)
+  (*   | inl (s, a) => (s, inl a) *)
+  (*   | inr (s, b) => (s, inr b) *)
+  (*   end. *)
+
+  (* Definition internalize {a b:Type} (f : Kleisli (eitherT S M) a b) : Kleisli M (S * a) (S * b) := *)
+  (*   fun (sa : S * a) => f (snd sa) (fst sa). *)
+
+  (* Lemma internalize_eq {a b:Type} (f g : Kleisli (eitherT S M) a b) : *)
+  (*   eq2 f g <-> eq2 (internalize f) (internalize g). *)
+  (* Proof. *)
+  (*   split. *)
+  (*   - intros. *)
+  (*     repeat red. destruct a0. *)
+  (*     unfold internalize. cbn.  apply H. *)
+  (*   - intros. *)
+  (*     repeat red. intros. *)
+  (*     unfold internalize in H. *)
+  (*     specialize (H (a1, a0)). *)
+  (*     apply H. *)
+  (* Qed. *)
+
+
+  (* Lemma internalize_pure {a b c} (f : Kleisli (eitherT S M) a b) (g : S * b -> S * c) : *)
+  (*   internalize f >>> pure g   ⩯   (internalize (f >>> (fun b s => ret (g (s,b))))). *)
+  (* Proof. *)
+  (*   repeat red. *)
+  (*   destruct a0. *)
+  (*   unfold internalize, cat, Cat_Kleisli. cbn. *)
+  (*   apply Proper_bind; auto. *)
+  (*   - reflexivity. *)
+  (*   - repeat red. *)
+  (*     destruct a1. *)
+  (*     unfold pure. reflexivity. *)
+  (* Qed. *)
+
+  Definition internalize {a b:Type} (f : Kleisli (eitherT A M) a b) : Kleisli M a (A + b) :=
+    fun x => let '(mkEitherT y) := f x in y.
+
+  Global Instance Iter_eitherTM : Iter (Kleisli (eitherT A M)) sum :=
+    fun (a b: Type) (f: a -> (eitherT A M (a + b))) x =>
+      mkEitherT (iter ((internalize f) >>> (pure iso)) x).
+
+  (* Instance proper_internalize: Proper (eqm ==> eq2) internalize. *)
+
+  Instance proper_internalize {a b}: Proper (eq2 ==> eq2) (@internalize a b).
+  intros x y H o; specialize (H o).
+  unfold internalize; destruct (x o), (y o).
+  apply H.
+  Qed.
+
+  (* Lemma internalize_cat {a b c} (f : Kleisli (eitherT A M) a b) (g : Kleisli (eitherT A M) b c) : *)
+  (*   (internalize (f >>> g)) ⩯ ((internalize f) >>> (internalize g)). *)
+  (* Proof. *)
+  (*   repeat red. *)
+  (*   destruct a0. *)
+  (*   cbn. *)
+  (*   unfold internalize. *)
+  (*   unfold cat, Cat_Kleisli. *)
+  (*   cbn. *)
+  (*   reflexivity. *)
+  (* Qed. *)
+
+  Global Instance Proper_Iter_eitherTM : forall a b, @Proper (Kleisli (eitherT A M) a (a + b) -> (Kleisli (eitherT A M) a b)) (eq2 ==> eq2) iter.
+  Proof.
+    destruct CM.
+    intros a b x y H a0.
+    apply iterative_proper_iter.
+    apply cat_eq2_r.
+    rewrite H; reflexivity.
+ Qed.
+
+  Global Instance IterUnfold_eitherTM : IterUnfold (Kleisli (eitherT A M)) sum.
+  Proof.
+    destruct CM.
+    intros a b f o.
+    cbn; destruct (f o) as [e] eqn:EQ; cbn.
+    unfold cat, Cat_Kleisli.
+    unfold iter, Iter_eitherTM.
+    rewrite iterative_unfold.
+    unfold cat, Cat_Kleisli.
+    rewrite bind_bind.
+    apply Proper_bind.
+    + unfold internalize; rewrite EQ; reflexivity.
+    + intros [xA | [xa | xb]]; unfold pure; rewrite bind_ret_l; reflexivity.
+  Qed.
+
+  Global Instance IterNatural_eitherTM : IterNatural (Kleisli (eitherT A M)) sum.
+  Proof.
+    destruct CM.
+    intros a b c f g o.
+    cbn; destruct (f o) as [e] eqn:EQf; cbn.
+    setoid_rewrite iterative_natural.
+    apply iterative_proper_iter; intros a'.
+    unfold cat, Cat_Kleisli.
+    unfold internalize; destruct (f a') eqn:EQf'; cbn.
+    rewrite! bind_bind.
+    apply Proper_bind; [reflexivity |].
+    intros [xA | [xa | xb]]; unfold pure; cbn; rewrite !bind_ret_l; cbn; unfold cat, Cat_Kleisli; cbn.
+    - rewrite bind_ret_l; cbn; reflexivity.
+    - unfold id_, Id_Kleisli, pure; rewrite bind_ret_l; reflexivity.
+    - destruct (g xb); cbn; rewrite bind_bind.
+      apply Proper_bind; [reflexivity |].
+      intros [? | ?]; rewrite bind_ret_l; reflexivity.
+  Qed.
+
+  Lemma iter_dinatural_helper:
+    forall (a b c : Type) (f : Kleisli (eitherT A M) a (b + c)) (g : Kleisli (eitherT A M) b (a + c)),
+      internalize (f >>> case_ g inr_) >>> pure iso ⩯ internalize f >>> pure iso >>> case_ (internalize g >>> pure iso) inr_.
+  Proof.
+    destruct CM.
+    intros a b c f g o.
+    unfold cat, Cat_Kleisli, internalize; cbn.
+    repeat rewrite bind_bind.
+    destruct (f o) as [fo] eqn: EQ; cbn.
+    unfold pure; cbn.
+    apply Proper_bind; [reflexivity | intros [xA | [xa | xb]]]; cbn.
+    - rewrite !bind_ret_l; reflexivity.
+    - destruct (g xa) as [gxa] eqn:EQ'; cbn.
+      rewrite bind_ret_l; cbn; rewrite EQ'; reflexivity.
+    - rewrite !bind_ret_l; reflexivity.
+  Qed.
+
+  Global Instance IterDinatural_eitherTM : IterDinatural (Kleisli (eitherT A M)) sum.
+  Proof.
+    destruct CM.
+    unfold IterDinatural.
+    intros a b c f g o.
+    unfold iter, Iter_eitherTM. cbn.
+    eapply transitivity.
+    eapply iterative_proper_iter.
+    apply iter_dinatural_helper.
+    rewrite iterative_dinatural.
+    cbn.
+    unfold cat, Cat_Kleisli.
+    rewrite bind_bind.
+    unfold internalize. cbn.
+    apply Proper_bind.
+    - reflexivity.
+    - unfold pure; cbn; intros [xA | [xa | xb]]; cbn.
+      + rewrite bind_ret_l; cbn; reflexivity.
+      + rewrite bind_ret_l; cbn.
+        eapply iterative_proper_iter.
+        intros ?; rewrite !bind_bind.
+        destruct (g a0) eqn:EQ; cbn.
+        apply Proper_bind; [reflexivity | intros [|[|]]]; cbn; rewrite !bind_ret_l; try reflexivity.
+      + rewrite bind_ret_l; cbn.
+        reflexivity.
+  Qed.
+
+  Global Instance IterCodiagonal_eitherTM : IterCodiagonal (Kleisli (eitherT A M)) sum.
+  Proof.
+    destruct CM.
+    unfold IterCodiagonal.
+    intros a b f o.
+    unfold iter, Iter_eitherTM.
+    cbn.
+    eapply transitivity.
+    eapply iterative_proper_iter.
+    eapply Proper_cat_Kleisli; [| reflexivity].
+    unfold internalize; cbn. reflexivity.
+    eapply transitivity.
+
+   eapply iterative_proper_iter.
+   apply iterative_natural.
+   rewrite iterative_codiagonal.
+   eapply iterative_proper_iter.
+   rewrite cat_assoc, bimap_case, cat_id_l, cat_id_r.
+   unfold internalize.
+   intros o'; cbn.
+   unfold cat, Cat_Kleisli; rewrite !bind_bind; destruct (f o'); cbn.
+   apply Proper_bind; [reflexivity | intros [| [|]]].
+   unfold pure; rewrite !bind_ret_l; reflexivity.
+   unfold pure; cbn; rewrite !bind_ret_l; reflexivity.
+   unfold pure; cbn; rewrite !bind_ret_l; reflexivity.
+  Qed.
+
+  Global Instance Iterative_eitherTM : Iterative (Kleisli (eitherT A M)) sum.
+  Proof.
+  constructor;
+  typeclasses eauto.
+  Qed.
+
+End Either.

--- a/theories/Basics/MonadEither.v
+++ b/theories/Basics/MonadEither.v
@@ -73,43 +73,6 @@ Section Either.
     | inr (inr b) => inr (inr b)
     end.
 
-  (* Definition iso_inv {a b:Type} (sab : (S * a) + (S * b)) : S * (a + b) := *)
-  (*   match sab with *)
-  (*   | inl (s, a) => (s, inl a) *)
-  (*   | inr (s, b) => (s, inr b) *)
-  (*   end. *)
-
-  (* Definition internalize {a b:Type} (f : Kleisli (eitherT S M) a b) : Kleisli M (S * a) (S * b) := *)
-  (*   fun (sa : S * a) => f (snd sa) (fst sa). *)
-
-  (* Lemma internalize_eq {a b:Type} (f g : Kleisli (eitherT S M) a b) : *)
-  (*   eq2 f g <-> eq2 (internalize f) (internalize g). *)
-  (* Proof. *)
-  (*   split. *)
-  (*   - intros. *)
-  (*     repeat red. destruct a0. *)
-  (*     unfold internalize. cbn.  apply H. *)
-  (*   - intros. *)
-  (*     repeat red. intros. *)
-  (*     unfold internalize in H. *)
-  (*     specialize (H (a1, a0)). *)
-  (*     apply H. *)
-  (* Qed. *)
-
-
-  (* Lemma internalize_pure {a b c} (f : Kleisli (eitherT S M) a b) (g : S * b -> S * c) : *)
-  (*   internalize f >>> pure g   ⩯   (internalize (f >>> (fun b s => ret (g (s,b))))). *)
-  (* Proof. *)
-  (*   repeat red. *)
-  (*   destruct a0. *)
-  (*   unfold internalize, cat, Cat_Kleisli. cbn. *)
-  (*   apply Proper_bind; auto. *)
-  (*   - reflexivity. *)
-  (*   - repeat red. *)
-  (*     destruct a1. *)
-  (*     unfold pure. reflexivity. *)
-  (* Qed. *)
-
   Definition internalize {a b:Type} (f : Kleisli (eitherT A M) a b) : Kleisli M a (A + b) :=
     fun x => let '(mkEitherT y) := f x in y.
 
@@ -117,25 +80,11 @@ Section Either.
     fun (a b: Type) (f: a -> (eitherT A M (a + b))) x =>
       mkEitherT (iter ((internalize f) >>> (pure iso)) x).
 
-  (* Instance proper_internalize: Proper (eqm ==> eq2) internalize. *)
-
   Instance proper_internalize {a b}: Proper (eq2 ==> eq2) (@internalize a b).
   intros x y H o; specialize (H o).
   unfold internalize; destruct (x o), (y o).
   apply H.
   Qed.
-
-  (* Lemma internalize_cat {a b c} (f : Kleisli (eitherT A M) a b) (g : Kleisli (eitherT A M) b c) : *)
-  (*   (internalize (f >>> g)) ⩯ ((internalize f) >>> (internalize g)). *)
-  (* Proof. *)
-  (*   repeat red. *)
-  (*   destruct a0. *)
-  (*   cbn. *)
-  (*   unfold internalize. *)
-  (*   unfold cat, Cat_Kleisli. *)
-  (*   cbn. *)
-  (*   reflexivity. *)
-  (* Qed. *)
 
   Global Instance Proper_Iter_eitherTM : forall a b, @Proper (Kleisli (eitherT A M) a (a + b) -> (Kleisli (eitherT A M) a b)) (eq2 ==> eq2) iter.
   Proof.

--- a/theories/Interp/InterpEither.v
+++ b/theories/Interp/InterpEither.v
@@ -1,0 +1,91 @@
+(** * Monadic interpretations of interaction trees *)
+
+(** We can derive semantics for an interaction tree [itree E ~> M]
+    from semantics given for every individual event [E ~> M],
+    when [M] is a monad (actually, with some more structure).
+
+    We define the following terminology for this library.
+    Other sources may have different usages for the same or related
+    words.
+
+    The notation [E ~> F] stands for [forall T, E T -> F T]
+    (in [ITree.Basics]).
+    It can mean many things, including the following:
+
+    - The semantics of itrees are given as monad morphisms
+      [itree E ~> M], also called "interpreters".
+
+    - "ITree interpreters" (or "itree morphisms") are monad morphisms
+      where the codomain is made of ITrees: [itree E ~> itree F].
+
+    Interpreters can be obtained from handlers:
+
+    - In general, "event handlers" are functions [E ~> M] where
+      [M] is a monad.
+
+    - "ITree event handlers" are functions [E ~> itree F].
+
+    Categorically, this boils down to saying that [itree] is a free
+    monad (not quite, but close enough).
+ *)
+
+(* begin hide *)
+From ExtLib Require Import
+     Structures.Functor
+     EitherMonad
+     Structures.Monad.
+
+From ITree Require Import
+     Basics.Basics
+     Core.ITreeDefinition
+     Indexed.Relation.
+(* end hide *)
+
+(** ** Translate *)
+
+(** An event morphism [E ~> F] lifts to an itree morphism [itree E ~> itree F]
+    by applying the event morphism to every visible event.  We call this
+    process _event translation_.
+
+    Translation is a special case of interpretation:
+[[
+    translate h t ≈ interp (trigger ∘ h) t
+]]
+    However this definition of [translate] yields strong bisimulations
+    more often than [interp].
+    For example, [translate (id_ E) t ≅ id_ (itree E)].
+*)
+
+(** A plain event morphism [E ~> F] defines an itree morphism
+    [itree E ~> itree F]. *)
+(* Definition translateF {E F R} (h : E ~> F) (rec: itree E R -> itree F R) (t : itreeF E R _) : itree F R  := *)
+(*   match t with *)
+(*   | RetF x => Ret x *)
+(*   | TauF t => Tau (rec t) *)
+(*   | VisF e k => Vis (h _ e) (fun x => rec (k x)) *)
+(*   end. *)
+
+(* Definition translate {E F} (h : E ~> F) *)
+(*   : itree E ~> itree F *)
+(*   := fun R => cofix translate_ t := translateF h translate_ (observe t). *)
+
+(* Arguments translate {E F} h [T]. *)
+
+(** ** Interpret *)
+
+(** An event handler [E ~> M] defines a monad morphism
+    [itree E ~> M] for any monad [M] with a loop operator. *)
+
+Definition interp_either {E M : Type -> Type} {A: Type}
+           {FM : Functor M} {MM : Monad M} {IM : MonadIter M}
+           (h : E ~> eitherT A M) :
+  eitherT A (itree E) ~> eitherT A M :=
+  fun R => iter (fun t =>
+                match observe (unEitherT t) with
+                | RetF (inl a) => mkEitherT (ret (inl a))
+                | RetF (inr r) => ret (inr r)
+                | TauF t => ret (inl (mkEitherT t))
+                | VisF e k => fmap (fun x => inl (mkEitherT (k x))) (h _ e)
+                end).
+
+Arguments interp_either {E M A FM MM IM} h [T].


### PR DESCRIPTION
This PR describes the ongoing work to denote open control flow graphs, such as in the `asm` language used in the tutorial, in presence of functional calls and return statements. The motivation for this PR comes from Vellvm.

Currently, we only extend `asm` with return statements, a `Bret` case in the `Branch` data-type, so that we do not have to bother with call-stacks. We quickly describe why this extension is already problematic.

A natural denotation for `Bret r` is to return the value stored in the register `r`. However, this impacts the type of the denotation of a block: from `itree E label`, we now may return a value, i.e. we now work with an `itree E (label + value)`.

This simple modification however completely jeopardize the denotation of open programs: by relying on a `loop` operator over the `ktree` category, we rely on the uniformity of the entry and return types. Intuitively, the issue is that returning acts as an exception, so that the loop combinator do not know what to do when fed such a value.

The natural answer is naturally "since it acts as an effect, it should be an event"! However, this cannot work either. Indeed, if the event is simply parametized by the register and returning a value, then our type has not changes. To avoid carrying a value, it would have to be parameterized by the continuation, i.e. the continuation at call-site, which would require some higher-order trickery that `itrees` do not support.

We therefore are exploring a more blasphemous path: stranding away from the beautiful land of the freer monad and denote (before interpretation!) our programs directly into `eitherT value (itree E)`. By doing so, the exception behavior is internalize by the `eitherT` monad transformers, and we recover the right type for our loop combinator.

As far as denotation is concerned, it is fairly straightforward: it only requires a slight generalization of the finite type manipulated, as well as of course lifting the Kleisli structure via the `EitherT` transformer (see `Basics/MonadEither.v`).

Things get a bit more troublesome from there. We now need a new interpreter, and as far as I can see it cannot be simply expressed in terms of the current `interp`. The file `InterEither` therefore define two such, where the hesitation comes from whether the handlers themselves should live in the `either` monad.

This path will likely lead to the duplication of all the code related to interpreters. Alternatively, we could try defining a type class of "Interpretable" monads in order to factor things out.

If anyone sees a simpler way to tackle this issue, suggestions are welcome :)