### PR TITLE
Bind notation allowing for type cast annotations of variables

### DIFF
--- a/theories/Core/ITreeDefinition.v
+++ b/theories/Core/ITreeDefinition.v
@@ -246,6 +246,8 @@ Notation "t1 >>= k2" := (ITree.bind t1 k2)
   (at level 58, left associativity) : itree_scope.
 Notation "x <- t1 ;; t2" := (ITree.bind t1 (fun x => t2))
   (at level 61, t1 at next level, right associativity) : itree_scope.
+Notation "` x : t <- t1 ;; t2" := (ITree.bind t1 (fun x : t => t2))
+  (at level 61, t at next level, t1 at next level, x ident, right associativity) : itree_scope.
 Notation "t1 ;; t2" := (ITree.bind t1 (fun _ => t2))
   (at level 61, right associativity) : itree_scope.
 Notation "' p <- t1 ;; t2" :=


### PR DESCRIPTION
Possible comfort fix for #174 

As far as my notation-foo goes, I think it is necessary to use a token before the ident, and that this token cannot be the same as the quote used for binding patterns. 

I used an antiquote here: sounds good to you as well @Lysxia ?