### PR TITLE
opam: Add explicit --root=. in dune build

### DIFF
--- a/coq-itree.opam
+++ b/coq-itree.opam
@@ -12,8 +12,8 @@ license: "MIT"
 build: [
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "build" "-j" jobs] {with-test}
-  ["dune" "runtest" "-j" jobs] {with-test}
+  ["dune" "build" "--root=." "-j" jobs] {with-test}
+  ["dune" "runtest" "--root=." "-j" jobs] {with-test}
 ]
 
 depends: [


### PR DESCRIPTION
In response to trouble in opam-coq-archive CI where dune somehow guessed the wrong root