### PR TITLE
Cartesian closure

### DIFF
--- a/theories/Basics/CategoryFacts.v
+++ b/theories/Basics/CategoryFacts.v
@@ -119,6 +119,19 @@ Proof.
   reflexivity.
 Qed.
 
+Context {t : obj}.
+Context {Terminal_t : Terminal C t}.
+Context {TerminalObject_t : TerminalObject C t}.
+
+(** The terminal morphism is unique. *)
+Lemma terminal_unique :
+  forall a (f g : C a t), f ⩯ g.
+Proof.
+  intros.
+  rewrite (terminal_object f), (terminal_object g).
+  reflexivity.
+Qed.
+
 End CategoryFacts.
 
 Global Hint Resolve initial_unique : cat.
@@ -399,6 +412,287 @@ Lemma swap_bimap' {a b c d} (ab : C a b) (cd : C c d) :
 Proof. cat_auto'. Qed.
 
 End CoproductFacts.
+
+
+(** ** Products *)
+
+Section ProductFacts.
+
+Context {obj : Type} {C : Hom obj}.
+
+Context {Eq2_C : Eq2 C}.
+Context {E_Eq2_C : forall a b, @Equivalence (C a b) eq2}.
+
+Context {Id_C : Id_ C} {Cat_C : Cat C}.
+
+Context {Category_C : Category C}.
+
+Context {bif : binop obj}.
+Context {Prod_C : Pair C bif}
+        {Fst_C : Fst C bif}
+        {Snd_C : Snd C bif}.
+Context {Product_C : Product C bif}.
+
+Lemma pair_fst' {a b c d} (ca : C c a) (cb : C c b) (dc : C d c)
+  : dc >>> pair_ ca cb >>> fst_ ⩯ dc >>> ca.
+Proof.
+  rewrite cat_assoc, pair_fst. reflexivity.
+Qed.
+
+Lemma pair_snd' {a b c d} (ca : C c a) (cb : C c b) (dc : C d c)
+  : dc >>> pair_ ca cb >>> snd_ ⩯ dc >>> cb.
+Proof.
+  rewrite cat_assoc, pair_snd. reflexivity.
+Qed.
+
+(** Commute [cat] and [pair_]. *)
+Lemma pair_cat {a b c d} (ab : C a b) (bc : C b c) (bd : C b d) 
+  : (ab >>> pair_ bc bd ⩯ pair_ (ab >>> bc) (ab >>> bd)).
+Proof.
+  apply pair_universal.
+  - rewrite pair_fst'; reflexivity.
+  - rewrite pair_snd'; reflexivity.
+Qed.
+
+(** Pair of projections is the identity. *)
+Corollary pair_eta {a b} : id_ (bif a b) ⩯ pair_ fst_ snd_.
+Proof.
+  apply pair_universal; rewrite cat_id_l; reflexivity.
+Qed.
+
+Lemma pair_eta' {a b c} (f : C a (bif b c)) :
+  f ⩯ pair_ (f >>> fst_) (f >>> snd_).
+Proof.
+  eapply pair_universal; reflexivity.
+Qed.
+
+(** We can prove the equivalence of morphisms on coproducts
+    by case analysis. *)
+Lemma pair_split {a b c} (f g : C a (bif b c)) :
+  (f >>> fst_ ⩯ g >>> fst_) ->
+  (f >>> snd_ ⩯ g >>> snd_) ->
+  f ⩯ g.
+Proof.
+  intros. rewrite (pair_eta' g).
+  apply pair_universal; assumption.
+Qed.
+
+Existing Instance Bimap_Product.
+Existing Instance Swap_Product.
+Existing Instance AssocR_Product.
+Existing Instance AssocL_Product.
+Existing Instance UnitL_Product.
+Existing Instance UnitL'_Product.
+Existing Instance UnitR_Product.
+Existing Instance UnitR'_Product.
+
+Ltac unfold_product :=
+  unfold
+    bimap, Bimap_Product,
+    assoc_r, AssocR_Product,
+    assoc_l, AssocL_Product,
+    unit_l, UnitL_Product,
+    unit_l', UnitL'_Product,
+    unit_r, UnitR_Product,
+    unit_r', UnitR'_Product,
+    swap, Swap_Product.
+
+(* Simplify expressions involving products. *)
+Ltac cat_auto_simpl_prod :=
+  match goal with
+  | [ |- eq2 ?lhs ?rhs ] =>
+    repeat (rewrite cat_id_l || rewrite cat_id_r
+     || rewrite pair_fst || rewrite <- (cat_assoc (pair_ _ _) fst_), pair_fst 
+     || rewrite pair_snd || rewrite <- (cat_assoc (pair_ _ _) snd_), pair_snd
+     || rewrite !cat_assoc);
+    reflexivity || eauto with cat
+  end.
+
+Ltac cat_auto_prod :=
+  unfold_product;
+  repeat progress (reflexivity || (try cat_auto_simpl_prod); try apply pair_split).
+
+Ltac cat_auto_prod' :=
+  repeat intro;
+  repeat match goal with
+         | [ |- eq2 _ _ ] => fail 1
+         | _ => red
+         end;
+  cat_auto_prod.
+
+
+Lemma swap_pair (a b c: obj) (f: C a b) (g: C a c)
+  : pair_ f g >>> swap ⩯ pair_ g f.
+Proof.
+  intros; unfold swap, Swap_Product.
+  rewrite pair_cat, pair_fst, pair_snd.  
+  reflexivity.
+Qed.
+
+Lemma swap_snd {a b} : swap_ a b >>> snd_ ⩯ fst_.
+Proof. apply pair_snd. Qed.
+
+Lemma swap_fst {a b} : swap_ a b >>> fst_ ⩯ snd_.
+Proof. apply pair_fst. Qed.
+
+Lemma bimap_pair_unfold {a b c d} (f : C a b) (g : C c d)
+  : bimap f g ⩯ pair_ (fst_ >>> f) (snd_ >>> g).
+Proof. reflexivity. Qed.
+
+Lemma bimap_fst {a b c d} (f : C a b) (g : C c d)
+  : bimap f g >>> fst_ ⩯ fst_ >>> f.
+Proof. apply pair_fst. Qed.
+
+Lemma bimap_snd {a b c d} (f : C a b) (g : C c d)
+  : bimap f g >>> snd_ ⩯ snd_ >>> g.
+Proof. apply pair_snd. Qed.
+
+Lemma pair_bimap {a b b' c c'}
+      (fb : C a b) (fc : C a c) (gb : C b b') (gc : C c c')
+  : pair_ fb fc >>> bimap gb gc ⩯ pair_ (fb >>> gb) (fc >>> gc).
+Proof. cat_auto_prod'. Qed.
+
+Lemma assoc_r_fst {a b c}
+  : assoc_r_ a b c >>> fst_ ⩯ fst_ >>> fst_.
+Proof. cat_auto_prod'. Qed.
+
+Lemma assoc_l_snd {a b c}
+  : assoc_l_ a b c >>> snd_ ⩯ snd_ >>> snd_.
+Proof. cat_auto_prod'. Qed.
+
+Lemma assoc_l_fst {a b c}
+  : assoc_l_ a b c >>> fst_ ⩯ bimap (id_ a) fst_.
+Proof. cat_auto_prod'. Qed.
+
+
+Lemma assoc_r_snd {a b c}
+  : assoc_r_ a b c >>> snd_ ⩯ bimap snd_ (id_ c).
+Proof. cat_auto_prod'. Qed.
+
+(** The product is a bifunctor. *)
+
+(* These Instances are kept local and should be made explicit locally using
+     [Existing Instance] to avoid clashes with the cocartesian instances
+ *)
+Instance Proper_Bimap_Product {a b c d}:
+  @Proper (C a b -> C c d -> _)
+          (eq2 ==> eq2 ==> eq2) bimap.
+Proof.
+  intros ac ac' eqac bd bd' eqbd.
+  unfold bimap, Bimap_Product.
+  rewrite eqac, eqbd; reflexivity.
+Qed.
+
+Instance BimapId_Product : BimapId C bif.
+Proof.
+  intros A B.
+  symmetry. unfold bimap, Bimap_Product.
+  rewrite 2 cat_id_r.
+  apply pair_eta.
+Qed.
+
+Instance BimapCat_Product : BimapCat C bif.
+Proof. cat_auto_prod'. Qed.
+
+Instance Bifunctor_Product : Bifunctor C bif.
+Proof.
+  constructor; typeclasses eauto.
+Qed.
+
+(** The coproduct is commutative *)
+
+Instance SwapInvolutive_Product {a b : obj}
+  : SemiIso C (swap_ a b) swap.
+Proof. cat_auto_prod'. Qed.
+
+(** The coproduct is associative *)
+
+Instance AssocRMono_Product {a b c : obj}
+  : SemiIso C (assoc_r_ a b c) assoc_l.
+Proof. cat_auto_prod'. Qed.
+
+Instance AssocLMono_Product {a b c : obj}
+  : SemiIso C (assoc_l_ a b c) assoc_r.
+Proof. cat_auto_prod'. Qed.
+
+Context (t : obj).
+Context {Terminal_t : Terminal C t}.
+Context {TerminalObject_t : TerminalObject C t}.
+
+(** The product has units. *)
+
+Instance UnitLMono_Product {a : obj}
+  : SemiIso C (unit_l_ t a) unit_l'.
+Proof. cat_auto_prod'. rewrite terminal_unique. reflexivity. Qed.
+
+(* TODO: derive this by symmetry *)
+Global Instance UnitRMono_Product {a : obj}
+  : SemiIso C (unit_r_ t a) unit_r'.
+Proof. cat_auto_prod'. rewrite terminal_unique. reflexivity. Qed.
+
+Global Instance UnitLEpi_Product {a : obj}
+  : SemiIso C (unit_l'_ t a) unit_l.
+Proof. cat_auto_prod'. Qed.
+
+Global Instance UnitREpi_Product {a : obj}
+  : SemiIso C (unit_r'_ t a) unit_r.
+Proof. cat_auto_prod'. Qed.
+
+Lemma unit_l'_snd {a} : unit_l' >>> snd_ ⩯ id_ a.
+Proof. apply (semi_iso _ _). Qed.
+
+Lemma unit_r'_fst {a} : unit_r' >>> fst_ ⩯ id_ a.
+Proof. apply (semi_iso _ _). Qed.
+
+Instance UnitLNatural_Product : UnitLNatural C bif t.
+Proof. cat_auto_prod'. Qed.
+
+Instance UnitL'Natural_Product : UnitL'Natural C bif t.
+Proof. cat_auto_prod'. rewrite terminal_unique. reflexivity. Qed.
+
+(** The product satisfies the monoidal coherence laws. *)
+
+Instance AssocRUnit_Product : AssocRUnit C bif t.
+Proof. cat_auto_prod'. Qed.
+
+Instance AssocRAssocR_Product : AssocRAssocR C bif.
+Proof. cat_auto_prod'. Qed.
+
+Instance Monoidal_Product : Monoidal C bif t.
+Proof.
+  constructor; idtac + constructor; typeclasses eauto.
+Qed.
+
+Instance AssocLAssocL_Product : AssocLAssocL C bif.
+Proof. cat_auto_prod'. Qed.
+
+(** The coproduct satisfies the symmetric monoidal laws. *)
+
+Instance SwapUnitL_Product : SwapUnitL C bif t.
+Proof. cat_auto_prod'. Qed.
+
+Instance SwapAssocR_Product : SwapAssocR C bif.
+Proof. cat_auto_prod'. Qed.
+
+Instance SwapAssocL_Product : SwapAssocL C bif.
+Proof. cat_auto_prod'. Qed.
+
+Instance SymMonoidal_Product : SymMonoidal C bif t.
+Proof.
+  constructor; typeclasses eauto.
+Qed.
+
+Lemma swap_bimap_prod {a b c d} (ab : C a b) (cd : C c d) :
+  bimap ab cd ⩯ (swap >>> bimap cd ab >>> swap).
+Proof. cat_auto_prod'. Qed.
+
+(* Naturality of swap *)
+Lemma swap_bimap_prod' {a b c d} (ab : C a b) (cd : C c d) :
+  swap >>> bimap ab cd ⩯ bimap cd ab >>> swap.
+Proof. cat_auto_prod'. Qed.
+
+End ProductFacts.
+
 
 Ltac cat_auto_step :=
   repeat (apply category_proper_cat; [ reflexivity | ]);

--- a/theories/Basics/CategoryOps.v
+++ b/theories/Basics/CategoryOps.v
@@ -384,17 +384,22 @@ Instance UnitR'_Product : UnitR' C PROD T :=
 
 End CartesianConstruct.
 
+(* A Cartesian Closed category has "internal hom" or "exponential"
+   objects. These offer curry and apply operations. *)
 Section CartesianClosed.
   Context {obj : Type}
           (C : Hom obj)
           (PROD : binop obj)
           (EXP : binop obj).
 
+
+  (* SAZ: I'm on the fence about what order the arguments for [EXP] should be:
+     B^A suggests one order, but A => B suggests the other. I went with the latter. *)
   Class Apply : Type :=
-    apply_ : forall a b, C (PROD (EXP b a) a) b.
+    apply_ : forall a b, C (PROD (EXP a b) a) b.
 
   Class Curry : Type :=
-    curry_ : forall a b c, C (PROD c a) b -> C c (EXP b a).
+    curry_ : forall a b c, C (PROD c a) b -> C c (EXP a b).
 
 End CartesianClosed.
 

--- a/theories/Basics/CategoryOps.v
+++ b/theories/Basics/CategoryOps.v
@@ -384,8 +384,25 @@ Instance UnitR'_Product : UnitR' C PROD T :=
 
 End CartesianConstruct.
 
+Section CartesianClosed.
+  Context {obj : Type}
+          (C : Hom obj)
+          (PROD : binop obj)
+          (EXP : binop obj).
+
+  Class Apply : Type :=
+    apply_ : forall a b, C (PROD (EXP b a) a) b.
+
+  Class Curry : Type :=
+    curry_ : forall a b c, C (PROD c a) b -> C c (EXP b a).
+
+End CartesianClosed.
+
+Arguments apply_ {obj C PROD EXP _ a b}.
+Arguments curry_ {obj C PROD EXP _ a b c}.  
+
 Section Dagger.
-  Context {obj : Type} (C : Hom obj) (Cat_C : Cat C).
+  Context {obj : Type} (C : Hom obj).
 
   Class Dagger : Type :=
     dagger : forall a b, op C a b -> C a b.

--- a/theories/Basics/CategoryTheory.v
+++ b/theories/Basics/CategoryTheory.v
@@ -306,7 +306,7 @@ Class CartesianClosed : Prop := {
   cartesian_product :> Product _ PROD;
   cartesian_curry_apply :> CurryApply;
   cartesian_proper_curry_ :> forall a b c,
-    @Proper (C (PROD c a) b -> C c (EXP b a)) (eq2 ==> eq2) curry_                          
+    @Proper (C (PROD c a) b -> C c (EXP a b)) (eq2 ==> eq2) curry_                          
 }.
   
 End CartesianClosureLaws.

--- a/theories/Basics/CategoryTheory.v
+++ b/theories/Basics/CategoryTheory.v
@@ -49,6 +49,12 @@ Class Category : Prop := {
 Class InitialObject (i : obj) {Initial_i : Initial C i} : Prop :=
   initial_object : forall a (f : C i a), f ⩯ empty.
 
+(** *** Terminal object *)
+
+(** There is a unique morphism from any other object and the terminal object. *)
+Class TerminalObject (t : obj) {Terminal_t : Terminal C t} : Prop :=
+  terminal_object : forall a (f : C a t), f ⩯ one.
+
 End CatLaws.
 
 Arguments cat_id_l {obj C Eq2C IdC CatC CatIdL} [a b] f.
@@ -56,9 +62,13 @@ Arguments cat_id_r {obj C Eq2C IdC CatC CatIdR} [a b] f.
 Arguments cat_assoc {obj C Eq2C CatC CatAssoc} [a b c d] f g.
 Arguments category_proper_cat {obj C Eq2C IdC CatC Category} [a b c].
 Arguments initial_object {obj C Eq2C i Initial_i InitialObject} [a] f.
+Arguments terminal_object {obj C Eq2C t Terminal_t TerminalObject} [a] f.
 
 (** Synonym of [initial_object]. *)
 Notation unique_initial := initial_object.
+
+(** Synonym of [terminal_object]. *)
+Notation unique_terminal := terminal_object.
 
 (** ** Mono-, Epi-, Iso- morphisms *)
 
@@ -268,6 +278,40 @@ End ProductLaws.
 Arguments pair_fst {obj C Eq2_C Cat_C bif Pair_C Fst_C PairFst} [a b c] f g.
 Arguments pair_snd {obj C Eq2_C Cat_C bif Pair_C Snd_C PairSnd} [a b c] f g.
 Arguments pair_universal {obj C _ _ bif _ _ _ _} [a b c] f g fg.
+
+(** Cartesian Closure *)
+Section CartesianClosureLaws.
+
+Context {obj : Type} (C : Hom obj).
+Context {Eq2_C : Eq2 C} {Id_C : Id_ C} {Cat_C : Cat C}.
+Context (ONE : obj)
+        {Term_C : Terminal C ONE}.
+Context (PROD : binop obj).
+Context {Pair_C : Pair C PROD}
+        {Fst_C : Fst C PROD}
+        {Snd_C : Snd C PROD}.
+Context (EXP : binop obj).
+Context (Apply_C : Apply C PROD EXP)
+        (Curry_C : Curry C PROD EXP).
+
+Existing Instance Bimap_Product.
+
+Class CurryApply : Prop :=
+  curry_apply :
+    forall a b c (f : C (PROD c a) b),
+      f ⩯ ((@bimap obj C PROD _ _ _ _ _ (curry_ f) (id_ a)) >>> apply_).
+
+Class CartesianClosed : Prop := {
+  cartesian_terminal :> TerminalObject _ ONE;
+  cartesian_product :> Product _ PROD;
+  cartesian_curry_apply :> CurryApply;
+  cartesian_proper_curry_ :> forall a b c,
+    @Proper (C (PROD c a) b -> C c (EXP b a)) (eq2 ==> eq2) curry_                          
+}.
+  
+End CartesianClosureLaws.
+
+Arguments curry_apply {obj C Eq2_C Id_C Cat_C PROD Pair_C Fst_C Snd_C EXP Apply_C Curry_C} _ [a b c] f.
 
 (** ** Monoidal categories *)
 

--- a/theories/Basics/CategoryTheory.v
+++ b/theories/Basics/CategoryTheory.v
@@ -291,8 +291,8 @@ Context {Pair_C : Pair C PROD}
         {Fst_C : Fst C PROD}
         {Snd_C : Snd C PROD}.
 Context (EXP : binop obj).
-Context (Apply_C : Apply C PROD EXP)
-        (Curry_C : Curry C PROD EXP).
+Context {Apply_C : Apply C PROD EXP}
+        {Curry_C : Curry C PROD EXP}.
 
 Existing Instance Bimap_Product.
 

--- a/theories/Basics/Function.v
+++ b/theories/Basics/Function.v
@@ -47,3 +47,12 @@ Instance case_sum : Case Fun sum :=
 (** Injections *)
 Instance sum_inl : Inl Fun sum := @inl.
 Instance sum_inr : Inr Fun sum := @inr.
+
+(** ** The [pair] product. *)
+Instance Pair_Fun : Pair Fun prod :=
+  fun {A B C} l r c => (l c, r c).
+
+Instance Fst_Fun : Fst Fun prod := @fst.
+Instance Snd_Fun : Snd Fun prod := @snd.
+
+

--- a/theories/Basics/Function.v
+++ b/theories/Basics/Function.v
@@ -34,6 +34,10 @@ Instance Cat_Fun : Cat Fun :=
 Instance Initial_void : Initial Fun void :=
   fun _ v => match v : void with end.
 
+(** [unit] as a final object. *)
+Instance Terminal_unit : Terminal Fun unit :=
+  fun _ x => tt.
+
 (** ** The [sum] coproduct. *)
 
 (** Coproduct elimination *)
@@ -56,3 +60,10 @@ Instance Fst_Fun : Fst Fun prod := @fst.
 Instance Snd_Fun : Snd Fun prod := @snd.
 
 
+(** ** Cartesian closure. *)
+(** The [exponential] is just [_ -> _], which is a just another name for [Fun] *)
+Instance Apply_Fun : Apply Fun prod Fun :=
+    fun {A B} '(f, b) => f b.
+  
+Instance Curry_Fun : Curry Fun prod Fun :=
+  fun {A B C} f => fun c a => f (c, a).

--- a/theories/Basics/FunctionFacts.v
+++ b/theories/Basics/FunctionFacts.v
@@ -2,7 +2,8 @@
 
 (* begin hide *)
 From Coq Require Import
-     Morphisms.
+     Morphisms
+     FunctionalExtensionality.
 
 From ITree Require Import
      Basics.Basics
@@ -35,6 +36,9 @@ Proof. red; reflexivity. Qed.
 
 Instance InitialObject_void : InitialObject Fun void :=
   fun _ _ v => match v : void with end.
+
+Instance TerminalObject_unit : TerminalObject Fun unit.
+Proof. red. intros. intro. destruct (f a0). reflexivity. Qed.
 
 Instance eeq_case_sum {A B C} :
   @Proper (Fun A C -> Fun B C -> Fun (A + B) C)
@@ -113,5 +117,25 @@ Section Products.
     - exact BimapProper_Fun_prod.
   Qed.
 
+  Global Instance Product_Fun : Product Fun prod.
+  Proof.
+    constructor; typeclasses eauto.
+  Qed.  
+  
 End Products.
 
+Section CartesianClosure.
+
+  Global Instance CurryApply_Fun : CurryApply Fun prod Fun Apply_Fun Curry_Fun.
+  Proof.
+    red. repeat intro. destruct a0. unfold curry_, Curry_Fun, cat, Cat_Fun. reflexivity.
+  Qed.
+
+  (* Properness of currying requires(?) functional extensionality *)
+  Global Instance CartesianClosed_Fun : CartesianClosed Fun unit prod Fun Apply_Fun Curry_Fun.
+  Proof.
+    constructor; try typeclasses eauto.
+    repeat intro. unfold curry_, Curry_Fun. apply functional_extensionality.
+    intros. apply H.
+  Qed.
+End CartesianClosure.

--- a/theories/Basics/FunctionFacts.v
+++ b/theories/Basics/FunctionFacts.v
@@ -56,3 +56,62 @@ Proof.
   - intros a b c f g fg Hf Hg [x | y]; cbv in *; auto.
   - typeclasses eauto.
 Qed.
+
+Instance PairFst_Fun : PairFst Fun prod.
+Proof.
+  split.
+Qed.
+
+Instance PairSnd_Fun : PairSnd Fun prod.
+Proof.
+  split.
+Qed.
+
+Instance PairUniversal_Fun : PairUniversal Fun prod.
+Proof.
+  repeat intro.
+  unfold pair_, Pair_Fun. specialize (H a0). specialize (H0 a0). rewrite <- H.
+  rewrite <- H0. unfold cat, Cat_Fun.
+  destruct (fg a0). reflexivity.
+Qed.
+
+Instance Proper_pair_Fun : forall a b c, Proper (eq2 ==> eq2 ==> eq2) (@pair_ _ _ _ _ a b c).
+Proof.
+  intros ? ? ? f1 f2 F g1 g2 G c.
+  unfold pair_, Pair_Fun. rewrite F. rewrite G. reflexivity.
+Qed.  
+
+Section Products.
+  Existing Instance Bimap_Product.
+
+  Global Instance BimapId_Fun_prod : BimapId Fun prod.
+  Proof.
+    repeat intro.
+    destruct a0. reflexivity.
+  Qed.
+   
+  Global Instance BimapCat_Fun_prod : BimapCat Fun prod.
+  Proof.
+    repeat intro.
+    destruct a.
+    reflexivity.
+  Qed.
+
+  Global Instance BimapProper_Fun_prod :
+    forall A B C D,
+      @Proper ((A -> C) -> (B -> D) -> (A * B -> C * D)) (eq2 ==> eq2 ==> eq2) bimap.
+  Proof.
+    repeat intro.
+    unfold bimap, Bimap_Product. rewrite H. rewrite H0. reflexivity.
+  Qed.
+
+  Global Instance Bifunctor_Fun_prod : Bifunctor Fun prod.
+  Proof.
+    constructor.
+    - exact BimapId_Fun_prod.
+    - exact BimapCat_Fun_prod.
+    - exact BimapProper_Fun_prod.
+  Qed.
+
+End Products.
+

--- a/theories/Basics/FunctionFacts.v
+++ b/theories/Basics/FunctionFacts.v
@@ -126,13 +126,13 @@ End Products.
 
 Section CartesianClosure.
 
-  Global Instance CurryApply_Fun : CurryApply Fun prod Fun Apply_Fun Curry_Fun.
+  Global Instance CurryApply_Fun : CurryApply Fun prod Fun.
   Proof.
     red. repeat intro. destruct a0. unfold curry_, Curry_Fun, cat, Cat_Fun. reflexivity.
   Qed.
 
   (* Properness of currying requires(?) functional extensionality *)
-  Global Instance CartesianClosed_Fun : CartesianClosed Fun unit prod Fun Apply_Fun Curry_Fun.
+  Global Instance CartesianClosed_Fun : CartesianClosed Fun unit prod Fun.
   Proof.
     constructor; try typeclasses eauto.
     repeat intro. unfold curry_, Curry_Fun. apply functional_extensionality.


### PR DESCRIPTION
I've been doing a bit of work extending the category theory base to include cartesian closed categories.  This pull request adds the basic components for products and exponentials and instantiates them for `Fun`.  I'm not 100% sure about how the global vs. local typeclass instances for products interacts with the way I've specified the typeclasses for curry and apply.  I also imagine that there are more standard lemmas about CCC's that could be added to `CategoryFacts.v`, but I'm not sure where to look for a relevant list of lemmas, but this is a starting point.