### PR TITLE
Remove uses of axioms

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,9 +44,6 @@ workflows:
   build:
     jobs:
     - test:
-        name: "Coq 8.8"
-        coq: "8.8"
-    - test:
         name: "Coq 8.9"
         coq: "8.9"
     - test:

--- a/README.md
+++ b/README.md
@@ -42,6 +42,30 @@ See [`coq-itree.opam`](./coq-itree.opam) for version details.
 
 Feel free to open an issue or a pull request!
 
+## Axioms
+
+This library depends on UIP for the inversion lemma:
+
+```coq
+Lemma eqit_inv_Vis
+  : eutt eq (Vis e k1) (Vis e k2) ->
+    forall x, eutt eq (k1 x) (k2 x).
+```
+
+There are a few more lemmas that depend on it, but you might not actually need
+it. For example, the compiler proof in `tutorial` doesn't need it and is
+axiom-free.
+
+That lemma also has a weaker, but axiom-free version using heterogeneous
+equality: `eqit_inv_Vis_weak`.
+
+The library exports the following axiom for convenience, though it's unlikely
+you'll need it, and the rest of the library does not depend on it:
+
+```coq
+Axiom bisimulation_is_eq : t1 ≅ t2 -> t1 = t2.
+```
+
 ---
 
 ## For developers

--- a/_CoqConfig
+++ b/_CoqConfig
@@ -29,6 +29,7 @@ theories/Core/Subevent.v
 theories/Core/ITreeMonad.v
 
 theories/Eq.v
+theories/Eq/Paco2.v
 theories/Eq/Shallow.v
 theories/Eq/Eq.v
 theories/Eq/UpToTaus.v

--- a/coq-itree.opam
+++ b/coq-itree.opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml"
   "coq" {>= "8.8"}
   "coq-ext-lib" {>= "0.11.1"}
-  "coq-paco" {>= "4.0.0"}
+  "coq-paco" {>= "4.0.1"}
   "ocamlbuild" {with-test}
 ]
 authors: [

--- a/coq-itree.opam
+++ b/coq-itree.opam
@@ -15,7 +15,7 @@ run-test: [ make "-j%{jobs}%" "all" ]
 
 depends: [
   "ocaml"
-  "coq" {>= "8.8"}
+  "coq" {>= "8.9"}
   "coq-ext-lib" {>= "0.11.1"}
   "coq-paco" {>= "4.0.1"}
   "ocamlbuild" {with-test}

--- a/examples/ITreePredicatesExample.v
+++ b/examples/ITreePredicatesExample.v
@@ -12,14 +12,15 @@ From Coq Require Import
      Classes.Morphisms
      ProofIrrelevance.
 
+From Paco Require Import paco.
+
 From ExtLib Require Import
      Monads.
 
 From ITree Require Import
      ITree
-     ITreeFacts.
-
-From Paco Require Import paco.
+     ITreeFacts
+     Eq.Paco2.
 
 Import ITreeNotations.
 
@@ -96,7 +97,7 @@ Section Proper.
    *)
   Instance proper_interpret_state {S R} : Proper ((@eq_itree (stateE S) R _ eq) ==> (@eq S) ==> (@eq_itree void1 (S * R) _ eq)) interpret_state.
   Proof.
-    ginit. gcofix CIH.
+    ginit. pcofix CIH.
     intros x y H0 x2 y0 H1. 
     rewrite (itree_eta (interpret_state x x2)).
     rewrite (itree_eta (interpret_state y y0)).
@@ -230,7 +231,7 @@ Lemma state_independent : forall {S R} (t:itree (stateE S) R)
     forall s s', ('(s,x) <- interpret_state t s ;; ret x) ≅ ('(s,x) <- interpret_state t s' ;; ret x).
 Proof.
   intros S R.
-  ginit. gcofix CIH.
+  ginit. pcofix CIH.
   intros t H0 s s'. 
   rewrite (itree_eta (interpret_state t s)).
   rewrite (itree_eta (interpret_state t s')).
@@ -262,7 +263,7 @@ Lemma state_independent_k : forall {S R U} (t:itree (stateE S) R)
     forall s s', (sx <- interpret_state t s ;; (k sx)) ≅ (sx <- interpret_state t s' ;; (k sx)).
 Proof.
   intros S R U.
-  ginit. gcofix CIH.
+  ginit. pcofix CIH.
   intros t H0 k INV s s'. 
   rewrite (itree_eta (interpret_state t s)).
   rewrite (itree_eta (interpret_state t s')).

--- a/theories/Core/KTreeFacts.v
+++ b/theories/Core/KTreeFacts.v
@@ -2,7 +2,6 @@
 
 (* begin hide *)
 From Coq Require Import
-     Program
      Classes.Morphisms
      Setoids.Setoid
      Relations.Relations.
@@ -21,7 +20,8 @@ From ITree Require Import
      Core.ITreeMonad
      Core.KTree
      Eq.Eq
-     Eq.UpToTaus.
+     Eq.UpToTaus
+     Eq.Paco2.
 
 Import ITreeNotations.
 Import CatNotations.
@@ -65,7 +65,7 @@ Lemma eq_itree_iter' {E I1 I2 R1 R2}
   : forall (i1 : I1) (i2 : I2) (RI_i : RI i1 i2),
     @eq_itree E _ _ RR (ITree.iter body1 i1) (ITree.iter body2 i2).
 Proof.
-  ginit. gcofix CIH. intros.
+  ginit. pcofix CIH. intros.
   specialize (eutt_body i1 i2 RI_i).
   do 2 rewrite unfold_iter.
   guclo eqit_clo_bind; econstructor; eauto.
@@ -202,8 +202,8 @@ Lemma iter_dinatural_ktree {E A B C}
      | inr b => Ret b
      end.
 Proof.
-  revert A B C f g a0.
-  ginit. gcofix CIH. intros.
+  revert f g a0.
+  ginit. pcofix CIH. intros.
   rewrite unfold_iter_ktree.
   rewrite bind_bind.
   guclo eqit_clo_bind. econstructor. try reflexivity.
@@ -265,7 +265,7 @@ Lemma iter_codiagonal_ktree {E A B} (f : ktree E A (A + (A + B))) (a0 : A)
        end) a0.
 Proof.
   revert a0.
-  ginit. gcofix CIH. intros.
+  ginit. pcofix CIH. intros.
   rewrite unfold_iter_ktree.
   rewrite (unfold_iter_ktree (fun _ => _ _ _)).
   rewrite unfold_iter_ktree, !bind_bind.
@@ -274,7 +274,7 @@ Proof.
   - rewrite bind_ret_l, bind_tau.
     gstep. constructor.
     revert a.
-    gcofix CIH'. intros.
+    pcofix CIH'. intros.
     rewrite unfold_iter_ktree.
     rewrite (unfold_iter_ktree (fun _ => _ _ _)).
     rewrite !bind_bind.
@@ -334,8 +334,7 @@ Proof.
     rewrite ! bind_ret_l.
     rewrite bind_tau.
     etau.
-    specialize (CIH xa).
-    cbn in CIH.
+    specialize (CIHL xa). cbn in CIHL.
     match goal with
       |- euttG _ _ _ _ _ ?t _ => remember t
     end.

--- a/theories/Eq/Eq.v
+++ b/theories/Eq/Eq.v
@@ -164,7 +164,7 @@ Hint Unfold eutt: core.
 Hint Unfold euttge: core.
 Hint Unfold id: core.
 
-Lemma eqitF_VisF_inv_r {E R1 R2} (RR : R1 -> R2 -> Prop) {b1 b2 vclo sim}
+Lemma eqitF_inv_VisF_r {E R1 R2} (RR : R1 -> R2 -> Prop) {b1 b2 vclo sim}
     t1 X2 (e2 : E X2) (k2 : X2 -> _)
   : eqitF RR b1 b2 vclo sim t1 (VisF e2 k2) ->
     (exists k1, t1 = VisF e2 k1 /\ forall v, vclo sim (k1 v) (k2 v)) \/
@@ -184,7 +184,7 @@ Proof.
   - destruct i0; eauto.
 Qed.
 
-Lemma eqitF_VisF_inv {E R1 R2} (RR : R1 -> R2 -> Prop) {b1 b2 vclo sim}
+Lemma eqitF_inv_VisF_weak {E R1 R2} (RR : R1 -> R2 -> Prop) {b1 b2 vclo sim}
     X1 (e1 : E X1) (k1 : X1 -> _) X2 (e2 : E X2) (k2 : X2 -> _)
   : eqitF RR b1 b2 vclo sim (VisF e1 k1) (VisF e2 k2) ->
     exists p : X1 = X2, eqeq E p e1 e2 /\ pweqeq (vclo sim) p k1 k2.
@@ -202,7 +202,7 @@ Proof.
   - destruct i; exact I.
 Qed.
 
-Lemma eqitF_VisF_inv_strong {E R1 R2} (RR : R1 -> R2 -> Prop) {b1 b2 vclo sim}
+Lemma eqitF_inv_VisF {E R1 R2} (RR : R1 -> R2 -> Prop) {b1 b2 vclo sim}
     X (e : E X) (k1 : X -> _) (k2 : X -> _)
   : eqitF RR b1 b2 vclo sim (VisF e k1) (VisF e k2) ->
     forall x, vclo sim (k1 x) (k2 x).
@@ -210,7 +210,7 @@ Proof.
   intros H. dependent destruction H. assumption.
 Qed.
 
-Lemma eqitF_VisF {E R1 R2} {RR : R1 -> R2 -> Prop} {b1 b2 vclo sim}
+Lemma eqitF_VisF_gen {E R1 R2} {RR : R1 -> R2 -> Prop} {b1 b2 vclo sim}
     {X1 X2} (p : X1 = X2) (e1 : E X1) (k1 : X1 -> _) (e2 : E X2) (k2 : X2 -> _)
   : eqeq E p e1 e2 -> pweqeq (vclo sim) p k1 k2 ->
     eqitF RR b1 b2 vclo sim (VisF e1 k1) (VisF e2 k2).
@@ -603,59 +603,53 @@ End eqit_eq.
 
 (** *** One-sided inversion *)
 
-Lemma eq_itree_inv_ret {E R} (t : itree E R) r :
+Lemma eq_itree_inv_Ret_r {E R} (t : itree E R) r :
   t ≅ (Ret r) -> observe t = RetF r.
 Proof.
   intros; punfold H; inv H; try inv CHECK; eauto.
 Qed.
 
-Lemma eq_itree_inv_vis {E R U} (t : itree E R) (e : E U) (k : U -> _) :
+Lemma eq_itree_inv_Vis_r {E R U} (t : itree E R) (e : E U) (k : U -> _) :
   t ≅ Vis e k -> exists k', observe t = VisF e k' /\ forall u, k' u ≅ k u.
 Proof.
-  intros; punfold H; apply eqitF_VisF_inv_r in H.
+  intros; punfold H; apply eqitF_inv_VisF_r in H.
   destruct H as [ [? [-> ?]] | [] ]; [ | discriminate ].
   pclearbot. eexists; split; eauto.
 Qed.
 
-Lemma eq_itree_inv_tau {E R} (t t' : itree E R) :
+Lemma eq_itree_inv_Tau_r {E R} (t t' : itree E R) :
   t ≅ Tau t' -> exists t0, observe t = TauF t0 /\ t0 ≅ t'.
 Proof.
   intros; punfold H; inv H; try inv CHECK; pclearbot; eauto.
 Qed.
 
-Lemma eqit_inv_ret {E R1 R2 RR} b1 b2 r1 r2 :
+Lemma eqit_inv_Ret {E R1 R2 RR} b1 b2 r1 r2 :
   @eqit E R1 R2 RR b1 b2 (Ret r1) (Ret r2) -> RR r1 r2.
 Proof.
   intros. punfold H. inv H. eauto.
 Qed.
 
-Lemma pweqeq_mon {R1 R2} (RR1 RR2 : R1 -> R2 -> Prop) X1 X2 (p : X1 = X2) k1 k2
-  : (forall r1 r2, RR1 r1 r2 -> RR2 r1 r2) -> pweqeq RR1 p k1 k2 -> pweqeq RR2 p k1 k2.
-Proof.
-  destruct p; cbn; auto.
-Qed.
-
 (* Axiom-free, weaker version of [eqit_inv_vis] *)
-Lemma eqit_inv_vis_weak {E R1 R2 RR} b1 b2
+Lemma eqit_inv_Vis_weak {E R1 R2 RR} b1 b2
   {u1 u2} (e1 : E u1) (e2 : E u2) (k1: u1 -> itree E R1) (k2: u2 -> itree E R2) :
   eqit RR b1 b2 (Vis e1 k1) (Vis e2 k2) ->
   exists p, eqeq E p e1 e2 /\ pweqeq (eqit RR b1 b2) p k1 k2.
 Proof.
-  intros. punfold H; apply eqitF_VisF_inv in H.
+  intros. punfold H; apply eqitF_inv_VisF_weak in H.
   destruct H as [ p []]. exists p; split; auto.
   revert H0; apply pweqeq_mon; intros; pclearbot; auto.
 Qed.
 
 (* This assumes UIP. *)
-Lemma eqit_inv_vis {E R1 R2} (RR : R1 -> R2 -> Prop) b1 b2 U (e : E U)
+Lemma eqit_inv_Vis {E R1 R2} (RR : R1 -> R2 -> Prop) b1 b2 U (e : E U)
     (k1 : U -> itree E R1) (k2 : U -> itree E R2)
   : eqit RR b1 b2 (Vis e k1) (Vis e k2) ->
     forall u, eqit RR b1 b2 (k1 u) (k2 u).
 Proof.
-  intros H x; punfold H; apply eqitF_VisF_inv_strong with (x := x) in H; pclearbot; auto.
+  intros H x; punfold H; apply eqitF_inv_VisF with (x := x) in H; pclearbot; auto.
 Qed.
 
-Lemma eqit_inv_tauL {E R1 R2 RR} b1 t1 t2 :
+Lemma eqit_inv_Tau_l {E R1 R2 RR} b1 t1 t2 :
   @eqit E R1 R2 RR b1 true (Tau t1) t2 -> eqit RR b1 true t1 t2.
 Proof.
   intros. punfold H. red in H. simpl in *.
@@ -666,7 +660,7 @@ Proof.
   - red in IHeqitF. pstep. red; simpobs. econstructor; eauto. pstep_reverse.
 Qed.
 
-Lemma eqit_inv_tauR {E R1 R2 RR} b2 t1 t2 :
+Lemma eqit_inv_Tau_r {E R1 R2 RR} b2 t1 t2 :
   @eqit E R1 R2 RR true b2 t1 (Tau t2) -> eqit RR true b2 t1 t2.
 Proof.
   intros. punfold H. red in H. simpl in *.
@@ -677,7 +671,7 @@ Proof.
   - inv Heqtt2. punfold_reverse H.
 Qed.
 
-Lemma eqit_inv_tauLR {E R1 R2 RR} b1 b2 t1 t2 :
+Lemma eqit_inv_Tau {E R1 R2 RR} b1 b2 t1 t2 :
   @eqit E R1 R2 RR b1 b2 (Tau t1) (Tau t2) -> eqit RR b1 b2 t1 t2.
 Proof.
   intros. punfold H. red in H. simpl in *.
@@ -692,96 +686,62 @@ Proof.
     + pstep. red. simpobs. econstructor; eauto. pstep_reverse. apply IHeqitF; eauto.
 Qed.
 
-Lemma eqit_inv_ret_vis: forall {E X R1 R2 RR} b1 b2 (r: R1) (e: E X) k,
-    @eqit E R1 R2 RR b1 b2 (Ret r) (Vis e k) -> False.
+Section eqit_inv.
+
+Context {E : Type -> Type} {R1 R2} {RR : R1 -> R2 -> Prop} {b1 b2 : bool}.
+Context {vclo : (itree E R1 -> itree E R2 -> Prop) -> (itree E R1 -> itree E R2 -> Prop)}.
+Context {sim : itree E R1 -> itree E R2 -> Prop}.
+
+Notation eqit__ t1_ t2_ :=
+  match _observe t1_, _observe t2_ with
+  | RetF r1, RetF r2 => RR r1 r2
+  | VisF e1 k1, VisF e2 k2 =>
+    exists p, eqeq E p e1 e2 /\ pweqeq (eqit RR b1 b2) p k1 k2
+  | RetF _, VisF _ _ | VisF _ _, RetF _ => False
+  | TauF t1, TauF t2 => eqit RR b1 b2 t1 t2
+  | TauF t1, _ =>
+    if b1 then eqit RR b1 b2 t1 t2_
+    else False
+  | _, TauF t2 =>
+    if b2 then eqit RR b1 b2 t1_ t2
+    else False
+  end.
+
+Lemma eqit_inv t1 t2 : eqit RR b1 b2 t1 t2 -> eqit__ t1 t2.
 Proof.
-  intros.
-  punfold H; inv H.
+  intros H; punfold H; red in H.
+  genobs t1 ot1; genobs t2 ot2; revert t1 t2 Heqot1 Heqot2; unfold observe, _observe.
+  destruct H; pclearbot; intros * E1 E2; rewrite <- E1, <- E2; cbn; auto.
+  - exists eq_refl; cbn; eauto.
+  - rewrite CHECK in *. destruct ot2.
+    1,3: pfold; red; unfold observe, _observe; rewrite <- E2; assumption.
+    1: apply eqit_inv_Tau_r; pfold; red; unfold observe, _observe; assumption.
+  - rewrite CHECK in *. destruct ot1.
+    1,3: pfold; red; unfold observe, _observe; rewrite <- E1; assumption.
+    1: apply eqit_inv_Tau_l; pfold; red; unfold observe, _observe; assumption.
 Qed.
 
-Lemma eutt_inv_ret_vis: forall {X Y E} (x: X) (e: E Y) k, Ret x ≈ Vis e k -> False.
-Proof.
-  intros; eapply eqit_inv_ret_vis; eauto.
-Qed.
+End eqit_inv.
 
-Lemma eqitree_inv_ret_vis: forall {X Y E} (x: X) (e: E Y) k, Ret x ≅ Vis e k -> False.
-Proof.
-  intros; eapply eqit_inv_ret_vis; eauto.
-Qed.
-
-Lemma eqit_inv_tau_vis: forall {E X R1 R2 RR} b2 (e: E X) k t,
-    @eqit E R1 R2 RR false b2 (Tau t) (Vis e k) -> False.
-Proof.
-  intros.
-  punfold H; inv H.
-  inv CHECK.
-Qed.
-
-Lemma eqit_inv_vis_tau: forall {E X R1 R2 RR} b1 (e: E X) k t,
-    @eqit E R1 R2 RR b1 false (Vis e k) (Tau t) -> False.
-Proof.
-  intros.
-  punfold H; inv H.
-  inv CHECK.
-Qed.
-
-Lemma euttge_inv_tau_vis: forall {E A B} (e: E A) (k : A -> itree E B) (a : itree E B), Vis e k ≳ Tau a -> False.
-Proof.
-  intros; eapply eqit_inv_vis_tau; eauto.
-Qed.
-
-Lemma eqitree_inv_tau_vis: forall {E A B} (e: E A) (k : A -> itree E B) (a : itree E B), Tau a ≅ Vis e k -> False.
-Proof.
-  intros; eapply eqit_inv_tau_vis; eauto.
-Qed.
-
-Lemma eqit_inv_ret_tau: forall {E R1 R2 RR} b1 (r: R1) t,
-    @eqit E R1 R2 RR b1 false (Ret r) (Tau t) -> False.
-Proof.
-  intros.
-  punfold H; inv H.
-  inv CHECK.
-Qed.
-
-Lemma eqit_inv_tau_ret: forall {E R1 R2 RR} b2 (r: R2) t,
-    @eqit E R1 R2 RR false b2 (Tau t) (Ret r) -> False.
-Proof.
-  intros.
-  punfold H; inv H.
-  inv CHECK.
-Qed.
-
-Lemma euttge_inv_ret_tau: forall {E A} (r : A) (a : itree E A),
-    Ret r ≳ Tau a -> False.
-Proof.
-  intros; eapply eqit_inv_ret_tau; eauto.
-Qed.
-
-Lemma eqitree_inv_ret_tau: forall {E A} (r : A) (a : itree E A),
-    Ret r ≅ Tau a -> False.
-Proof.
-  intros; eapply eqit_inv_ret_tau; eauto.
-Qed.
-
-Lemma eutt_inv_ret {E R} r1 r2 :
+Lemma eutt_inv_Ret {E R} r1 r2 :
   (Ret r1: itree E R) ≈ (Ret r2) -> r1 = r2.
 Proof.
-  intros; eapply eqit_inv_ret; eauto.
+  intros; eapply eqit_inv_Ret; eauto.
 Qed.
 
-Lemma eqitree_inv_ret {E R} r1 r2 :
+Lemma eq_itree_inv_Ret {E R} r1 r2 :
   (Ret r1: itree E R) ≅ (Ret r2) -> r1 = r2.
 Proof.
-  intros; eapply eqit_inv_ret; eauto.
+  intros; eapply eqit_inv_Ret; eauto.
 Qed.
 
-Lemma eqit_tauL {E R1 R2 RR} b2 (t1 : itree E R1) (t2 : itree E R2) :
+Lemma eqit_Tau_l {E R1 R2 RR} b2 (t1 : itree E R1) (t2 : itree E R2) :
   eqit RR true b2 t1 t2 -> eqit RR true b2 (Tau t1) t2.
 Proof.
   intros. pstep. econstructor; eauto. punfold H.
 Qed.
 
-Lemma eqit_tauR {E R1 R2 RR} b1 (t1 : itree E R1) (t2 : itree E R2) :
+Lemma eqit_Tau_r {E R1 R2 RR} b1 (t1 : itree E R1) (t2 : itree E R2) :
   eqit RR b1 true t1 t2 -> eqit RR b1 true t1 (Tau t2).
 Proof.
   intros. pstep. econstructor; eauto. punfold H.
@@ -790,7 +750,7 @@ Qed.
 Lemma tau_euttge {E R} (t: itree E R) :
   Tau t ≳ t.
 Proof.
-  apply eqit_tauL. reflexivity.
+  apply eqit_Tau_l. reflexivity.
 Qed.
 
 Lemma tau_eutt {E R} (t: itree E R) :
@@ -832,7 +792,7 @@ Proof.
     destruct DEC as [EQ | EQ].
     + destruct EQ as [m3 ?]; subst.
       econstructor. right. pclearbot. eapply CIH; eauto with paco.
-      eapply eqit_inv_tauLR. eauto.
+      eapply eqit_inv_Tau. eauto.
     + inv INR; try (exfalso; eapply EQ; eauto; fail).
       econstructor; eauto.
       pclearbot. punfold REL. red in REL.
@@ -845,7 +805,7 @@ Proof.
         destruct (REL v), (REL0 v); try contradiction. eauto.
       * eapply IHREL0; eauto. pstep_reverse.
         destruct b1; inv CHECK0.
-        apply eqit_inv_tauR. eauto.
+        apply eqit_inv_Tau_r. eauto.
   - remember (VisF e k2) as ot.
     hinduction INR before CIH; intros; try discriminate; eauto; inv_Vis.
     econstructor. intros.
@@ -1092,10 +1052,10 @@ Proof.
   - destruct b1; try discriminate.
     guclo eqit_clo_trans.
     econstructor; auto_ctrans_eq; cycle -1; eauto; try reflexivity.
-    eapply eqit_tauL. rewrite unfold_bind, <-itree_eta. reflexivity.
+    eapply eqit_Tau_l. rewrite unfold_bind, <-itree_eta. reflexivity.
   - destruct b2; try discriminate.
     guclo eqit_clo_trans. econstructor; auto_ctrans_eq; cycle -1; eauto; try reflexivity.
-    eapply eqit_tauL. rewrite unfold_bind, <-itree_eta. reflexivity.
+    eapply eqit_Tau_l. rewrite unfold_bind, <-itree_eta. reflexivity.
 Qed.
 
 Lemma eutt_clo_bind {U1 U2 UU} t1 t2 k1 k2
@@ -1311,9 +1271,9 @@ Proof.
       cbn in *. rewrite <- H0. rewrite itree_eta, Hobtl.
       apply eqit_Ret; auto.
     * cbn in H0. rewrite itree_eta in H0. rewrite Hobtl in H0.
-      apply eqitree_inv_ret_tau in H0. contradiction.
+      apply eqit_inv in H0. contradiction.
     * cbn in H0. rewrite itree_eta, Hobtl in H0.
-      apply eqitree_inv_ret_vis in H0. contradiction.
+      apply eqit_inv in H0. contradiction.
   - intros. inversion Heqtr.
   - intros. inversion Heqtr.
   - intros. subst.
@@ -1328,16 +1288,16 @@ Proof.
         reflexivity.
       * exists a; split; auto.
         rewrite itree_eta, Hobma in H1.
-        apply eqit_inv_ret in H1; subst.
+        apply eqit_inv_Ret in H1; subst.
         rewrite <- H0.
         destruct b1; [| inv CHECK].
-        apply eqit_tauL; auto.
+        apply eqit_Tau_l; auto.
     + cbn in *. rewrite eqitree_Tau in H0.
       edestruct IHeqitF as (a & ? & ?);[reflexivity | apply H0 | reflexivity |].
       exists a; split; [| assumption].
       destruct b1; [| inv CHECK].
-      rewrite itree_eta, Hobma; apply eqit_tauL; auto.
-    + exfalso. cbn in H0; apply eqitree_inv_tau_vis in H0; contradiction.
+      rewrite itree_eta, Hobma; apply eqit_Tau_l; auto.
+    + exfalso. cbn in H0; apply eqit_inv in H0; contradiction.
   - intros. inversion Heqtr.
 Qed.
 
@@ -1381,9 +1341,9 @@ Proof.
     + right. exists r. split. rewrite itree_eta. rewrite Hobma. reflexivity.
       rewrite <- H0. apply eqit_Vis.
       intros. destruct (REL u0); auto. inv H.
-    + symmetry in H0. apply eqitree_inv_tau_vis in H0. contradiction.
+    + symmetry in H0. apply eqit_inv in H0. contradiction.
     + setoid_rewrite itree_eta at 1. rewrite Hobma. clear Hobma Heqtl'.
-      red in H0. apply eqit_inv_vis_weak in H0.
+      red in H0. apply eqit_inv_Vis_weak in H0.
       destruct H0 as [<- [<- H0]]; cbn in H0.
       inv_Vis.
       left. exists k. split; [reflexivity |].
@@ -1401,12 +1361,12 @@ Proof.
         reflexivity.
       * left.
         destruct a as (kca & HMA & HEQ).
-        exfalso. eapply eqit_inv_ret_vis. eapply eqit_trans; [| apply HMA].
-        apply eqit_flip. rewrite itree_eta. rewrite Hobma. reflexivity.
+        exfalso. eapply eqit_inv in HMA. unfold observe in Hobma; rewrite Hobma in HMA.
+        contradiction.
       * right. destruct a.
         destruct H1 as [H1 H2].
         rewrite itree_eta, Hobma in H1.
-        apply eqit_inv_ret in H1; subst.
+        apply eqit_inv_Ret in H1; subst.
         setoid_rewrite itree_eta at 1.
         rewrite Hobma.
         exists x. split; try reflexivity. rewrite <- H0.
@@ -1421,7 +1381,7 @@ Proof.
         rewrite Hobma.
         destruct a as (? & ? & ?). exists x; split; auto.
         punfold H1. pstep. unfold eqit_ in *. constructor 4; auto.
-    + exfalso. cbn in H0; apply eqitree_inv_tau_vis in H0; contradiction.
+    + exfalso. cbn in H0; apply eqit_inv in H0; contradiction.
   - intros. inv Heqtr.
 Qed.
 
@@ -1472,7 +1432,7 @@ Proof.
       left. exists t. rewrite itree_eta. rewrite Hobma. split; [reflexivity |].
       rewrite eqitree_Tau in H0. rewrite <- H0. pclearbot. auto.
     + cbn in *.
-      apply eqitree_inv_tau_vis in H0. contradiction.
+      apply eqit_inv in H0. contradiction.
   - intros. subst. inv Heqtr'.
   - intros. subst. rewrite itree_eta in H0. rewrite <- Heqtl' in H0.
     rewrite unfold_bind in H0.
@@ -1480,31 +1440,31 @@ Proof.
     destruct (observe ma) eqn:Hobma.
     + cbn in *.
       right. exists r. rewrite itree_eta. rewrite Hobma. split; [reflexivity |].
-      rewrite <- H0. apply eqit_tauL. auto.
+      rewrite <- H0. apply eqit_Tau_l. auto.
     + cbn in *.
       rewrite eqitree_Tau in H0.
       edestruct IHeqitF; eauto; auto.
       * left. destruct H1 as (t' & ? & ?).
         exists t'. rewrite itree_eta. rewrite Hobma. split; auto.
-        apply eqit_tauL. auto.
+        apply eqit_Tau_l. auto.
       * left. destruct H1 as (a & ? & ?).
         exists (Ret a). rewrite itree_eta. rewrite Hobma. rewrite H1.
         split; [reflexivity |]. rewrite unfold_bind. cbn.
-        apply eqit_tauL in H2. rewrite <- eqit_Tau. auto.
-    + cbn in *. apply eqitree_inv_tau_vis in H0; contradiction.
+        apply eqit_Tau_l in H2. rewrite <- eqit_Tau. auto.
+    + cbn in *. apply eqit_inv in H0; contradiction.
   - intros. subst. inv Heqtr'.
     rewrite unfold_bind in H0.
     inv CHECK.
     destruct (observe ma) eqn:Hobma.
     + cbn in *.
       right. exists r. rewrite itree_eta. rewrite Hobma. split; [reflexivity |].
-      rewrite <- H0. apply eqit_tauR. auto.
+      rewrite <- H0. apply eqit_Tau_r. auto.
     + cbn in *.
       left. exists (Tau t). rewrite itree_eta. rewrite Hobma.
-      split; [apply eqit_tauR; reflexivity |].
+      split; [apply eqit_Tau_r; reflexivity |].
       rewrite unfold_bind. simpl. rewrite <- H0. auto.
     + cbn in *. left. exists (Vis e k). rewrite itree_eta. rewrite Hobma.
-      split; [apply eqit_tauR; reflexivity |].
+      split; [apply eqit_Tau_r; reflexivity |].
       rewrite bind_vis. rewrite <- H0. auto.
 Qed.
 

--- a/theories/Eq/Paco2.v
+++ b/theories/Eq/Paco2.v
@@ -1,0 +1,182 @@
+(** Redefinition of [pcofix] and [pcofix] without using the [JMeq_eq] axiom.
+Both tactics are now called [pcofix]. The same core is reused to define [ecofix]
+in [Eq.UpToTaus]. *)
+
+From Paco Require Import paco.
+
+Ltac debug_goal :=
+  match goal with
+  | [ |- ?G ] => idtac G
+  end.
+
+(* A variant of [paco2_acc] that is more convenient to use in the [pcofix] tactic. *)
+Lemma paco2_accF
+  : forall {T0 : Type} {T1 : forall a : T0, Type}
+      (gf : rel2 T0 T1 -> rel2 T0 T1) (r : rel2 T0 T1)
+      (X : Type)
+      (f0 : X -> T0) (f1 : forall x : X, T1 (f0 x)),
+      (forall rr : rel2 T0 T1,
+        (forall a0 a1, r a0 a1 -> rr a0 a1) ->
+        (forall x, rr (f0 x) (f1 x)) ->
+        forall x : X, paco2 gf rr (f0 x) (f1 x)) ->
+      forall x : X, paco2 gf r (f0 x) (f1 x).
+Proof.
+  intros.
+  apply paco2_acc with
+    (l := fun a0 (a1 : T1 a0) => exists x, existT _ (f0 x) (f1 x) = existT _ a0 a1); [ | eauto ].
+  intros. change (paco2 gf rr (projT1 (existT _ _ x1)) (projT2 (existT _ _ x1))).
+  destruct PR as [? <-].
+  eauto.
+Qed.
+
+Lemma gpaco2_accF
+  : forall {T0 : Type} {T1 : forall a : T0, Type}
+      (gf : rel2 T0 T1 -> rel2 T0 T1),
+      monotone2 gf ->
+    forall (clo : rel2 T0 T1 -> rel2 T0 T1) (r rg : rel2 T0 T1)
+      (X : Type)
+      (f0 : X -> T0) (f1 : forall x : X, T1 (f0 x))
+      (OBG : forall rr : rel2 T0 T1,
+        (forall x y, rg x y -> rr x y) ->
+        (forall x, rr (f0 x) (f1 x)) ->
+        forall x : X, gpaco2 gf clo r rr (f0 x) (f1 x)),
+      forall x : X, gpaco2 gf clo r rg (f0 x) (f1 x).
+Proof.
+  intros.
+  apply gpaco2_cofix with
+    (l := fun a0 (a1 : T1 a0) => exists x, existT _ (f0 x) (f1 x) = existT _ a0 a1); [ eauto | | eauto ].
+  intros. change (gpaco2 gf clo r rr (projT1 (existT _ _ x1)) (projT2 (existT _ _ x1))).
+  destruct PR as [? <-].
+  eauto.
+Qed.
+
+Ltac apply_paco_acc self unpack_goal unpack_hyp :=
+  let unpack _tt :=
+    let r := fresh "r" in
+    let self_ := fresh "_tmp_" self in
+    let self := fresh self in
+    intros r self_ self;
+    let self1 := fresh self in
+    rename self_ into self1;
+    unpack_goal tt;
+    unpack_hyp self in
+  lazymatch goal with
+  | [ |- forall _, paco2 ?gf ?r0 _ _ ] => apply paco2_accF; unpack tt
+  | [ |- forall _, gpaco2 ?gf ?clo _ _ _ _ ] => apply gpaco2_accF; [ eauto with paco | unpack tt ]
+  (* TODO: other arities *)
+  | _ => fail "paco not found at the head of the goal"
+  end.
+
+Lemma curry_sig {A : Type} {P : A -> Type} {Q : forall (a : A) (b : P a), Prop}
+  : (forall x : sigT P, Q (projT1 x) (projT2 x)) -> forall (a : A) (p : P a), Q a p.
+Proof.
+  exact (fun H a p => H (existT _ a p)).
+Qed.
+
+(* [pcofix self]: Apply coinduction to a goal with [paco] at the head of the conclusion
+   (possibly after unfolding definitions).
+   The parameter [self] is the name of the coinduction hypothesis. *)
+
+(* Internal definition of [pcofix_]:
+Example initial goal:
+<<
+===========
+forall (x : X) (y : Y), hyp x y -> paco2 gf bot2 (f0 x y) (f1 x y)
+>>
+   1. [pcofix_] first recursively introduces all hypotheses [H], being careful to
+      preserve existing names, and at the same time builds up continuations
+      to process the goal once we reach the conclusion. This technique has the
+      benefit that the name of each hypothesis is available, so it does
+      not need to be guessed repeatedly.
+Goal after step 1:
+<<
+x : X
+y : Y
+H : hyp x y
+===========
+paco2 gf bot2 (f0 x y) (f1 x y)
+>>
+   2. Having reached the conclusion, we use the [pack_goal0] continuation to
+      regeneralize the hypotheses we introduced into a single sigma type
+      (a chain of [{_ & _}]/[sigT]),
+Goal after step 2:
+<<
+===========
+forall (u : {x : X & {y : Y & {_ : hyp x y & unit}}}),
+  paco2 gf bot2 (f0 (projT1 u) (projT2 u)) (f1 (projT1 u) (projT2 u))
+>>
+   3. We can now apply [paco2_accF] (depending on the arity of paco)
+Goal after step 3:
+<<
+r : rel2 T0 T1
+_pacotmp_SELF: forall (u : _), r (f0 (projT1 u) (projT2 u)) (f1 (projT1 u) (projT2 u))
+==========
+forall (u : {x : X & {y : Y & {_ : hyp x y & unit}}}),
+  paco2 gf r (f0 (projT1 u) (projT2 u)) (f1 (projT1 u) (projT2 u))
+>>
+   4. We decompose the tuple in the goal using the [unpack_goal0] continuation
+      (basically the reverse of [pack_goal0]) and [revert_tmp0].
+Goal after step 4:
+<<
+r : rel2 T0 T1
+_pacotmp_SELF: forall (u : _), r (f0 (projT1 u) (projT2 u)) (f1 (projT1 u) (projT2 u))
+==========
+forall x y, hyp x y -> paco2 gf r (f0 x y) (f1 x y)
+>>
+   5. We decompose the tuple in the coinduction hypothesis
+Goal after step 5:
+<<
+r : rel2 T0 T1
+SELF: forall x y, hyp x y -> r (f0 x y) (f1 x y)
+==========
+forall x y, hyp x y -> paco2 gf r (f0 x y) (f1 x y)
+>>
+tODO: Currently this step does not preserve variable names,
+so the actual hypothesis looks more like this:
+<<
+SELF: forall x0 x1, hyp x0 x1 -> r (f0 x0 x1) (f1 x0 x1)
+>>
+*)
+Ltac pcofix_ apply_paco_acc0 pack_goal0 unpack_goal0 revert_tmp0 unpack_hyp0 :=
+  hnf;
+  lazymatch goal with
+  | [ |- forall H : ?X, _ ] =>
+    (* 1. *)
+    let H := fresh H in
+    intros H;
+    let pack_goal := (revert H; apply curry_sig; pack_goal0) in
+    let unpack_goal H0 := ltac:(unpack_goal0 H0; destruct H0 as [H H0]; cbn [projT1 projT2]) in
+    let revert_tmp := revert H; revert_tmp0 in
+    let unpack_hyp tmp_self :=
+      intros H;
+      let tmp := fresh tmp_self in
+      rename tmp_self into tmp;
+      assert (tmp_self := fun TMP => tmp (existT _ H TMP));
+      clear tmp;
+      unpack_hyp0 tmp_self in
+    pcofix_ apply_paco_acc0 pack_goal unpack_goal revert_tmp unpack_hyp
+  | _ =>
+    let (* 4 *) unpack_goal _tt :=
+      let tmp_H0 := fresh "_pacotmp_" in
+      intros tmp_H0; unpack_goal0 tmp_H0; clear tmp_H0;
+      revert_tmp0 in
+    let (* 5 *) unpack_hyp HYP :=
+      let tmp_prop := fresh HYP "_prop_" in
+      let tmp_hyp := fresh HYP "_v_" in
+      evar (tmp_prop : Prop); assert (tmp_hyp : tmp_prop); subst tmp_prop;
+        [ unpack_hyp0 HYP; cbn in HYP; exact (HYP tt)
+        | clear HYP ];
+      try rename tmp_hyp into HYP in
+    (* 2. pack_goal *) assert (tmp_H0 := tt); revert tmp_H0; pack_goal0;
+    (* 3. paco_acc *) apply_paco_acc0 unpack_goal unpack_hyp
+  end.
+
+Ltac pcofix_with apply_paco_acc0 :=
+  let pack_goal0 := idtac in
+  let unpack_goal0 _ := idtac in
+  let revert_tmp0 := idtac in
+  let unpack_hyp0 _ := idtac in
+  pcofix_ apply_paco_acc0 pack_goal0 unpack_goal0 revert_tmp0 unpack_hyp0.
+
+Tactic Notation "pcofix" ident(self) :=
+  pcofix_with ltac:(apply_paco_acc self).

--- a/theories/Eq/Shallow.v
+++ b/theories/Eq/Shallow.v
@@ -21,25 +21,39 @@ From Coq Require Import
      JMeq.
 (* end hide *)
 
-(* This exists in the stdlib as [ProofIrrelevance.inj_pair2], but we reprove
-   it to not depend on proof irrelevance (we use axiom [JMeq.JMeq_eq] instead) *)
-Lemma inj_pair2 :
-  forall (U : Type) (P : U -> Type) (p : U) (x y : P p),
-    existT P p x = existT P p y -> x = y.
+Definition eqeq {A : Type} (P : A -> Type) {a1 a2 : A} (p : a1 = a2) : P a1 -> P a2 -> Prop :=
+  match p with
+  | eq_refl => eq
+  end.
+
+Definition pweqeq {R1 R2} (RR : R1 -> R2 -> Prop) {X1 X2 : Type} (p : X1 = X2)
+  : (X1 -> R1) -> (X2 -> R2) -> Prop :=
+  match p with
+  | eq_refl => fun k1 k2 => forall x, RR (k1 x) (k2 x)
+  end.
+
+Lemma eq_VisF_inv {E R X1 X2} (e1 : E X1) (e2 : E X2) (k1 : X1 -> itree E R) (k2 : X2 -> itree E R)
+  : VisF (R := R) e1 k1 = VisF (R := R) e2 k2 ->
+    exists p : X1 = X2, eqeq E p e1 e2 /\ eqeq (fun X => X -> itree E R) p k1 k2.
 Proof.
-  intros. apply JMeq_eq.
-  refine (
-      match H in _ = w return JMeq x (projT2 w) with
-      | eq_refl => JMeq_refl
-      end).
+  refine (fun H =>
+    match H in _ = t return
+      match t with
+      | VisF e2 k2 => _
+      | _ => True
+      end
+    with
+    | eq_refl => _
+    end); cbn.
+  exists eq_refl; cbn; auto.
 Qed.
 
-(** Rewrite all heterogeneous equalities with the axiom
-    [inj_pair2 : existT _ T a = existT _ T b -> a = b]. *)
-Ltac auto_inj_pair2 :=
-  repeat (match goal with
-          | [ H : _ |- _ ] => apply inj_pair2 in H
-          end).
+Ltac inv_Vis :=
+  discriminate +
+  match goal with
+  | [ E : VisF _ _ = VisF _ _ |- _ ] =>
+     apply eq_VisF_inv in E; destruct E as [ <- [<- <-]]
+  end.
 
 (** ** [observing]: Lift relations through [observe]. *)
 Inductive observing {E R1 R2}

--- a/theories/Eq/Shallow.v
+++ b/theories/Eq/Shallow.v
@@ -32,7 +32,13 @@ Definition pweqeq {R1 R2} (RR : R1 -> R2 -> Prop) {X1 X2 : Type} (p : X1 = X2)
   | eq_refl => fun k1 k2 => forall x, RR (k1 x) (k2 x)
   end.
 
-Lemma eq_VisF_inv {E R X1 X2} (e1 : E X1) (e2 : E X2) (k1 : X1 -> itree E R) (k2 : X2 -> itree E R)
+Lemma pweqeq_mon {R1 R2} (RR1 RR2 : R1 -> R2 -> Prop) X1 X2 (p : X1 = X2) k1 k2
+  : (forall r1 r2, RR1 r1 r2 -> RR2 r1 r2) -> pweqeq RR1 p k1 k2 -> pweqeq RR2 p k1 k2.
+Proof.
+  destruct p; cbn; auto.
+Qed.
+
+Lemma eq_inv_VisF_weak {E R X1 X2} (e1 : E X1) (e2 : E X2) (k1 : X1 -> itree E R) (k2 : X2 -> itree E R)
   : VisF (R := R) e1 k1 = VisF (R := R) e2 k2 ->
     exists p : X1 = X2, eqeq E p e1 e2 /\ eqeq (fun X => X -> itree E R) p k1 k2.
 Proof.
@@ -52,7 +58,7 @@ Ltac inv_Vis :=
   discriminate +
   match goal with
   | [ E : VisF _ _ = VisF _ _ |- _ ] =>
-     apply eq_VisF_inv in E; destruct E as [ <- [<- <-]]
+     apply eq_inv_VisF_weak in E; destruct E as [ <- [<- <-]]
   end.
 
 (** ** [observing]: Lift relations through [observe]. *)

--- a/theories/Eq/SimUpToTaus.v
+++ b/theories/Eq/SimUpToTaus.v
@@ -25,12 +25,11 @@ From Coq Require Import
      Relations.Relations.
 
 From ITree Require Import
-     Core.ITreeDefinition.
-
-From ITree Require Import
+     Core.ITreeDefinition
      Eq.Eq
      Eq.UpToTaus
-     Eq.Shallow.
+     Eq.Shallow
+     Eq.Paco2.
 
 Section SUTT.
 
@@ -89,7 +88,7 @@ Lemma suttF_inv_vis {E R1 R2} (RR : R1 -> R2 -> Prop) sutt :
     suttF RR sutt (VisF e k1) (VisF e k2) ->
     forall x, sutt (observe (k1 x)) (observe (k2 x)).
 Proof.
-  intros. inv H. auto_inj_pair2. subst. auto.
+  intros. inv H. apply inj_pair2 in H3; apply inj_pair2 in H5. subst. auto.
 Qed.
 
 Lemma sutt_inv_vis {E R1 R2} (RR : R1 -> R2 -> Prop) :
@@ -98,7 +97,7 @@ Lemma sutt_inv_vis {E R1 R2} (RR : R1 -> R2 -> Prop) :
   forall x, sutt RR (k1 x) (k2 x).
 Proof.
   intros. pstep. punfold H. simpl in *.
-  inv H. auto_inj_pair2. subst. specialize (SUTTK x). pclearbot. punfold SUTTK.
+  eapply suttF_inv_vis in H; pclearbot; punfold H.
 Qed.
 
 Lemma sutt_tau_right {E R1 R2} (RR : R1 -> R2 -> Prop) :
@@ -159,12 +158,12 @@ Theorem sutt_eutt {E R1 R2} (RR : R1 -> R2 -> Prop) :
     sutt RR t1 t2 -> sutt (flip RR) t2 t1 -> eutt RR t1 t2.
 Proof.
   pcofix CIH. intros.
-  punfold H0. punfold H1. pstep. red.
+  punfold H0. punfold H. pstep. red.
   induction H0; intros; subst; auto.
-  - constructor. intro. right. eapply suttF_inv_vis in H1. pclearbot. eauto with paco.
+  - constructor. intro. right. eapply suttF_inv_vis in H. pclearbot. eauto with paco.
   - constructor; eauto. eapply IHsuttF; auto. eapply suttF_inv_tau_left; auto.
   - (* doing induction when one of the trees is a tau doesn't work well *)
-    inv H1; pclearbot.
+    inv H; pclearbot.
     + clear t1 t2. genobs t0 ot0.
       hinduction EQTAUS0 before CIH; intros; subst; pclearbot.
       * constructor; eauto. simpobs. constructor. eauto.

--- a/theories/Eq/UpToTaus.v
+++ b/theories/Eq/UpToTaus.v
@@ -35,11 +35,13 @@
  *)
 
 (* begin hide *)
-Require Import Paco.paco Program Setoid Morphisms RelationClasses.
+From Coq Require Import Setoid Morphisms RelationClasses.
+From Paco Require Import paco.
 
 From ITree Require Import
      Core.ITreeDefinition
-     Eq.Eq.
+     Eq.Eq
+     Eq.Paco2.
 
 Import ITreeNotations.
 Local Open Scope itree.
@@ -55,7 +57,6 @@ Tactic Notation "gpaco_" :=
 Ltac gpaco := repeat red; under_forall ltac:(gpaco_).
 
 (**** END ****)
-
 
 Section EUTTG.
 
@@ -214,7 +215,7 @@ Qed.
 Lemma euttVC_flip gH r:
   flip (euttVC (flip RR) (flip gH) (flip r)) <2= @euttVC E R1 R2 RR gH r.
 Proof.
-  gcofix CIH. intros. gunfold PR.
+  pcofix CIH. intros. gunfold PR.
   gclo. apply rclo_transD.
   eapply rclo_flip; eauto with paco.
   eapply rclo2_mon_gen; eauto; intros.
@@ -232,7 +233,7 @@ Lemma euttG_flip gH r:
   flip (gupaco2 (eqit_ (flip RR) true true (euttVC (flip RR) (flip gH))) (transD (flip RR)) (flip r)) <2=
   gupaco2 (@eqit_ E R1 R2 RR true true (euttVC RR gH)) (transD RR) r.
 Proof.
-  gcofix CIH; intros.
+  pcofix CIH; intros.
   destruct PR. econstructor.
   eapply rclo_flip; eauto with paco.
   eapply rclo2_mon_gen; eauto using transD_flip. intros.
@@ -301,7 +302,7 @@ Lemma transL_closed vclo r
   transL (gupaco2 (eqit_ RR true true vclo) (transD RR) r)
   <2= gupaco2 (eqit_ RR true true vclo) (transD RR) r.
 Proof.
-  gcofix CIH. intros t1 t2 [].
+  pcofix CIH. intros t1 t2 [].
   apply gpaco2_dist in EQR; eauto with paco.
   destruct EQR; cycle 1.
   { gbase. apply rclo_transD in H. destruct H. eauto 7. }
@@ -342,10 +343,8 @@ Proof.
         -- auto_ctrans.
     + punfold REL0. red in REL0. simpl in *.
       remember (VisF e k1) as ot. genobs m1 ot2.
-      hinduction REL0 before CIH; intros; subst; try dependent destruction Heqot; cycle 1.
-      * gclo; econstructor; auto_ctrans_eq; try reflexivity.
-        rewrite (simpobs Heqot1), tau_euttge. reflexivity.
-      * pclearbot. gstep. red. do 2 (simpobs; econstructor; eauto). intros.
+      hinduction REL0 before CIH; intros; try discriminate.
+      * inv_Vis. pclearbot. gstep. red. do 2 (simpobs; econstructor; eauto). intros.
         eapply MON; [|intros; gbase; eapply CIH; eauto].
         eapply CLOV.
         { intros. destruct PR, EQR.
@@ -354,15 +353,15 @@ Proof.
         eapply MON; eauto. intros.
         econstructor; try reflexivity; auto_ctrans.
         gfinal. destruct PR; eauto.
+      * gclo; econstructor; auto_ctrans_eq; try reflexivity.
+        rewrite (simpobs Heqot1), tau_euttge. reflexivity.
     + eapply IHREL0; try eapply eqit_trans; auto_ctrans_eq.
       rewrite <-itree_eta, tau_eutt. reflexivity.
     + gclo; econstructor; auto_ctrans_eq; try reflexivity.
       rewrite (simpobs Heqot2), tau_euttge. reflexivity.
   - remember (VisF e k2) as ot. genobs t2 ot2.
-    hinduction REL0 before CIH; intros; subst; try dependent destruction Heqot; cycle 1.
-    + gclo; econstructor; auto_ctrans_eq; try reflexivity.
-      rewrite (simpobs Heqot2), tau_euttge. reflexivity.
-    + pclearbot. gstep. red. simpobs. econstructor; eauto. intros.
+    hinduction REL0 before CIH; intros; subst; try discriminate.
+    + inv_Vis. pclearbot. gstep. red. simpobs. econstructor; eauto. intros.
       eapply MON; [|intros; gbase; eapply CIH; eauto].
       eapply CLOV.
       { intros. destruct PR, EQR.
@@ -371,6 +370,8 @@ Proof.
       eapply MON; eauto. intros.
       econstructor; auto_ctrans_eq; try reflexivity.
       gfinal. destruct PR; eauto.
+    + gclo; econstructor; auto_ctrans_eq; try reflexivity.
+      rewrite (simpobs Heqot2), tau_euttge. reflexivity.
   - gclo; econstructor; auto_ctrans_eq; try reflexivity.
     rewrite (simpobs Heqot1), tau_euttge. reflexivity.
   - clear t' Heqot'. remember (TauF t2) as ot. genobs t0 ot0.
@@ -432,7 +433,7 @@ Lemma euttVC_gen gH r:
   <2= @euttVC E R1 R2 RR gH r.
 Proof.
   intros. eapply euttG_transU_aux in PR; eauto using transU_compose.
-  revert x0 x1 PR. gcofix CIH. intros.
+  revert x0 x1 PR. pcofix CIH. intros.
   gunfold PR. apply rclo_transD in PR.
   gclo. eapply transD_mon; eauto. intros.
   destruct PR0; eauto with paco.
@@ -461,9 +462,9 @@ Lemma euttG_cofix_aux: forall rH rL gL gH x,
     (x <2= euttG rH rL (gL \2/ x) (gH \2/ x)) -> (x <2= euttG rH rL gL gH).
 Proof.
   intros. apply euttG_gen.
-  econstructor. revert x0 x1 PR. gcofix CIH.
-  intros. apply H in PR. destruct PR.
-  revert_until CIH. gcofix CIH. intros.
+  econstructor. revert x0 x1 PR. pcofix CIH.
+  intros t1 t2 PR. apply H in PR. destruct PR as [IN]. revert t1 t2 IN.
+  pcofix CIH. intros.
   apply gpaco2_dist in IN; eauto with paco.
   destruct IN; cycle 1.
   { apply rclo_transD in H0; eauto with paco.
@@ -471,7 +472,7 @@ Proof.
   }
   assert (LEM: upaco2 (eqit_ RR true true (euttVC RR (gH \2/ x)))
                       (rclo2 (transD RR) ((gL \2/ x) \2/ (transU RR rH \2/ rL)))
-               <2= gpaco2 (eqit_ RR true true (euttVC RR gH)) (transD RR) r r).
+               <2= gpaco2 (eqit_ RR true true (euttVC RR gH)) (transD RR) r0 r0).
   { intros m1 m2 [REL|REL].
     - gbase. apply CIH1.
       gpaco. gfinal. right.
@@ -506,6 +507,15 @@ Lemma euttG_cofix rH rL gL gH x
 Proof.
   eapply euttG_cofix_aux; intros.
   eapply OBG; eauto.
+Qed.
+
+Lemma euttG_accF rH rL gL gH X (f : X -> _) (g : X -> _)
+    (OBJ: forall gL' (INCL: gL <2= gL') (CIHL: forall x : X, gL' (f x) (g x)) gH' (INCH: gH <2= gH') (CIHH: forall x : X, gH' (f x) (g x)), forall x : X, euttG rH rL gL' gH' (f x) (g x)):
+    forall x : X, euttG rH rL gL gH (f x) (g x).
+Proof.
+  intros x.
+  apply euttG_cofix with (x := fun a b => exists x, a = (f x) /\ b = (g x)); [ | eauto ].
+  intros. destruct PR as [? [-> ->]]. apply OBJ; eauto.
 Qed.
 
 (* Process itrees *)
@@ -575,6 +585,17 @@ Proof.
     eauto using gpaco2_clo, transDleU, transU_mon with paco.
 Qed.
 
+Lemma euttG_vis_gen rH rL gL gH u1 (e1: E u1) u2 (e2 : E u2) k1 k2 (p : u1 = u2)
+  : eqeq E p e1 e2 -> pweqeq (euttG gH gH gH gH) p k1 k2 ->
+    euttG rH rL gL gH (Vis e1 k1) (Vis e2 k2).
+Proof.
+  econstructor. gstep. apply (eqitF_VisF p); auto. destruct p; cbn in *; intros.
+  specialize (H0 x). destruct H0.
+  apply euttVC_gen. econstructor; auto_ctrans_eq; try reflexivity.
+  eapply gpaco2_mon_gen; eauto; intros; repeat destruct PR as [PR|PR];
+    eauto using gpaco2_clo, transDleU, transU_mon with paco.
+Qed.
+
 (* Use available hypotheses *)
 
 Lemma euttG_base: forall rH rL gL gH t1 t2,
@@ -599,8 +620,8 @@ Proof.
   }
   clear IN.
   revert x0 x1 H. pcofix CIH. intros.
-  punfold H0. pstep. unfold_eqit.
-  induction H0; pclearbot; eauto.
+  punfold H. pstep. unfold_eqit.
+  induction H; pclearbot; eauto.
   econstructor; intros. specialize (REL v).
   right. apply CIH.
   ginit. gupaco. eapply gupaco2_mon_gen; eauto with paco; intros.
@@ -621,16 +642,20 @@ Qed.
 
 End EUTTG_principles.
 
-Require Import Paco.pacotac_internal.
+Ltac apply_paco_acc CIH unpack_goal unpack_hyp :=
+  apply euttG_accF;
+  let gL' := fresh "gL'" in
+  let INCL := fresh "INCL" in
+  let CIHL := fresh CIH "L" in
+  let gH' := fresh "gH'" in
+  let INCH := fresh "INCH" in
+  let CIHH := fresh CIH "H" in
+  intros gL' INCL CIHL gH' INCH CIHH;
+  unpack_goal tt;
+  unpack_hyp CIHL;
+  unpack_hyp CIHH.
 
-Tactic Notation "ecofix" ident(CIH) "with" ident(gL) ident(gH) :=
-  repeat red;
-  paco_pre2;
-  eapply euttG_cofix;
-  paco_post2 CIH with gL;
-  paco_post2 CIH with gH.
-
-Tactic Notation "ecofix" ident(CIH) := ecofix CIH with gL gH.
+Ltac ecofix CIH := pcofix_with ltac:(apply_paco_acc CIH).
 
 Ltac einit := repeat red; under_forall ltac:(eapply euttG_le_eutt; eauto with paco).
 Ltac efinal := repeat red; under_forall ltac:(eapply eutt_le_euttG; eauto with paco).
@@ -729,20 +754,19 @@ Lemma eutt_conj {E} {R S} {RS RS'} :
     eutt (RS /2\ RS') t s. 
 Proof.
   repeat red.
-  einit.
-  ecofix CIH; intros * EQ EQ'.
+  einit. ecofix CIH. intros * EQ EQ'.
   rewrite itree_eta, (itree_eta s).
   punfold EQ; punfold EQ'; red in EQ; red in EQ'.
   genobs t ot; genobs s os.
-  hinduction EQ before CIH0; subst; intros; pclearbot; simpl.
+  hinduction EQ before CIHH; subst; intros; pclearbot; simpl.
 
   - estep; split; auto.
     inv EQ'; auto.
-  - estep; ebase; right; eapply CIH; eauto.
+  - estep; ebase; right; eapply CIHL; eauto.
     rewrite <- tau_eutt.
     rewrite <- (tau_eutt m2); auto.
-  - estep; ebase; intros ?; right; eapply CIH0; eauto.
-    eapply eqit_Vis; eauto.
+  - assert (EE := eqitF_VisF_inv_strong _ _ _ _ _ EQ'); pclearbot.
+    eapply euttG_vis; ebase; left; apply CIHH; auto.
   - eapply fold_eqitF in EQ'; eauto.
     assert (t ≈ Tau t1) by (rewrite itree_eta, <- Heqot; reflexivity).
     rewrite H in EQ'.
@@ -806,4 +830,3 @@ Proof.
   repeat intro; subst.
   unfold eutt; rewrite H; reflexivity.
 Qed.
-

--- a/theories/Eq/UpToTaus.v
+++ b/theories/Eq/UpToTaus.v
@@ -321,7 +321,7 @@ Proof.
     + gclo. econstructor; auto_ctrans_eq.
       * rewrite (simpobs Heqot1). reflexivity.
       * rewrite (simpobs Heqot2), tau_euttge. reflexivity.
-  - pclearbot. apply eqit_tauR in REL. rewrite Heqot' in REL, REL0. clear m2 Heqot'.
+  - pclearbot. apply eqit_Tau_r in REL. rewrite Heqot' in REL, REL0. clear m2 Heqot'.
     genobs t' ot'. genobs t2 ot2.
     hinduction REL0 before CIH; intros; subst.
     + apply eqit_ret_gen in REL0.
@@ -589,7 +589,7 @@ Lemma euttG_vis_gen rH rL gL gH u1 (e1: E u1) u2 (e2 : E u2) k1 k2 (p : u1 = u2)
   : eqeq E p e1 e2 -> pweqeq (euttG gH gH gH gH) p k1 k2 ->
     euttG rH rL gL gH (Vis e1 k1) (Vis e2 k2).
 Proof.
-  econstructor. gstep. apply (eqitF_VisF p); auto. destruct p; cbn in *; intros.
+  econstructor. gstep. apply (eqitF_VisF_gen p); auto. destruct p; cbn in *; intros.
   specialize (H0 x). destruct H0.
   apply euttVC_gen. econstructor; auto_ctrans_eq; try reflexivity.
   eapply gpaco2_mon_gen; eauto; intros; repeat destruct PR as [PR|PR];
@@ -765,16 +765,16 @@ Proof.
   - estep; ebase; right; eapply CIHL; eauto.
     rewrite <- tau_eutt.
     rewrite <- (tau_eutt m2); auto.
-  - assert (EE := eqitF_VisF_inv_strong _ _ _ _ _ EQ'); pclearbot.
+  - assert (EE := eqitF_inv_VisF _ _ _ _ _ EQ'); pclearbot.
     eapply euttG_vis; ebase; left; apply CIHH; auto.
   - eapply fold_eqitF in EQ'; eauto.
     assert (t ≈ Tau t1) by (rewrite itree_eta, <- Heqot; reflexivity).
     rewrite H in EQ'.
-    apply eqit_inv_tauL in EQ'.
+    apply eqit_inv_Tau_l in EQ'.
     subst; specialize (IHEQ _ _ eq_refl eq_refl).
     punfold EQ'; red in EQ'.
     specialize (IHEQ EQ').
-    rewrite eqit_tauL; [|reflexivity].
+    rewrite eqit_Tau_l; [|reflexivity].
     rewrite (itree_eta t1).
     eapply IHEQ. 
   - subst; cbn.

--- a/theories/Eq/UpToTaus.v
+++ b/theories/Eq/UpToTaus.v
@@ -45,37 +45,6 @@ Import ITreeNotations.
 Local Open Scope itree.
 (* end hide *)
 
-
-(**** START: taken from Paco-4.0.1 ****)
-
-Lemma gpaco2_gen_guard {T0 T1} gf clo r rg:
-  @gpaco2 T0 T1 gf clo r (rg \2/ r) <2= gpaco2 gf clo r rg.
-Proof.
-  intros. destruct PR. econstructor.
-  eapply rclo2_mon. apply IN. intros.
-  destruct PR; [|right; apply H].
-  left. eapply paco2_mon_gen; intros. apply H. apply PR.
-  destruct PR. apply H0. right. apply H0.
-Qed.
-
-Lemma gpaco2_gpaco {T0 T1} gf (gf_mon: @monotone2 T0 T1 gf) clo r rg:
-  gpaco2 gf clo (gpaco2 gf clo r rg) (gupaco2 gf clo (rg \2/ r)) <2= gpaco2 gf clo r rg.
-Proof.
-  intros. apply gpaco2_unfold in PR; eauto.
-  econstructor. apply rclo2_rclo. eapply rclo2_mon. apply PR. clear x0 x1 PR. intros.
-  destruct PR; [|destruct H; apply IN].
-  apply rclo2_base. left. pstep.
-  eapply gf_mon. apply H. clear x0 x1 H. intros.
-  cut (@gupaco2 T0 T1 gf clo (rg \2/ r) x0 x1).
-  { intros. destruct H. eapply rclo2_mon. apply IN. intros.
-    destruct PR0; [|right; apply H].
-    left. eapply paco2_mon. apply H. intros. destruct PR0; apply H0.
-  }
-  apply gpaco2_gupaco; eauto. eapply gupaco2_mon. apply PR. intros.
-  destruct PR0; [apply H|].
-  eapply gpaco2_mon; [apply H|right|left]; intros; apply PR0.
-Qed.
-
 (** ** gpaco
 *)
 

--- a/theories/Events/FailFacts.v
+++ b/theories/Events/FailFacts.v
@@ -171,7 +171,7 @@ Global Instance interp_fail_eq_itree {X E F} {R : X -> X -> Prop} (h : E ~> fail
 Proof.
   repeat red. 
   ginit.
-  gcofix CIH.
+  pcofix CIH.
   intros s t EQ.
   rewrite 2 unfold_interp_fail.
   punfold EQ; red in EQ.
@@ -270,7 +270,7 @@ Lemma interp_fail_bind : forall {X Y E F} (t : itree _ X) (k : X -> itree _ Y) (
                 ITree.bind (interp_fail h t)
                 (fun mx => match mx with | None => ret None | Some x => interp_fail h (k x) end).
 Proof.
-  intros X Y; ginit; gcofix CIH; intros.
+  intros X Y; ginit; pcofix CIH; intros.
   rewrite unfold_bind.
   rewrite (unfold_interp_fail h t).
   destruct (observe t) eqn:EQ; cbn.
@@ -294,7 +294,7 @@ Lemma interp_failure_bind' : forall {X Y E F} (t : itree _ X) (k : X -> itree _ 
                 bind (interp_fail h t)
                 (fun x => interp_fail h (k x)).
 Proof.
-  intros X Y E F; ginit; gcofix CIH; intros.
+  intros X Y E F; ginit; pcofix CIH; intros.
   cbn in *.
   rewrite unfold_bind, (unfold_interp_fail _ t).
   destruct (observe t) eqn:EQ; cbn.

--- a/theories/Events/MapDefaultFacts.v
+++ b/theories/Events/MapDefaultFacts.v
@@ -23,6 +23,7 @@ From ITree Require Import
      Basics.HeterogeneousRelations
      ITree
      ITreeFacts
+     Eq.Paco2
      Indexed.Sum
      Interp.Interp
      Events.State
@@ -186,7 +187,7 @@ Section MapFacts.
     unfold map_default_eq, interp_map; intros.
     revert t s1 s2 H.
     ginit.
-    gcofix CH.
+    pcofix CH.
     intros.
     repeat rewrite unfold_interp_state. unfold _interp_state.
     destruct (observe t).
@@ -235,5 +236,5 @@ Section MapFacts.
     - rewrite tau_euttge, unfold_interp_state.
       eauto.
   Qed.
-    
+
 End MapFacts.

--- a/theories/Events/StateFacts.v
+++ b/theories/Events/StateFacts.v
@@ -20,6 +20,7 @@ From ITree Require Import
      Core.KTreeFacts
      Eq.Eq
      Eq.UpToTaus
+     Eq.Paco2
      Indexed.Sum
      Interp.Interp
      Interp.InterpFacts
@@ -64,7 +65,7 @@ Instance eq_itree_interp_state {E F S R} (h : E ~> Monads.stateT S (itree F)) :
          (@interp_state _ _ _ _ _ _ h R).
 Proof.
   revert_until R.
-  ginit. gcofix CIH. intros h x y H0 x2 _ [].
+  ginit. pcofix CIH. intros h x y H0 x2 _ [].
   rewrite !unfold_interp_state.
   punfold H0; repeat red in H0.
   destruct H0; subst; pclearbot; try discriminate; cbn.
@@ -129,7 +130,7 @@ Lemma interp_state_bind {E F : Type -> Type} {A B S : Type}
   (interp_state f t s >>= fun st => interp_state f (k (snd st)) (fst st)).
 Proof.
   revert A t k s.
-  ginit. gcofix CIH.
+  ginit. pcofix CIH.
   intros A t k s.
   rewrite unfold_bind. (* TODO: slow *)
   rewrite (unfold_interp_state f t).
@@ -151,7 +152,7 @@ Instance eutt_interp_state {E F: Type -> Type} {S : Type}
          (h : E ~> Monads.stateT S (itree F)) R RR :
   Proper (eutt RR ==> eq ==> eutt (prod_rel eq RR)) (@interp_state E (itree F) S _ _ _ h R).
 Proof.
-  repeat intro. subst. revert_until R.
+  repeat intro. subst. revert_until RR.
   einit. ecofix CIH. intros.
 
   rewrite !unfold_interp_state. punfold H0. red in H0.
@@ -272,7 +273,7 @@ Lemma interp_state_iter {E F } S (f : E ~> stateT S (itree F)) {I A}
                   (Basics.iter t' i).
 Proof.
   unfold Basics.iter, MonadIter_stateT0, Basics.iter, MonadIter_itree in *; cbn.
-  ginit. gcofix CIH; intros i s.
+  ginit. pcofix CIH; intros i s.
   rewrite 2 unfold_iter; cbn.
   rewrite !bind_bind.
   setoid_rewrite bind_ret_l.

--- a/theories/Interp/InterpFacts.v
+++ b/theories/Interp/InterpFacts.v
@@ -25,6 +25,7 @@ From ITree Require Import
      Core.KTreeFacts
      Eq.Eq
      Eq.UpToTaus
+     Eq.Paco2
      Indexed.Sum
      Indexed.Function
      Indexed.Relation
@@ -113,8 +114,8 @@ Instance eq_itree_interp {E F}
             interp.
 Proof.
   intros f g Hfg T.
-  ginit. gcofix CIH with rr.
-  intros l r Hlr.
+  ginit. pcofix CIH.
+  intros l r0 Hlr.
   rewrite 2 unfold_interp.
   punfold Hlr; red in Hlr.
   destruct Hlr; cbn; subst; try discriminate; pclearbot; try (gstep; constructor; eauto with paco; fail).
@@ -138,7 +139,7 @@ Instance eutt_interp (E F : Type -> Type)
 Proof.
   repeat red.
   intros until T.
-  ginit. gcofix CIH. intros.
+  ginit. pcofix CIH. intros.
 
   rewrite !unfold_interp. punfold H1. red in H1.
   induction H1; intros; subst; pclearbot; simpl.
@@ -159,7 +160,7 @@ Instance euttge_interp (E F : Type -> Type)
 Proof.
   repeat red.
   intros until T.
-  ginit. gcofix CIH. intros.
+  ginit. pcofix CIH. intros.
 
   rewrite !unfold_interp. punfold H1. red in H1.
   induction H1; intros; subst; pclearbot; simpl.
@@ -227,7 +228,7 @@ Lemma interp_bind {E F R S}
     interp f (ITree.bind t k)
   ≅ ITree.bind (interp f t) (fun r => interp f (k r)).
 Proof.
-  revert R t k. ginit. gcofix CIH; intros.
+  revert R t k. ginit. pcofix CIH; intros.
   rewrite unfold_bind, (unfold_interp t).
   destruct (observe t); cbn.
   - rewrite bind_ret_l. apply reflexivity.
@@ -246,7 +247,7 @@ Hint Rewrite @interp_bind : itree.
 Lemma interp_id_h {A R} (t : itree A R)
   : interp (id_ A) t ≳ t.
 Proof.
-  revert t. ginit. gcofix CIH. intros.
+  revert t. ginit. pcofix CIH. intros.
   rewrite (itree_eta t), unfold_interp.
   destruct (observe t); try (gstep; constructor; auto with paco).
   cbn. gstep. red; cbn. constructor; red; intros.
@@ -271,7 +272,7 @@ Theorem interp_interp {E F G R} (f : E ~> itree F) (g : F ~> itree G) :
       interp g (interp f t)
     ≅ interp (fun _ e => interp g (f _ e)) t.
 Proof.
-  ginit. gcofix CIH. intros.
+  ginit. pcofix CIH. intros.
   rewrite 2 (unfold_interp t).
   destruct (observe t); cbn.
   - rewrite interp_ret. gstep. constructor. reflexivity.
@@ -290,7 +291,7 @@ Lemma interp_translate {E F G} (f : E ~> F) (g : F ~> itree G) {R} (t : itree E 
   interp g (translate f t) ≅ interp (fun _ e => g _ (f _ e)) t.
 Proof.
   revert t.  
-  ginit. gcofix CIH.
+  ginit. pcofix CIH.
   intros t.
   rewrite !unfold_interp. unfold _interp.
   rewrite unfold_translate_. unfold translateF.
@@ -318,7 +319,7 @@ Lemma interp_forever {E F} (f : E ~> itree F) {R S}
   : interp f (ITree.forever t)
   ≅ @ITree.forever F R S (interp f t).
 Proof.
-  ginit. gcofix CIH.
+  ginit. pcofix CIH.
   rewrite (unfold_forever t).
   rewrite (unfold_forever (interp _ _)).
   rewrite interp_bind.
@@ -335,7 +336,7 @@ Lemma interp_iter' {E F} (f : E ~> itree F) {I A}
     interp f (ITree.iter t i)
   ≅ ITree.iter t' i.
 Proof.
-  ginit. gcofix CIH; intros i.
+  ginit. pcofix CIH; intros i.
   rewrite 2 unfold_iter.
   rewrite interp_bind.
   guclo eqit_clo_bind; econstructor; eauto.

--- a/theories/Interp/RecursionFacts.v
+++ b/theories/Interp/RecursionFacts.v
@@ -21,6 +21,7 @@ From ITree Require Import
      Core.KTree
      Eq.Eq
      Eq.UpToTaus
+     Eq.Paco2
      Indexed.Sum
      Indexed.Function
      Interp.Interp
@@ -77,7 +78,7 @@ Definition mrecursive (f : D ~> itree (D +' E))
 Global Instance eq_itree_mrec {R} :
   Proper (eq_itree eq ==> eq_itree eq) (@interp_mrec _ _ ctx R).
 Proof.
-  ginit. gcofix CIH. intros.
+  ginit. pcofix CIH. intros.
   rewrite !unfold_interp_mrec.
   punfold H0. inv H0; try discriminate; pclearbot; simpobs; [| |destruct e]; gstep.
   - apply reflexivity.
@@ -90,7 +91,7 @@ Theorem interp_mrec_bind {U T} (t : itree _ U) (k : U -> itree _ T) :
   interp_mrec ctx (ITree.bind t k) ≅
   ITree.bind (interp_mrec ctx t) (fun x => interp_mrec ctx (k x)).
 Proof.
-  revert t k; ginit. gcofix CIH; intros.
+  revert t k; ginit. pcofix CIH; intros.
   rewrite (unfold_interp_mrec _ t).
   rewrite (unfold_bind t). (* TODO: should be [unfold_bind] but it is much slower *)
   destruct (observe t); cbn;
@@ -119,7 +120,7 @@ Theorem interp_mrec_as_interp {T} (c : itree _ T) :
   interp_mrec ctx c ≈ interp (mrecursive ctx) c.
 Proof.
   rewrite <- (tau_eutt (interp _ _)).
-  revert_until T. ginit. gcofix CIH. intros.
+  revert_until T. ginit. pcofix CIH. intros.
   rewrite unfold_interp_mrec, unfold_interp.
   destruct (observe c); [| |destruct e]; simpl; eauto with paco.
   - gstep; repeat econstructor; eauto.
@@ -152,7 +153,7 @@ Theorem unfold_interp_mrec_h {T} (t : itree _ T)
   ≈ interp_mrec ctx t.
 Proof.
   rewrite <- tau_eutt.
-  revert t. ginit; gcofix CIH. intros.
+  revert t. ginit; pcofix CIH. intros.
   rewrite (itree_eta t); destruct (observe t);
     try (rewrite 2 unfold_interp_mrec; cbn; gstep; repeat constructor; auto with paco; fail).
   rewrite interp_vis.
@@ -182,7 +183,7 @@ Global Instance Proper_interp_mrec {D E} :
           interp_mrec.
 Proof.
   intros f g Hfg R.
-  ginit; gcofix CIH; intros t1 t2 Ht.
+  ginit; pcofix CIH; intros t1 t2 Ht.
   rewrite 2 unfold_interp_mrec.
   punfold Ht; induction Ht; cbn; pclearbot.
   3: { destruct e; gstep; constructor.
@@ -227,7 +228,7 @@ Global Instance euttge_interp_mrec {D E} :
           interp_mrec.
 Proof.
   intros f g Hfg R.
-  ginit; gcofix CIH; intros t1 t2 Ht.
+  ginit; pcofix CIH; intros t1 t2 Ht.
   rewrite 2 unfold_interp_mrec.
   punfold Ht; induction Ht; cbn; pclearbot.
   3: { destruct e; gstep; constructor.

--- a/theories/Interp/Traces.v
+++ b/theories/Interp/Traces.v
@@ -1,6 +1,8 @@
 (** * ITrees as sets of traces *)
 
 (* begin hide *)
+From Coq Require Import ProofIrrelevance.
+
 From Paco Require Import
      paco.
 
@@ -9,7 +11,8 @@ From ITree Require Import
      Eq.Eq
      Eq.UpToTaus
      Eq.SimUpToTaus
-     Eq.Shallow.
+     Eq.Shallow
+     Eq.Paco2.
 
 Local Open Scope itree.
 (* end hide *)
@@ -92,14 +95,14 @@ Proof.
   - punfold H. rewrite <- Heqi in H.
     remember (VisF _ _). remember (observe t2).
     generalize dependent t2.
-    induction H; intros; try inv Heqi0.
-    + auto_inj_pair2. subst. red. rewrite <- Heqi1. constructor.
+    induction H; intros; try discriminate.
+    + inv_Vis. subst. red. rewrite <- Heqi1. constructor.
     + red. rewrite <- Heqi1. constructor. eapply IHsuttF; eauto.
   - punfold H. rewrite <- Heqi in H.
     remember (VisF _ _). remember (observe t2).
     generalize dependent t2.
-    induction H; intros; try inv Heqi0.
-    + pclearbot. auto_inj_pair2. subst. red. rewrite <- Heqi1. constructor.
+    induction H; intros; try discriminate.
+    + inv_Vis. pclearbot. subst. red. rewrite <- Heqi1. constructor.
       eapply IHis_traceF; auto.
     + red. rewrite <- Heqi1. constructor. apply IHsuttF; auto.
 Qed.
@@ -110,6 +113,21 @@ Proof.
   split.
   - apply sutt_trace_incl; apply eutt_sutt; auto.
   - symmetry in H. apply sutt_trace_incl; apply eutt_sutt; auto.
+Qed.
+
+Lemma eq_trace_inv {E R} (t1 t2 : @trace E R) (H : t1 = t2)
+  : match t1, t2 with
+    | TEnd, TEnd => True
+    | TRet r1, TRet r2 => r1 = r2
+    | TEventEnd e1, TEventEnd e2 => exists p, eqeq E p e1 e2
+    | TEventResponse e1 x1 t1, TEventResponse e2 x2 t2 =>
+      exists p, eqeq E p e1 e2 /\ eqeq (fun X => X) p x1 x2 /\ t1 = t2
+    | _, _ => False
+    end.
+Proof.
+  destruct H, t1; auto.
+  - exists eq_refl; cbn; auto.
+  - exists eq_refl; cbn; auto.
 Qed.
 
 Lemma trace_incl_sutt : forall {E R} (t1 t2 : itree E R),
@@ -137,15 +155,17 @@ Proof.
       clear Hincl. rename H into Hincl.
       remember (observe t). remember (TEventEnd _).
       generalize dependent t.
-      induction H1; intros; try inv Heqt0; auto.
+      induction H1; intros; try discriminate.
       * constructor. eapply IHis_traceF; eauto.
         intros. rewrite is_traceF_tau. apply Hincl; auto.
-      * auto_inj_pair2. subst. constructor. intro. right. apply CIH. intros.
+      * apply eq_trace_inv in Heqt0; destruct Heqt0 as [<- <-].
+        subst. constructor. intro. right. apply CIH. intros.
         assert (is_traceF (VisF e k) (TEventResponse e x tr)) by (constructor; auto).
-        apply Hincl in H0. inv H0. auto_inj_pair2. subst. auto.
-    + auto_inj_pair2. subst. constructor. intro. right. apply CIH. intros.
+        apply Hincl in H1. inv H1.
+        apply inj_pair2 in H5; apply inj_pair2 in H7; subst; auto.
+    + apply inj_pair2 in H2; apply inj_pair2 in H5. subst. constructor. intro. right. apply CIH. intros.
       assert (is_traceF (VisF e k) (TEventResponse e x tr)) by (constructor; auto).
-      apply Hincl in H0. inv H0. auto_inj_pair2. subst. auto.
+      apply Hincl in H0. inv H0. apply inj_pair2 in H5; apply inj_pair2 in H7. subst. auto.
 Qed.
 
 Theorem trace_incl_iff_sutt : forall {E R} (t1 t2 : itree E R),

--- a/theories/Interp/TranslateFacts.v
+++ b/theories/Interp/TranslateFacts.v
@@ -1,6 +1,14 @@
 (** * Theorems about [Interp.translate] *)
 
 (* begin hide *)
+From Coq Require Import
+     Program
+     Setoid
+     Morphisms
+     RelationClasses.
+
+From Paco Require Import paco.
+
 From ExtLib Require
      Structures.Monoid.
 
@@ -11,20 +19,13 @@ From ITree Require Import
      Core.Subevent
      Eq.Eq
      Eq.UpToTaus
+     Eq.Paco2
      Indexed.Sum
      Indexed.Function
      Indexed.Relation
      Interp.Interp.
 
 Import ITreeNotations.
-
-From Paco Require Import paco.
-
-From Coq Require Import
-     Program
-     Setoid
-     Morphisms
-     RelationClasses.
 (* end hide *)
 
 Section TranslateFacts.
@@ -70,7 +71,7 @@ Qed.
 Global Instance eq_itree_translate' :
   Proper (eq_itree eq ==> eq_itree eq) (@translate _ _ h R).
 Proof.
-  ginit. gcofix CIH.
+  ginit. pcofix CIH.
   intros x y H.
   rewrite itree_eta, (itree_eta (translate h y)), !unfold_translate, <-!itree_eta.
   punfold H. gstep. red in H |- *.
@@ -94,7 +95,7 @@ Lemma translate_bind : forall {E F R S} (h : E ~> F) (t : itree E S) (k : S -> i
 Proof.
   intros E F R S h t k.
   revert S t k.
-  ginit. gcofix CIH.
+  ginit. pcofix CIH.
   intros s t k.
   rewrite !unfold_translate, !unfold_bind.
   genobs_clear t ot. destruct ot; cbn.
@@ -107,7 +108,7 @@ Lemma translate_id : forall E R (t : itree E R), translate (id_ _) t ≅ t.
 Proof.
   intros E R t.
   revert t.
-  ginit. gcofix CIH.
+  ginit. pcofix CIH.
   intros t.
   rewrite itree_eta.
   rewrite (itree_eta t).
@@ -126,7 +127,7 @@ Lemma translate_cmpE : forall E F G R (g : F ~> G) (f : E ~> F) (t : itree E R),
 Proof.
   intros E F G R g f t.
   revert t.
-  ginit. gcofix CIH.
+  ginit. pcofix CIH.
   intros t.
   rewrite !unfold_translate.
   genobs_clear t ot. destruct ot; cbn.
@@ -167,7 +168,7 @@ Instance eq_itree_translate {E F}
             translate.
 Proof.
   intros f g Hfg T.
-  ginit. gcofix CIH; rename r into rr; intros l r Hlr.
+  ginit. pcofix CIH; rename r into rr; intros l r Hlr.
   rewrite 2 unfold_translate.
   punfold Hlr; red in Hlr.
   destruct Hlr; cbn; try discriminate; pclearbot.
@@ -183,7 +184,7 @@ Instance eutt_translate {E F}
 Proof.
   repeat red.
   intros until T.
-  ginit. gcofix CIH. intros.
+  ginit. pcofix CIH. intros.
   rewrite !unfold_translate. punfold H1. red in H1.
   induction H1; intros; subst; simpl.
   - gstep. econstructor. eauto.

--- a/theories/Simple.v
+++ b/theories/Simple.v
@@ -312,12 +312,12 @@ Qed.
 Lemma eutt_inv_ret (r1 r2 : R)
   : Ret r1 ≈ Ret r2 ->
     r1 = r2.
-Proof. apply ITree.Eq.Eq.eqit_inv_ret. Qed.
+Proof. apply ITree.Eq.Eq.eqit_inv_Ret. Qed.
 
 Lemma eutt_inv_vis {U : Type} (e : E U) (k1 k2 : U -> itree E R)
   : Vis e k1 ≈ Vis e k2 ->
     (forall u, k1 u ≈ k2 u).
-Proof. apply ITree.Eq.Eq.eqit_inv_vis; auto. Qed.
+Proof. apply ITree.Eq.Eq.eqit_inv_Vis; auto. Qed.
 
 End EquivalenceUpToTaus.
 


### PR DESCRIPTION
Closes #72

There is one inversion lemma left which necessitates UIP, which is `eqit_Vis_inv`. It's actually not as useful as it seems (the tutorial example doesn't use it), but when you do run into it, it's very hard to do without (one can try using `eqit_Vis_inv_weak` instead).

There may be some way of strengthening `eqitF` so that `eqit_Vis_inv` is provable. That's Future Work™.

- [x] Think about organizing lemma names
- [x] Document status of axioms in library (basically, we try to avoid axioms, but I think itrees may be especially counterintuitive to use without UIP, i.e., without `eqit_Vis_inv`)
- [x] Check compatibility with older versions of paco

---

`JMeq_eq`/UIP is the main axiom we use. It is used by `pcofix`/etc. and more directly in various places.

- [x] Override the `pcofix`, `gcofix`, and `ecofix` tactics to not use axioms (ideally this should be implemented in paco, but these new implementations have performance issues for relations of high arity, so we just provide them locally for now)
- [x] Don't use `dependent destruct`
- [x] Weaken inversion lemmas (there are still some places where we use `Vis e k1 = Vis e k2 -> k1 = k2`, which is actually not provable without `JMeq_eq`)