### PR TITLE
Trace

### DIFF
--- a/DMonadREADME.md
+++ b/DMonadREADME.md
@@ -1,0 +1,17 @@
+Comparison to paper notes:
+	All Dijkstra Monad related library code is in the theories/Dijkstra folder
+
+	The Hoare Logic and nat_sqrt example are in examples/ImpHoare.v
+
+	The paper often uses names different from those used in this repo.
+        We have included an index of translations of all lemmas and several
+        important definitions in dmf_proof_pointers.txt
+
+Building Notes:
+	Follow the instructions in README.md to build the Interaction Trees Library
+	We have tested that it builds on Coq 8.10 and Coq 8.12, we make no guarantees for any version older < 8.10
+
+Admitted Proofs Notes:
+	All Admitted lemmas in the attached code are unrelated to the project (all that I am aware of are tutorial) or commented out.
+
+Main Toplevel results contained in DelaySpecMonad.v and TraceIT.v.. Our implementation of the Dijkstra Monad Framework implemented with Coq Typeclasses is in DijkstraMonad.v. Each file in the Dijkstra folder contains comments near the top explaining some of the main contributions of the file.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: clean all coq test tests examples tutorial install uninstall depgraph for-dune
+.PHONY: clean all coq test tests examples tutorial hoare_example install uninstall depgraph for-dune
 
 COQPATHFILE=$(wildcard _CoqPath)
 
@@ -9,8 +9,8 @@ include common.mk
 all:
 	# Build the library before tests
 	$(MAKE) coq
-	$(MAKE) tutorial
 	$(MAKE) test
+	$(MAKE) tutorial
 
 install: Makefile.coq coq
 	$(MAKE) -f $< $@

--- a/_CoqConfig
+++ b/_CoqConfig
@@ -3,6 +3,7 @@
 theories/Simple.v
 theories/ITree.v
 theories/ITreeFacts.v
+theories/Axioms.v
 
 theories/Basics/Tacs.v
 theories/Basics/Basics.v
@@ -35,10 +36,14 @@ theories/Eq/Eq.v
 theories/Eq/UpToTaus.v
 theories/Eq/SimUpToTaus.v
 theories/Eq/EqAxiom.v
+theories/Eq/EuttExtras.v
+theories/Eq/Rutt.v
 
 theories/Props/Leaf.v
 theories/Props/Finite.v
 theories/Props/HasPost.v
+theories/Props/Divergence.v
+theories/Props/EuttDiv.v
 
 theories/Indexed/Sum.v
 theories/Indexed/Relation.v
@@ -60,6 +65,7 @@ theories/Events/StateFacts.v
 theories/Events/Reader.v
 theories/Events/Writer.v
 theories/Events/Exception.v
+theories/Events/ExceptionFacts.v
 theories/Events/Nondeterminism.v
 theories/Events/Map.v
 theories/Events/MapDefault.v
@@ -67,3 +73,9 @@ theories/Events/MapDefaultFacts.v
 theories/Events/Concurrency.v
 theories/Events/Dependent.v
 theories/Events/FailFacts.v
+
+theories/ITrace/ITraceDefinition.v
+theories/ITrace/ITraceFacts.v
+theories/ITrace/ITracePrefix.v
+theories/ITrace/ITraceBind.v
+theories/ITrace/ITracePreds.v

--- a/dmf_proof_pointers.txt
+++ b/dmf_proof_pointers.txt
@@ -1,0 +1,31 @@
+Format 
+paper_name -> repo_name :: file_name
+
+itree -> itree :: Core/ITreeDefinition.v
+itrace -> itrace :: Dijkstra/ITrace.v
+bind -> bind :: Core/ITreeDefinition.v
+iter_itree -> iter :: Core/ITreeDefinition.v
+euttEv -> euttEv ::  Dijkstra/EuttEv.v
+eutt -> eutt :: Eq/Eq.v
+
+div_cast_eutt -> div_cast_nop :: Dijkstra/EuttDiv.v
+div_or_ret_a -> eutt_reta_or_div :: Dijkstra/PureITreeBasics.v
+loop_invar_sound -> loop_invar ::  Dijkstra/DelaySpecMonad.v
+classic_wf -> classic_wf ::  Dijkstra/IterRel.v
+loop_invar_state -> loop_invar_state ::  Dijkstra/StateSpecT.v
+intro_not_wf -> intro_not_wf ::  Dijkstra/IterRel.v
+wf_intro_gt -> intro_wf ::  Dijkstra/IterRel.v
+nat_sqrt_spec -> both_hold_nat_sqrt :: tutorial/ImpHoare.v
+bind_ret_counter -> bind_ret_failure ::  Dijkstra/ITreeDijkstra.v
+trace_set_complete -> trace_set_complete ::  Dijkstra/ITrace.v
+converge_bind_refine -> trace_refine_converge_bind ::  Dijkstra/ITrace.v
+diverge_bind_refine -> trace_refine_diverge_bind ::  Dijkstra/ITrace.v
+bind_refine_inv -> decompose_trace_refine_bind ::  Dijkstra/ITraceBind.v
+trace_prefix_bind -> trace_prefix_bind ::  Dijkstra/ITracePrefix.v
+peel_lemma -> peel_lemma ::  Dijkstra/ITraceBind.v
+monad_morph_unfold,
+monad_morph_forward_conv,
+monad_morph_forward_div,
+monad_morph_backwards_conv,
+monad_morph_backwards_div -> TraceSpecMorph ::  Dijkstra/TracesIT.v (the lemmas stated here are all unfolded subcases of this proof)
+queryUnitFalse_spec -> decide_ex_satisfies_spec ::  Dijkstra/TracesIT.v

--- a/examples/ITreePredicatesExample.v
+++ b/examples/ITreePredicatesExample.v
@@ -22,6 +22,9 @@ From ITree Require Import
      ITreeFacts
      Eq.Paco2.
 
+
+From Paco Require Import paco.
+
 Import ITreeNotations.
 
 
@@ -97,7 +100,7 @@ Section Proper.
    *)
   Instance proper_interpret_state {S R} : Proper ((@eq_itree (stateE S) R _ eq) ==> (@eq S) ==> (@eq_itree void1 (S * R) _ eq)) interpret_state.
   Proof.
-    ginit. pcofix CIH.
+    ginit. gcofix CIH.
     intros x y H0 x2 y0 H1.
     rewrite (itree_eta (interpret_state x x2)).
     rewrite (itree_eta (interpret_state y y0)).
@@ -231,7 +234,7 @@ Lemma state_independent : forall {S R} (t:itree (stateE S) R)
     forall s s', ('(s,x) <- interpret_state t s ;; ret x) ≅ ('(s,x) <- interpret_state t s' ;; ret x).
 Proof.
   intros S R.
-  ginit. pcofix CIH.
+  ginit. gcofix CIH.
   intros t H0 s s'.
   rewrite (itree_eta (interpret_state t s)).
   rewrite (itree_eta (interpret_state t s')).
@@ -263,7 +266,7 @@ Lemma state_independent_k : forall {S R U} (t:itree (stateE S) R)
     forall s s', (sx <- interpret_state t s ;; (k sx)) ≅ (sx <- interpret_state t s' ;; (k sx)).
 Proof.
   intros S R U.
-  ginit. pcofix CIH.
+  ginit. gcofix CIH.
   intros t H0 k INV s s'.
   rewrite (itree_eta (interpret_state t s)).
   rewrite (itree_eta (interpret_state t s')).

--- a/theories/Axioms.v
+++ b/theories/Axioms.v
@@ -1,0 +1,40 @@
+(** * Axioms used in the ITree library. *)
+
+(** Other ITree modules should import this to avoid accidentally using more
+   axioms elsewhere. *)
+
+From Coq Require Import
+  Logic.Classical_Prop
+  Logic.IndefiniteDescription
+  Logic.EqdepFacts
+.
+
+(* Must be imported to use [ddestruction] *)
+From Coq Require Export
+  Program.Equality
+.
+
+Set Implicit Arguments.
+
+(* The following tactics may be used:
+   - [dependent destruction]
+   - [dependent induction] *)
+Ltac ddestruction :=
+  repeat lazymatch goal with | H : existT _ _ _ = _ |- _ => dependent destruction H end.
+
+(* Consequence of UIP; used by tactic [dependent destrcution] *)
+Definition eq_rect_eq := Eqdep.Eq_rect_eq.eq_rect_eq.
+
+Definition classic := Classical_Prop.classic.
+
+Definition constructive_indefinite_description :=
+  IndefiniteDescription.constructive_indefinite_description.
+
+Lemma classicT : forall (P : Prop), {P} + {~ P}.
+Proof.
+  intros P.
+  assert (H : exists b : bool, if b then P else ~ P).
+  { destruct (classic P); [exists true | exists false]; assumption. }
+  apply constructive_indefinite_description in H.
+  destruct H as [[] ?]; [ left | right ]; assumption.
+Qed.

--- a/theories/Basics/Monad.v
+++ b/theories/Basics/Monad.v
@@ -9,8 +9,7 @@ From ExtLib Require Export
 
 From ITree Require Import
      Basics.Basics
-     Basics.CategoryOps
-     Basics.Function.
+     Basics.CategoryOps.
 (* end hide *)
 
 Set Primitive Projections.

--- a/theories/Eq.v
+++ b/theories/Eq.v
@@ -1,7 +1,8 @@
 (** * Equivalences for interaction trees *)
 
-From ITree Require Export
-     Eq.Shallow
-     Eq.Eq
-     Eq.UpToTaus
-     Eq.SimUpToTaus.
+From ITree.Eq Require Export
+  Shallow
+  Eq
+  UpToTaus
+  SimUpToTaus
+  EuttExtras.

--- a/theories/Eq/Eq.v
+++ b/theories/Eq/Eq.v
@@ -361,6 +361,7 @@ Proof.
   destruct IN. econstructor; eauto.
 Qed.
 
+
 Hint Resolve eqitC_mon : paco.
 
 Lemma eqitC_wcompat b1 b2 vclo
@@ -1240,6 +1241,23 @@ Ltac tau_steps_right :=
 Ltac tau_steps :=
   tau_steps_left;
   tau_steps_right.
+
+
+Ltac force_left_in H :=
+  match type of H with _ ?x _ => rewrite (itree_eta x) in H; cbn in H end.
+
+Ltac force_right_in H :=
+  match type of H with _ _ ?x => rewrite (itree_eta x) in H; cbn in H end.
+
+Ltac tau_steps_left_in H :=
+  repeat (force_left_in H; rewrite tau_eutt in H); force_left_in H.
+
+Ltac tau_steps_right_in H :=
+  repeat (force_right_in H; rewrite tau_eutt in H); force_right_in H.
+
+Ltac tau_steps_in H :=
+  tau_steps_left_in H;
+  tau_steps_right_in H.
 
 Lemma eqit_inv_bind_ret:
   forall {E X R1 R2 RR} b1 b2

--- a/theories/Eq/EuttExtras.v
+++ b/theories/Eq/EuttExtras.v
@@ -1,0 +1,36 @@
+(** * More facts about eutt *)
+
+(** ... that have been added recently and I don't know where to put. *)
+
+(* TODO: Figure out some way to organize Eq/UpToTaus.v and Eq/Eq.v *)
+
+From Coq Require Import
+  Basics
+  RelationClasses.
+
+From Paco Require Import paco.
+
+From ITree Require Import
+  Core.ITreeDefinition Eq.Eq.
+
+Lemma paco2_eqit_refl : forall E R r (t : itree E R), paco2 (eqit_ eq true true id) r t t.
+Proof.
+  intros. eapply paco2_mon with (r := bot2); intuition.
+  enough (t ≈ t); auto. reflexivity.
+Qed.
+
+Lemma eutt_subrel : forall (E : Type -> Type) (A B : Type) (R1 R2 : A -> B -> Prop)
+                           (ta : itree E A) (tb : itree E B),
+    (forall a b, R1 a b -> R2 a b) -> eutt R1 ta tb -> eutt R2 ta tb.
+Proof.
+  intros.
+  eapply eqit_mon; eauto.
+Qed.
+
+Lemma eutt_flip : forall (E : Type -> Type) (A B : Type) (R : A -> B -> Prop)
+                         (ta : itree E A) (tb : itree E B),
+    eutt R ta tb -> eutt (flip R) tb ta.
+Proof.
+  intros. apply eqit_flip. 
+  eapply eutt_subrel with (R1 := R); eauto.
+Qed.

--- a/theories/Eq/Rutt.v
+++ b/theories/Eq/Rutt.v
@@ -1,0 +1,220 @@
+(** * Relation up to tau *)
+
+(** [rutt] ("relation up to tau") is a generalization of [eutt] that may relate trees
+  indexed by different event type families [E]. *)
+
+(** It corresponds roughly to the interpretation of "types as relations" from the relational
+  parametricity model by Reynolds (Types, Abstraction and Parametric Polymorphism).
+  Any polymorphic function [f : forall E R, itree E R -> ...] should respect this relation,
+  in the sense that for any relations [rE], [rR], the implication
+  [rutt rE rR t t' -> (f t ~~ f t')] should hold, where [~~] is some canonical relation on the
+  codomain of [f].
+
+  If we could actually quotient itrees "up to taus", and Coq could generate
+  parametricity ("free") theorems on demand, the above might be a free theorem. *)
+
+(** [rutt] is used to define the [trace_refine] relation in [ITree.ITrace.ITraceDefinition]. *)
+
+From Coq Require Import
+     Morphisms
+.
+
+From ITree Require Import
+     Axioms
+     ITree
+     ITreeFacts
+.
+
+
+From Paco Require Import paco.
+
+Import Monads.
+Import MonadNotation.
+Local Open Scope monad_scope.
+
+Section RuttF.
+
+Context {E1 E2 : Type -> Type}.
+Context {R1 R2 : Type}.
+(* From the point of view of relational parametricity, it would be more fitting
+  to replace [(REv, RAns)] with one [REv : forall A1 A2, (A1 -> A2 -> Prop) -> (E1 A1 -> E2 A2 -> Prop)].
+  Contributions to that effect are welcome. *)
+Context (REv : forall (A B : Type), E1 A -> E2 B -> Prop ).
+Context (RAns : forall (A B : Type), E1 A -> A -> E2 B -> B -> Prop ).
+Context (RR : R1 -> R2 -> Prop).
+Arguments REv {A} {B}.
+Arguments RAns {A} {B}.
+
+Inductive ruttF
+          (vclo : (itree E1 R1 -> itree E2 R2 -> Prop) -> itree E1 R1 -> itree E2 R2 -> Prop)
+          (sim : itree E1 R1 -> itree E2 R2 -> Prop) : itree' E1 R1 -> itree' E2 R2 -> Prop :=
+  | EqRet : forall (r1 : R1) (r2 : R2), RR r1 r2 -> ruttF vclo sim (RetF r1) (RetF r2)
+  | EqTau : forall (m1 : itree E1 R1) (m2 : itree E2 R2), sim m1 m2 -> ruttF vclo sim (TauF m1) (TauF m2)
+  | EqTauL : forall (t1 : itree E1 R1) (ot2 : itree' E2 R2),
+      ruttF vclo sim (observe t1) ot2 -> ruttF vclo sim (TauF t1) ot2
+  | EqTauR : forall (ot1 : itree' E1 R1) (t2 : itree E2 R2),
+      ruttF vclo sim ot1 (observe t2) -> ruttF vclo sim ot1 (TauF t2)
+  | EqVis : forall (A B : Type) (e1 : E1 A) (e2 : E2 B ) (k1 : A -> itree E1 R1) (k2 : B -> itree E2 R2),
+      REv e1 e2 ->
+      (forall (a : A) (b : B), RAns e1 a e2 b -> vclo sim (k1 a) (k2 b) : Prop) -> ruttF vclo sim (VisF e1 k1) (VisF e2 k2).
+Hint Constructors ruttF.
+
+Definition rutt_ (vclo : (itree E1 R1 -> itree E2 R2 -> Prop) -> itree E1 R1 -> itree E2 R2 -> Prop )
+           (sim : itree E1 R1 -> itree E2 R2 -> Prop) (t1 : itree E1 R1) (t2 : itree E2 R2) :=
+  ruttF vclo sim (observe t1) (observe t2).
+Hint Unfold rutt_.
+Lemma rutt_monot (vclo : (itree E1 R1 -> itree E2 R2 -> Prop) -> itree E1 R1 -> itree E2 R2 -> Prop):
+  (monotone2 vclo) -> monotone2 (rutt_ vclo).
+Proof.
+  intros. red in H. red. intros. red. red in IN. induction IN; eauto.
+Qed.
+
+
+
+Lemma rutt_id_monot : monotone2 (@id (itree E1 R1 -> itree E2 R2 -> Prop) ).
+Proof. auto. Qed.
+
+
+
+Definition rutt : itree E1 R1 -> itree E2 R2 -> Prop := paco2 (rutt_ id) bot2.
+
+End RuttF.
+
+
+Hint Resolve rutt_monot : paco.
+
+Hint Resolve rutt_id_monot : paco.
+
+Lemma rutt_inv_tauL {E1 E2 R1 R2 REv RAns RR} t1 t2 :
+  @rutt E1 E2 R1 R2 REv RAns RR (Tau t1) t2 -> rutt REv RAns RR t1 t2.
+Proof.
+  intros. punfold H. red in H. simpl in *.
+  remember (TauF t1) as tt1. genobs t2 ot2.
+  hinduction H before t1; intros; try discriminate.
+  - inv Heqtt1. pclearbot. pstep. red. simpobs. econstructor; eauto. pstep_reverse.
+  - inv Heqtt1. punfold_reverse H.
+  - red in IHruttF. pstep. red; simpobs. econstructor; eauto. pstep_reverse.
+Qed.
+
+Lemma rutt_add_tauL {E1 E2 R1 R2 REv RAns RR} t1 t2 :
+  @rutt E1 E2 R1 R2 REv RAns RR t1 t2 -> rutt REv RAns RR (Tau t1) t2.
+Proof.
+  intros. pfold. red. cbn. constructor. pstep_reverse.
+Qed.
+
+Lemma rutt_inv_tauR {E1 E2 R1 R2 REv RAns RR} t1 t2 :
+  @rutt E1 E2 R1 R2 REv RAns RR t1 (Tau t2) -> rutt REv RAns RR t1 t2.
+Proof.
+  intros. punfold H. red in H. simpl in *.
+  pstep. red. remember (TauF t2) as tt2 eqn:Ett2 in H.
+  revert t2 Ett2; induction H; try discriminate; intros; inversion Ett2; subst; auto.
+  - pclearbot. constructor. pstep_reverse.
+  - constructor. eapply IHruttF; eauto.
+Qed.
+
+Lemma rutt_add_tauR {E1 E2 R1 R2 REv RAns RR} t1 t2 :
+  @rutt E1 E2 R1 R2 REv RAns RR t1 t2 -> rutt REv RAns RR t1 (Tau t2).
+Proof.
+  intros. pfold. red. cbn. constructor. pstep_reverse.
+Qed.
+
+Lemma rutt_inv_tauLR  {E1 E2 R1 R2 REv RAns RR} t1 t2 :
+   @rutt E1 E2 R1 R2 REv RAns RR (Tau t1) (Tau t2) -> rutt REv RAns RR t1 t2.
+Proof.
+  intros; apply rutt_inv_tauR, rutt_inv_tauL; assumption.
+Qed.
+
+Section eqitC_rutt.
+  Context {E1 E2 : Type -> Type} {R1 R2 : Type} (RR : R1 -> R2 -> Prop).
+  (* Question, is it a problem that I don't have the booleans, is that necessary?
+     Would be simple to add but would necessitate some busy work *)
+
+  (* A transitivity functor *)
+  Variant eqit_trans_clo  (b1 b2 b1' b2' : bool)  (r : itree E1 R1 -> itree E2 R2 -> Prop) :
+    itree E1 R1 -> itree E2 R2 -> Prop :=
+    eqit_trans_clo_intro t1 t2 t1' t2' RR1 RR2
+      (EQVl: eqit RR1 b1 b1' t1 t1')
+      (EQVr: eqit RR2 b2 b2' t2 t2')
+      (REL: r t1' t2')
+      (LERR1: forall x x' y, RR1 x x' -> RR x' y -> RR x y)
+      (LERR2: forall x y y', RR2 y y' -> RR x y' -> RR x y) :
+      eqit_trans_clo b1 b2 b1' b2' r t1 t2.
+  Hint Constructors eqit_trans_clo : core.
+  (* sets directionality *)
+  Definition eqitC_rutt b1 b2 := eqit_trans_clo b1 b2 false false.
+  Hint Unfold eqitC_rutt : core.
+
+  Lemma eqitC_rutt_mon b1 b2 r1 r2 t1 t2
+    (IN : eqitC_rutt b1 b2 r1 t1 t2)
+    (LE : r1 <2= r2) :
+    eqitC_rutt b1 b2 r2 t1 t2.
+  Proof.
+    destruct IN; econstructor; eauto.
+  Qed.
+
+  Hint Resolve eqitC_rutt_mon : paco.
+
+End eqitC_rutt.
+
+(*replicate this proof for the models functor*)
+Lemma eqitC_rutt_wcompat (b1 b2 : bool) E1 E2 R1 R2 (REv : forall A B, E1 A -> E2 B -> Prop)
+      (RAns : forall A B, E1 A -> A -> E2 B -> B -> Prop ) (RR : R1 -> R2 -> Prop)
+     (vclo: (itree E1 R1 -> itree E2 R2 -> Prop) -> (itree E1 R1 -> itree E2 R2 -> Prop) )
+     (MON: monotone2 vclo)
+      (CMP: compose (eqitC_rutt RR b1 b2) vclo <3= compose vclo (eqitC_rutt RR b1 b2)) :
+  wcompatible2 (Rutt.rutt_ REv RAns RR vclo) (eqitC_rutt RR b1 b2).
+Proof.
+  constructor; eauto with paco.
+  { red. intros. eapply eqitC_rutt_mon; eauto. }
+  intros.
+  destruct PR. punfold EQVl. punfold EQVr. unfold_eqit.
+  hinduction REL before r; intros; clear t1' t2'.
+  - remember (RetF r1) as x. red.
+    hinduction EQVl before r; intros; subst; try inv Heqx; eauto; (try constructor; eauto).
+    remember (RetF r3) as x. hinduction EQVr before r; intros; subst; try inv Heqx; (try constructor; eauto).
+  - red. remember (TauF m1) as x.
+    hinduction EQVl before r; intros; subst; try inv Heqx; try inv CHECK; ( try (constructor; eauto; fail )).
+    remember (TauF m3) as y.
+    hinduction EQVr before r; intros; subst; try inv Heqy; try inv CHECK; (try (constructor; eauto; fail)).
+    pclearbot. constructor. gclo. econstructor; eauto with paco.
+  - remember (TauF t1) as x. red.
+    hinduction EQVl before r; intros; subst; try inv Heqx; try inv CHECK; (try (constructor; eauto; fail)).
+    pclearbot. punfold REL. constructor. eapply IHREL; eauto.
+  - remember (TauF t2) as y. red.
+    hinduction EQVr before r; intros; subst; try inv Heqy; try inv CHECK; (try (constructor; eauto; fail)).
+    pclearbot. punfold REL. constructor. eapply IHREL; eauto.
+  - remember (VisF e1 k1) as x. red.
+    hinduction EQVl before r; intros; subst; try discriminate; try (constructor; eauto; fail).
+    remember (VisF e2 k3) as y.
+    hinduction EQVr before r; intros; subst; try discriminate; try (constructor; eauto; fail).
+    dependent destruction Heqx.
+    dependent destruction Heqy.
+    constructor; auto. intros. apply H0 in H1. pclearbot. eapply MON.
+    + eapply CMP. red. econstructor; eauto.
+    + intros. apply gpaco2_clo; auto.
+Qed.
+
+Definition eqitC_rutt_wcompat' := eqitC_rutt_wcompat true true.
+
+Hint Resolve (eqitC_rutt_wcompat') : paco.
+
+Global Instance grutt_cong_eqit {R1 R2 : Type} {E1 E2 : Type -> Type} {REv : forall A B, E1 A -> E2 B -> Prop}
+      {RAns : forall A B, E1 A -> A -> E2 B -> B -> Prop} {RR1 RR2} {RS : R1 -> R2 -> Prop} r rg
+      (LERR1: forall x x' y, (RR1 x x': Prop) -> (RS x' y: Prop) -> RS x y)
+       (LERR2: forall x y y', (RR2 y y': Prop) -> RS x y' -> RS x y) :
+    Proper (eq_itree RR1 ==> eq_itree RR2 ==> flip impl)
+         (gpaco2 (Rutt.rutt_ REv RAns RS id) (eqitC_rutt RS true true) r rg).
+Proof.
+  repeat intro. gclo. econstructor; eauto;
+  try eapply eqit_mon; try apply H; try apply H0; auto.
+Qed.
+
+Global Instance grutt_cong_euttge {R1 R2 : Type} {E1 E2 : Type -> Type} {REv : forall A B, E1 A -> E2 B -> Prop}
+      {RAns : forall A B, E1 A -> A -> E2 B -> B -> Prop} {RR1 RR2} {RS : R1 -> R2 -> Prop} r rg
+      (LERR1: forall x x' y, (RR1 x x': Prop) -> (RS x' y: Prop) -> RS x y)
+       (LERR2: forall x y y', (RR2 y y': Prop) -> RS x y' -> RS x y) :
+    Proper (euttge RR1 ==> euttge RR2 ==> flip impl)
+         (gpaco2 (Rutt.rutt_ REv RAns RS id) (eqitC_rutt RS true true) r rg).
+Proof.
+  repeat intro. gclo. econstructor; eauto.
+Qed.

--- a/theories/Eq/SimUpToTaus.v
+++ b/theories/Eq/SimUpToTaus.v
@@ -88,7 +88,7 @@ Lemma suttF_inv_vis {E R1 R2} (RR : R1 -> R2 -> Prop) sutt :
     suttF RR sutt (VisF e k1) (VisF e k2) ->
     forall x, sutt (observe (k1 x)) (observe (k2 x)).
 Proof.
-  intros. inv H. apply inj_pair2 in H3; apply inj_pair2 in H5. subst. auto.
+  intros. inv H. dependent destruction H3. dependent destruction H5. subst. auto.
 Qed.
 
 Lemma sutt_inv_vis {E R1 R2} (RR : R1 -> R2 -> Prop) :

--- a/theories/Events/Exception.v
+++ b/theories/Events/Exception.v
@@ -1,16 +1,37 @@
 (** * Exception event *)
 
 (* begin hide *)
-Set Implicit Arguments.
-Set Contextual Implicit.
+
+From Coq Require Import
+     Arith.PeanoNat
+     Lists.List
+     Strings.String
+     Morphisms
+     Setoid
+     RelationClasses
+     Logic.Classical_Prop
+     Logic.FunctionalExtensionality
+.
+
+From ExtLib Require Import
+     Data.String
+     Structures.Monad
+     Structures.Traversable
+     Data.List.
 
 From ITree Require Import
-     Basics.Basics
-     Core.ITreeDefinition
-     Indexed.Sum
-     Core.Subevent
-     Interp.Interp.
+     ITree
+     ITreeFacts
+     Events.MapDefault
+     Events.State
+     Events.StateFacts
+.
+
 (* end hide *)
+
+Import Monads.
+Import MonadNotation.
+Local Open Scope monad_scope.
 
 (** Throw exceptions of type [Err]. *)
 Variant exceptE (Err : Type) : Type -> Type :=
@@ -21,4 +42,70 @@ Variant exceptE (Err : Type) : Type -> Type :=
 Definition throw {Err : Type} {E : Type -> Type} `{exceptE Err -< E} {X}
            (e : Err)
   : itree E X
-  := vis (Throw e) (fun v : void => match v with end).
+  := vis (Throw _ e) (fun v : void => match v with end).
+
+(* translate *)
+
+Definition try_catch {Err R : Type } {E : Type -> Type} 
+            (ttry : itree (exceptE Err +' E) R) (kcatch : Err -> itree (exceptE Err +' E) R) : itree (exceptE Err +' E) R :=
+  (* the problem is kcatch is actually not a handler, need basic iter?*)
+  let catch_body (t : itree (exceptE Err +' E) R) : itree (exceptE Err +' E) ((itree (exceptE Err +' E) R) + R )  := 
+       match observe t with
+       | RetF r => Ret (inr r)
+       | TauF t' => Ret (inl t')
+       | VisF e k =>
+         match e with
+         | inl1 (Throw _ exc) => Functor.fmap inr (kcatch exc)
+         | inr1 e' =>  Functor.fmap (fun x => inl (k x) ) (trigger e) end end
+
+  in 
+  ITree.iter catch_body ttry.
+
+
+Definition throw_prefix {Err R : Type} {E : Type -> Type}
+           (t : itree (exceptE Err +' E) R) : itree  (exceptE Err +' E) (R + Err) :=
+  let prefix_body (t' : itree (exceptE Err +' E)  R ) : itree (exceptE Err +' E)  ((itree (exceptE Err +' E) R) + (R + Err) ) :=
+      match observe t' with
+      | RetF r => Ret (inr (inl r) )
+      | TauF t' => Ret (inl t')
+      | VisF e k =>
+        match e with
+        | inl1 (Throw _ exc) => Ret (inr (inr exc) )
+        | inr1 e' =>  Functor.fmap (fun x => inl (k x) ) (trigger e)
+        end
+      end in
+  ITree.iter prefix_body t.
+
+
+Lemma try_catch_ret : forall E Err R r (kcatch : Err -> itree (exceptE Err +' E) R),
+    try_catch (Ret r) kcatch ≅ Ret r.
+Proof.
+  intros. unfold try_catch. unfold iter, Iter_Kleisli, Basics.iter, MonadIter_itree.
+  rewrite unfold_iter. cbn. rewrite bind_ret_l. reflexivity.
+Qed.
+
+Lemma try_catch_tau : forall E Err R t (kcatch : Err -> itree (exceptE Err +' E) R),
+    try_catch (Tau t) kcatch ≅ Tau (try_catch t kcatch).
+Proof.
+  intros. unfold try_catch. unfold iter, Iter_Kleisli, Basics.iter, MonadIter_itree.
+  rewrite unfold_iter. cbn. rewrite bind_ret_l. reflexivity.
+Qed.
+
+Lemma try_catch_exc : forall E Err R exc (k :void -> itree (exceptE Err +' E) R) 
+                               (kcatch : Err -> itree (exceptE Err +' E) R),
+    try_catch (Vis (inl1 (Throw _ exc)) k ) kcatch ≅ kcatch exc.
+Proof.
+   intros. unfold try_catch. unfold iter, Iter_Kleisli, Basics.iter, MonadIter_itree.
+   rewrite unfold_iter. cbn. unfold ITree.map.
+   rewrite bind_bind. setoid_rewrite bind_ret_l. rewrite bind_ret_r.
+   reflexivity.
+Qed.
+
+Lemma try_catch_ev : forall E A Err R (ev: E A) k (kcatch : Err -> itree (exceptE Err +' E) R),
+    try_catch (Vis (inr1 ev) k ) kcatch ≅ Vis (inr1 ev) (fun x => Tau (try_catch (k x) kcatch) ).
+Proof.
+  intros. unfold try_catch. unfold iter, Iter_Kleisli, Basics.iter, MonadIter_itree.
+  rewrite unfold_iter. cbn. unfold ITree.map at 3.
+  setoid_rewrite bind_bind. rewrite bind_trigger. cbn.
+  setoid_rewrite bind_ret_l. reflexivity.
+Qed.

--- a/theories/Events/ExceptionFacts.v
+++ b/theories/Events/ExceptionFacts.v
@@ -1,0 +1,244 @@
+From Coq Require Import
+     Arith.PeanoNat
+     Lists.List
+     Strings.String
+     Morphisms
+     Setoid
+     RelationClasses
+     Logic.Classical_Prop
+     Logic.FunctionalExtensionality
+.
+
+From ExtLib Require Import
+     Data.String
+     Structures.Monad
+     Structures.Traversable
+     Data.List.
+
+From ITree Require Import
+     ITree
+     ITreeFacts
+     Events.MapDefault
+     Events.State
+     Events.StateFacts
+     Events.Exception
+.
+
+(* end hide *)
+
+Import Monads.
+Import MonadNotation.
+Local Open Scope monad_scope.
+From Paco Require Import paco.
+
+Global Instance proper_eqitree_try_catch {E Err R} : Proper (eq_itree eq ==> pointwise_relation Err (eq_itree eq) ==> eq_itree eq) (@try_catch Err R E).
+Proof.
+  intros t1 t2 Ht k1 k2 Hk. red in Hk. generalize dependent t2. revert t1.
+  ginit. gcofix CIH. intros. unfold try_catch.  setoid_rewrite unfold_iter_ktree.
+  pinversion Ht; try inv CHECK.
+  - repeat rewrite bind_ret_l. gfinal; right. pfold; constructor; auto.
+  - repeat rewrite bind_ret_l. gstep; constructor. gfinal. left. eauto.
+  - destruct e.
+    + destruct e. cbn. repeat rewrite bind_map. repeat rewrite bind_ret_r.  gfinal.
+      right. eapply paco2_mon; try apply Hk. intros; contradiction.
+    + cbn. repeat rewrite bind_map. repeat rewrite bind_trigger. gstep. constructor. intros.
+      gstep. constructor. gfinal. left. eauto.
+Qed.
+
+Global Instance proper_eutt_try_catch {E Err R} : Proper (eutt eq ==> pointwise_relation Err (eutt eq) ==> eutt eq) (@try_catch Err R E).
+Proof.
+  intros t1 t2 Ht k1 k2 Hk. red in Hk. generalize dependent t2. revert t1.
+  ginit. gcofix CIH. intros. unfold try_catch. setoid_rewrite unfold_iter_ktree.
+  punfold Ht. red in Ht.
+  hinduction Ht before r; intros; subst; eauto; try inv CHECK; pclearbot.
+  - repeat rewrite bind_ret_l. gfinal; right. pfold; constructor; auto.
+  - repeat rewrite bind_ret_l. gstep; constructor. gfinal. left. eauto.
+  - destruct e.
+    + destruct e. cbn. repeat rewrite bind_map. repeat rewrite bind_ret_r.  gfinal.
+      right. eapply paco2_mon; try apply Hk. intros; contradiction.
+    + cbn. repeat rewrite bind_map. repeat rewrite bind_trigger. gstep. constructor. intros.
+      gstep. constructor. gfinal. left. eauto.
+  - rewrite bind_ret_l. rewrite tau_euttge. rewrite unfold_iter_ktree. eapply IHHt; eauto.
+  - rewrite bind_ret_l. rewrite tau_euttge. rewrite unfold_iter_ktree. eapply IHHt; eauto.
+Qed.
+
+
+Global Instance proper_eqitree_throw_prefix {E Err R b} : Proper (eqit eq b b ==> eqit eq b b) (@throw_prefix Err R E).
+Proof.
+  intros t1 t2 Ht. generalize dependent t2. revert t1.
+  ginit. gcofix CIH. intros. unfold throw_prefix. setoid_rewrite unfold_iter_ktree.
+  punfold Ht. red in Ht. hinduction Ht before r; intros; subst; eauto; try inv CHECK.
+  - repeat rewrite bind_ret_l. gfinal; right. subst. pfold; constructor; auto.
+  - repeat rewrite bind_ret_l. gstep; constructor. gfinal. left. pclearbot.
+    eapply CIH. auto.
+  - destruct e.
+    + destruct e. cbn. repeat rewrite bind_map. repeat rewrite bind_ret_r. repeat rewrite bind_ret_l.  gfinal.
+      right. pfold; constructor; auto.
+    + cbn. repeat rewrite bind_map. repeat rewrite bind_trigger. gstep. constructor. intros.
+      gstep. constructor. gfinal. left. pclearbot. eapply CIH; eauto.
+  - rewrite bind_ret_l. rewrite tau_euttge. rewrite unfold_iter_ktree. eapply IHHt; eauto.
+  - rewrite bind_ret_l. rewrite tau_euttge. rewrite unfold_iter_ktree. eapply IHHt; eauto.
+Qed.
+
+
+Definition throw_prefix_ret : forall E Err R (r : R),
+    @throw_prefix Err R E (Ret r) ≅ Ret (inl r).
+Proof.
+  intros. setoid_rewrite unfold_iter_ktree. cbn. rewrite bind_ret_l. reflexivity.
+Qed.
+
+Definition throw_prefix_tau : forall E Err R (t : itree (exceptE Err +' E) R),
+    throw_prefix (Tau t) ≅ Tau (throw_prefix t) .
+Proof.
+  intros. setoid_rewrite unfold_iter_ktree at 1. cbn. rewrite bind_ret_l.
+  reflexivity.
+Qed.
+
+Definition throw_prefix_exc : forall E Err R k (e : Err), 
+    @throw_prefix Err R E (Vis (inl1 (Throw _ e) ) k) ≅ Ret (inr e).
+Proof.
+  intros. setoid_rewrite unfold_iter_ktree. cbn. rewrite bind_ret_l. reflexivity.
+Qed.
+
+Definition throw_prefix_ev : forall X E Err R k  (e : E X) , 
+    throw_prefix ((Vis (inr1 e) k : itree (exceptE Err +' E) R )) ≅ Vis (inr1 e) (fun x => Tau (throw_prefix (k x)) ).
+Proof.
+  intros. setoid_rewrite unfold_iter_ktree at 1. cbn. rewrite bind_map.
+  rewrite bind_trigger. apply eqit_Vis. intros. reflexivity.
+Qed.
+
+Lemma try_catch_throw_prefix_nop : forall E Err R  kcatch (ttry : itree (exceptE Err +' E) R),
+    try_catch (throw_prefix ttry) kcatch ≈ throw_prefix ttry.
+Proof. 
+  intros E Err R kcatch. ginit. gcofix CIH. intros.
+  destruct (observe ttry) eqn : Heq; symmetry in Heq; apply simpobs in Heq.
+  - rewrite Heq. rewrite throw_prefix_ret. rewrite try_catch_ret. gfinal. right.
+    pfold; constructor; auto.
+  - rewrite Heq. rewrite throw_prefix_tau. rewrite try_catch_tau. gstep. constructor.
+    gfinal; left; auto.
+  - destruct e.
+   + destruct e. rewrite Heq. rewrite throw_prefix_exc. rewrite try_catch_ret. gfinal.
+     right. pfold; constructor; auto.
+   + rewrite Heq. rewrite throw_prefix_ev. rewrite try_catch_ev. gstep.
+     constructor. intros. red. rewrite try_catch_tau. repeat rewrite tau_euttge.
+     gfinal. left. auto.
+Qed.
+
+Lemma throw_prefix_bind_decomp : forall E Err R (t : itree (exceptE Err +' E) R ),
+    t ≈ ITree.bind (throw_prefix t) (fun r => 
+                                    match r with 
+                                    | inr e => v <- trigger (inl1 (Throw _ e));; match v : void with end
+                                    | inl a => Ret a
+                                    end).
+Proof.
+  intros E Err R. ginit. gcofix CIH. intros.
+  destruct (observe t) eqn : Heq; symmetry in Heq; apply simpobs in Heq.
+  - rewrite Heq. rewrite throw_prefix_ret. rewrite bind_ret_l. gfinal. right. pfold; constructor; auto.
+  - rewrite Heq. rewrite throw_prefix_tau. rewrite bind_tau. gstep. constructor.
+    gfinal; left. auto.
+  - destruct e.
+    + rewrite Heq. destruct e. rewrite throw_prefix_exc. rewrite bind_ret_l. cbn. rewrite bind_trigger.
+      gstep. constructor. intros [].
+    + rewrite Heq. rewrite throw_prefix_ev. rewrite bind_vis. gstep. constructor.
+      intros. red. rewrite tau_euttge. gfinal; left; auto.
+Qed.
+
+Lemma try_catch_to_throw_prefix : forall E Err R (ttry : itree (exceptE Err +' E) R  ) (kcatch : Err -> itree (exceptE Err +' E) R),
+    try_catch ttry kcatch ≈ ITree.bind (throw_prefix ttry) (fun r =>
+                                                            match r with
+                                                            | inr e => kcatch e
+                                                            | inl a => Ret a
+                                                            end).
+Proof.
+  intros. revert ttry. ginit. gcofix CIH.
+  intros. destruct (observe ttry) eqn : Heq; symmetry in Heq; apply simpobs in Heq.
+  - rewrite Heq. rewrite try_catch_ret. rewrite throw_prefix_ret. rewrite bind_ret_l. gfinal.
+    right. pfold; constructor; auto.
+  - rewrite Heq. rewrite try_catch_tau. rewrite throw_prefix_tau. rewrite bind_tau.
+    gstep. constructor. gfinal; left; auto.
+  - destruct e.
+    + destruct e. rewrite Heq. rewrite try_catch_exc. rewrite throw_prefix_exc. rewrite bind_ret_l.
+      gfinal; right. apply paco2_mon with (r := bot2); intros; try contradiction.
+      enough (kcatch e ≈ kcatch e); auto. reflexivity.
+    + rewrite Heq. rewrite try_catch_ev. rewrite throw_prefix_ev. rewrite bind_vis. setoid_rewrite tau_euttge.
+      gstep. constructor. intros. gfinal. left. auto.
+Qed.
+
+Lemma throw_prefix_of_try_catch :  forall E Err R (ttry : itree (exceptE Err +' E) R  ) (kcatch : Err -> itree (exceptE Err +' E) R),
+    throw_prefix (try_catch ttry kcatch) ≈ try_catch (ITree.bind ttry (fun r => Ret (inl r)) ) (fun e => throw_prefix (kcatch e) ).
+Proof.
+  intros. revert ttry. ginit. gcofix CIH.
+  intros. destruct (observe ttry) eqn : Heq; symmetry in Heq; apply simpobs in Heq.
+  - rewrite Heq. rewrite bind_ret_l. repeat rewrite try_catch_ret. rewrite throw_prefix_ret.
+    gfinal; right; pfold; constructor; auto.
+  - rewrite Heq. rewrite bind_tau. repeat rewrite try_catch_tau. rewrite throw_prefix_tau.
+    gstep. constructor. gfinal. left. auto.
+  - destruct e.
+    + destruct e. rewrite Heq. rewrite bind_vis. repeat rewrite try_catch_exc.
+      gfinal; right. apply paco2_mon with (r := bot2); intros; try contradiction.
+      enough (throw_prefix (kcatch e) ≈ throw_prefix (kcatch e)); auto; try reflexivity.
+    + rewrite Heq. rewrite bind_vis. repeat rewrite try_catch_ev. rewrite throw_prefix_ev.
+      setoid_rewrite throw_prefix_tau.
+      repeat setoid_rewrite tau_euttge.
+      gstep. constructor. intros. gfinal. left. auto.
+Qed.
+
+Lemma throw_prefix_bind : forall E Err R S (t : itree (exceptE Err +' E) R ) (k : R -> itree (exceptE Err +' E) S),
+    throw_prefix (ITree.bind t k) ≅ ITree.bind (throw_prefix t) 
+                 (fun r : R + Err => match r with 
+                                  | inl r' => throw_prefix (k r') 
+                                  | inr e => Ret (inr e) end ).
+Proof.
+  intros. revert t. ginit. gcofix CIH.
+  intros. destruct (observe t) eqn : Heq; symmetry in Heq; apply simpobs in Heq.
+  - rewrite Heq. rewrite throw_prefix_ret. repeat rewrite bind_ret_l.
+    gfinal; right. apply paco2_mon with (r := bot2); intros; try contradiction.
+    enough (throw_prefix (k r0) ≅ throw_prefix (k r0)); auto; try reflexivity.
+  - rewrite Heq. rewrite throw_prefix_tau. repeat rewrite bind_tau. rewrite throw_prefix_tau.
+    gstep. constructor. gfinal; eauto.
+  - destruct e.
+    + destruct e. rewrite Heq. rewrite throw_prefix_exc. rewrite bind_vis. rewrite throw_prefix_exc.
+      rewrite bind_ret_l. gstep; constructor; auto.
+    + rewrite Heq. rewrite throw_prefix_ev. repeat rewrite bind_vis. rewrite throw_prefix_ev.
+      gstep. constructor. intros. red. rewrite bind_tau. gstep. constructor.
+      gfinal. eauto.
+Qed.
+
+Lemma throw_prefix_iter : forall E Err A B (body : A -> itree (exceptE Err +' E) (A + B)  ) (init : A),
+    throw_prefix (ITree.iter body init) ≅ ITree.iter (R := B + Err)  (fun a : A => r <- throw_prefix (body a);; 
+                                                             match (r : (A + B) + Err) with
+                                                             | inl (inl a) => Ret (inl a)
+                                                             | inl (inr b) => Ret (inr (inl b))
+                                                             | inr e => Ret (inr (inr e)) end)  init.
+Proof.
+  intros E Err A B. ginit. gcofix CIH. intros.
+  setoid_rewrite unfold_iter_ktree at 2 3.
+  destruct (observe (body init) ) eqn : Heq; symmetry in Heq; apply simpobs in Heq.
+  - rewrite Heq at 1. rewrite bind_ret_l. setoid_rewrite bind_bind. 
+    rewrite Heq at 1. rewrite throw_prefix_ret. rewrite bind_ret_l.
+    destruct r0; rewrite bind_ret_l.
+    + rewrite throw_prefix_tau. gstep. constructor. gfinal. eauto.
+    + rewrite throw_prefix_ret. gfinal. right. pfold; constructor; auto.
+  - rewrite Heq at 1. setoid_rewrite bind_bind. rewrite Heq at 1.
+    rewrite throw_prefix_tau. repeat rewrite bind_tau. rewrite throw_prefix_tau.
+    gstep. constructor. setoid_rewrite throw_prefix_bind at 1. guclo eqit_clo_bind.
+    econstructor; try reflexivity. intros; subst. destruct u2 as [ [ a | b] | e ].
+    + rewrite bind_ret_l. rewrite throw_prefix_tau. gstep. constructor. gfinal. eauto.
+    + rewrite bind_ret_l. rewrite throw_prefix_ret. gstep; constructor; auto.
+    + rewrite bind_ret_l. gstep; constructor; auto.
+  - rewrite Heq at 1. setoid_rewrite bind_bind. rewrite Heq at 1.
+    destruct e.
+    + destruct e. rewrite bind_vis. rewrite throw_prefix_exc.
+      setoid_rewrite throw_prefix_exc. repeat rewrite bind_ret_l.
+      gstep; constructor; auto.
+    + rewrite bind_vis. rewrite throw_prefix_ev. setoid_rewrite throw_prefix_ev.
+      rewrite bind_vis. setoid_rewrite bind_tau. gstep; constructor. intros. red.
+      gstep; constructor. rewrite throw_prefix_bind.
+      guclo eqit_clo_bind. econstructor; try reflexivity. intros; subst.
+      destruct u2 as [ [ a | b] | e' ].
+      * rewrite bind_ret_l. rewrite throw_prefix_tau. gstep; constructor.
+        gfinal. eauto.
+      * rewrite bind_ret_l. rewrite throw_prefix_ret.
+        gstep; constructor; auto.
+      * rewrite bind_ret_l. gstep; constructor; auto.
+Qed.

--- a/theories/Events/StateFacts.v
+++ b/theories/Events/StateFacts.v
@@ -157,7 +157,7 @@ Proof.
 
   rewrite !unfold_interp_state. punfold H0. red in H0.
   induction H0; intros; subst; simpl; pclearbot.
-  - eret. 
+  - eret.
   - etau.
   - ebind. econstructor; [reflexivity|].
     intros; subst.
@@ -255,13 +255,13 @@ Proof.
     pstep.
     constructor.
     cbn.
-    split; auto using (proj1 H2). 
+    split; auto using (proj1 H2).
   - rewrite bind_ret_l, 2 interp_state_ret. pstep. constructor. cbn.
     split; auto using (proj1 H2).
 Qed.
 
 (* SAZ: These are probably too specialized. *)
-Definition state_eq {E S X} 
+Definition state_eq {E S X}
   : (stateT S (itree E) X) -> (stateT S (itree E) X) -> Prop :=
   fun t1 t2 => forall s, eq_itree eq (t1 s) (t2 s).
 

--- a/theories/ITrace/ITraceBind.v
+++ b/theories/ITrace/ITraceBind.v
@@ -1,0 +1,1136 @@
+From Coq Require Import
+     Morphisms
+.
+
+From ITree Require Import
+     Axioms
+     ITree
+     ITreeFacts
+     Eq.Rutt
+     Props.Divergence
+     Props.EuttDiv
+     ITrace.ITraceDefinition
+     ITrace.ITraceFacts
+     ITrace.ITracePrefix
+.
+
+
+From Paco Require Import paco.
+
+Import Monads.
+Import MonadNotation.
+Local Open Scope monad_scope.
+
+(* Contains the proof of peel_lemma which allows us 
+   to decompose a trace of bind t f into a head that refines t and a tail
+   that refines f *)
+
+Lemma classicT : forall (P : Prop), {P} + {~ P}.
+Proof.
+  intros P.
+  assert (H : exists b : bool, if b then P else ~ P).
+  { destruct (classic P); [exists true | exists false]; assumption. }
+  apply constructive_indefinite_description in H.
+  destruct H as [[] ?]; [ left | right ]; assumption.
+Qed.
+
+Definition peel_vis {E R S A B} (e0 : E A) (a : A) (k0 : unit -> itrace E R)
+           (e1 : E B) (k1 : B -> itree E S) 
+           (peel : itrace' E R -> itree' E S -> itrace E S) : itrace E S.
+Proof.
+destruct (classicT (A = B) ).
+- subst. apply (Vis (evans _ e0 a) (fun _ => peel (observe (k0 tt)) (observe (k1 a) ) ) ).
+- apply ITree.spin.
+Defined.
+
+CoFixpoint peel_ {E R S} (ob : itrace' E R) (ot : itree' E S) : itrace E S :=
+  match ob, ot with
+  | TauF b, TauF t => Tau (peel_ (observe b) (observe t))
+  | _, RetF s => Ret s
+  | TauF b, ot => Tau (peel_ (observe b) ot )
+  | ob, TauF t => Tau (peel_ ob (observe t) )
+  | VisF (evempty _ Hempty e) _ , _ => Vis (evempty _ Hempty e) (fun v : void => match v with end)
+  (* The type of this is problematic need some tricky dependently typed programming
+     in order to have this work
+  *)
+
+  | VisF (evans _ e0 a) k0, VisF e1 k1 => peel_vis e0 a k0 e1 k1 peel_
+  | _, _ => ITree.spin 
+  end.
+
+Definition peel {E R S} (b : itrace E R) (t : itree E S) : itrace E S :=
+  peel_ (observe b) (observe t).
+(* here is a sketchy axiom use *)
+Definition peel_cont_vis {E R S A B} (e0 : E A) (a : A) (k0 : unit -> itrace E R)
+           (e1 : E B) (k1 : B -> itree E S) 
+           (peel : itrace' E R -> itree' E S -> itrace E R) : itrace E R.
+Proof.
+destruct (classicT (A = B) ).
+- subst. apply (Tau (peel (observe (k0 tt)) (observe (k1 a) ) ) ).
+- apply ITree.spin.
+Defined.
+
+(*Actually I may be able to remove this ugly bs. I think I really only use peel*)
+CoFixpoint peel_cont_ {E R S} (ob : itrace' E R) (ot : itree' E S) : itrace E R :=
+  match ot with
+  | RetF _ => go ob
+  | TauF t => match ob with 
+                   | TauF b => Tau (peel_cont_ (observe b) (observe t))
+                   | ob => Tau (peel_cont_ ob (observe t)  )
+                   end
+  | VisF e1 k1 => match ob with 
+                       | TauF b => Tau (peel_cont_ (observe b) ot)
+                       | VisF (evempty _ Hempty e) _ => 
+                         ITree.spin
+                       | VisF (evans _ e0 a) k0 => peel_cont_vis e0 a k0 e1 k1 peel_cont_
+                       | _ => ITree.spin
+                       end
+  end.
+
+Definition peel_cont {E R S} (b : itrace E R) (t : itree E S) : S -> itrace E R :=
+  fun s => peel_cont_ (observe b) (observe t).
+
+
+Lemma refine_ret_vis_contra : forall (E: Type -> Type) (R A: Type)
+                     (r : R) (e : E A) (k : A -> itree E R),
+    ~ (Ret r ⊑ Vis e k).
+Proof.
+  intros. intro Hcontra. pinversion Hcontra.
+Qed.
+
+(* maybe a better way of doing it is to use strong LEM to see if X = A in the vis case
+   then I can remove that if statement given
+
+ *)
+
+Lemma peel_t_ret : forall E R S (b : itrace E S) (t : itree E R) r, t ≅ Ret r -> (peel b t ≅ Ret r).
+Proof.
+  intros.  unfold peel.
+  pinversion H; subst; try inv CHECK.
+  destruct (observe b); cbn; auto. 
+  - pfold. red. cbn. constructor. auto.
+  - pfold. red. cbn. constructor; auto.
+  - pfold. red. cbn. simpl. destruct e.
+    + cbn. constructor. auto.
+    + cbn. constructor. auto.
+Qed.
+
+
+(*doing these proofs, may require some techniques you don't really know*)
+
+Lemma peel_refine_t : forall (E : Type -> Type) (R S : Type)
+                  (b : itrace E S) (t : itree E R) (f : R -> itree E S)
+     (Hrutt : b ⊑ ITree.bind t f),
+    peel b t ⊑ t.
+Proof.
+  intros E R S b t f. generalize dependent b. generalize dependent t.
+  pcofix CIH. intros.
+  punfold Hrutt. red in Hrutt. cbn in Hrutt. pfold. red.
+  unfold peel.
+  destruct (observe t) eqn : Heq.
+  - destruct (observe b); cbn; try (constructor; auto).
+    destruct e; cbn; constructor; auto.
+  - dependent induction Hrutt.
+    + exfalso. symmetry in Heq. apply simpobs in Heq. apply simpobs in x.
+      rewrite Heq in x. rewrite bind_tau in x. pinversion x.
+      inv CHECK.
+    + rewrite <- x0. cbn. constructor. right. eapply CIH.
+      pclearbot. symmetry in Heq. apply simpobs in x0.
+      apply simpobs in x. apply simpobs in Heq.
+      apply eq_sub_eutt in x0. apply eq_sub_eutt in Heq.
+      rewrite tau_eutt in Heq. rewrite tau_eutt in x0.
+      rewrite <- Heq. rewrite x. rewrite tau_eutt. auto.
+    + rewrite <- x. cbn. constructor. right. eapply CIH.
+      clear IHHrutt. symmetry in Heq. apply simpobs in Heq.
+      apply eq_sub_eutt in Heq. rewrite tau_eutt in Heq.
+      rewrite <- Heq. pfold. auto.
+    + cbn. destruct (observe b) eqn : Heq'.
+      * cbn. rewrite <- Heq'. constructor. right. eapply CIH. 
+        symmetry in Heq'.
+        apply simpobs in Heq'. rewrite Heq'.
+        symmetry in Heq. apply simpobs in Heq.
+        apply eq_sub_eutt in Heq. rewrite tau_eutt in Heq.
+        rewrite <- Heq. apply simpobs in x. rewrite x.
+        rewrite tau_eutt. pfold. auto.
+      * cbn. clear IHHrutt.
+        constructor. right. eapply CIH. 
+        symmetry in Heq. apply simpobs in Heq.
+        apply eq_sub_eutt in Heq. rewrite tau_eutt in Heq.
+        rewrite <- Heq.
+        apply simpobs in x. apply eq_sub_eutt in x.
+        rewrite tau_eutt in x. rewrite x.
+        enough (Tau t1 ⊑ t2). 
+        { rewrite tau_eutt in H. auto. }
+        pfold. auto.
+      * destruct e; cbn.
+        ++ constructor. right. rewrite <- Heq'. clear IHHrutt.
+           eapply CIH. symmetry in Heq.
+           apply simpobs in Heq. apply eq_sub_eutt in Heq. 
+           rewrite tau_eutt in Heq. apply simpobs in x.
+           apply eq_sub_eutt in x. rewrite tau_eutt in x.
+           rewrite <- Heq. rewrite x. pfold. red.
+           rewrite Heq'. auto.
+        ++ constructor. right. rewrite <- Heq'. clear IHHrutt.
+           eapply CIH. symmetry in Heq.
+           apply simpobs in Heq. apply eq_sub_eutt in Heq. 
+           rewrite tau_eutt in Heq. apply simpobs in x.
+           apply eq_sub_eutt in x. rewrite tau_eutt in x.
+           rewrite <- Heq. rewrite x. pfold. red.
+           rewrite Heq'. auto.
+    + exfalso. symmetry in Heq. apply simpobs in Heq.
+      apply simpobs in x.
+      rewrite Heq in x. rewrite bind_tau in x. pinversion x.
+      inv CHECK.
+  - dependent induction Hrutt.
+    + exfalso. symmetry in Heq. apply simpobs in Heq. apply simpobs in x.
+      rewrite Heq in x. rewrite bind_vis in x.
+      pinversion x.
+    + exfalso. symmetry in Heq. apply simpobs in Heq. apply simpobs in x.
+      rewrite Heq in x. rewrite bind_vis in x.
+      pinversion x; inv CHECK.
+    + rewrite <- x. cbn. constructor. eapply IHHrutt; eauto.
+    + exfalso. symmetry in Heq. apply simpobs in x. apply simpobs in Heq.
+      rewrite Heq in x. rewrite bind_vis in x.
+      pinversion x; inv CHECK.
+    + rewrite <- x0.
+      symmetry in Heq. apply simpobs in Heq. apply simpobs in x.
+      rewrite Heq in x. rewrite bind_vis in x. pinversion x.
+      ddestruction. inversion H; ddestruction.
+      * unfold observe. cbn. unfold peel_vis.
+        destruct (classicT (B = B) ); try contradiction.
+        unfold eq_rect_r, eq_rect. 
+        remember (eq_sym _) as He. clear HeqHe.
+        dependent destruction He. cbn. constructor; eauto.
+        intros. inversion H1. ddestruction.
+        apply H0 in H1. pclearbot. unfold id. right. eapply CIH.
+        red in x1. cbn in x1. inversion x1. ddestruction.
+        red in H0. specialize (H0 tt a (rar _ _ _)).
+        specialize (REL0 a). pclearbot.
+        rewrite REL0. apply H0.
+      * cbn. constructor; eauto. intros. contradiction.
+Qed.
+
+Lemma not_spin_eutt_ret : forall E R (r : R), ~ (@ITree.spin E R ≈ Ret r). 
+Proof.
+  intros. intros Hcontra. specialize (@spin_diverge E R) as Hdiv.
+  rewrite Hcontra in Hdiv. pinversion Hdiv.
+Qed.
+
+
+Lemma proper_peel_eutt_l : forall (E : Type -> Type) (R S : Type) 
+                             (b b': itrace E R) (t : itree E S),
+    (b ≈ b') -> (peel b t ≈ peel b' t).
+Proof.
+  intros E R S. pcofix CIH. intros. unfold peel.
+  destruct (observe t).
+  - pfold. red. destruct (observe b); destruct (observe b'); cbn;
+                  try (destruct e); try (destruct e0); cbn;
+                try (constructor; auto; fail).
+  - pfold. punfold H0. red in H0. dependent induction H0.
+    + rewrite <- x0. rewrite <- x. red. cbn. constructor.
+      right. rewrite x0. eapply CIH. reflexivity.
+    + rewrite <- x0. rewrite <- x. red. cbn. constructor. right.
+      pclearbot. eapply CIH. auto.
+    + rewrite <- x0. rewrite <- x. destruct e; cbn.
+      * red. cbn. constructor. right. rewrite x. rewrite x0. 
+        eapply CIH. pfold. red. rewrite <- x. rewrite <- x0.
+        constructor. auto.
+      * red. cbn. constructor. right. rewrite x0. rewrite x.
+        eapply CIH. pfold. red. rewrite <- x0. rewrite <- x.
+        constructor. auto.
+    + destruct (observe b); destruct (observe b'); dependent destruction x.
+      * red. cbn. constructor. right. remember (@go (EvAns E) _ (RetF r0)) as t1. 
+        assert (RetF r0 = observe t1). 
+        { rewrite Heqt1. auto. }
+        rewrite H. eapply CIH. rewrite Heqt1. pfold. auto.
+      * red. cbn. constructor. right. eapply CIH. 
+        enough (t2 ≈ Tau t3).
+        { rewrite tau_eutt in H. auto. }
+         pfold. auto.
+      * red. destruct e; cbn.
+        ++ constructor. right.
+           remember (@go (EvAns E) _ (VisF (evans A ev ans) k )  ) as t1.
+           assert (VisF (evans A ev ans) k  = observe t1).
+           { rewrite Heqt1. auto. }
+           rewrite H. eapply CIH. subst. pfold. auto.
+        ++ constructor. right.
+           remember (go (VisF (evempty A Hempty ev) k )  ) as t1.
+           assert (VisF (evempty A Hempty ev) k = observe t1 ).
+           { subst. auto. }
+           rewrite H. eapply CIH. subst. pfold. auto.
+    + destruct (observe b); destruct (observe b'); dependent destruction x.
+      * red. cbn. constructor. right. remember (@go (EvAns E) _ (RetF r0)) as t2. 
+        assert (RetF r0 = observe t2). 
+        { subst. auto. }
+        rewrite H. eapply CIH. rewrite Heqt2. pfold. auto.
+      * red. cbn. constructor. right. eapply CIH.
+        enough (Tau t1 ≈ t3).
+        { rewrite tau_eutt in H. auto. }
+        pfold. auto.
+      * red. destruct e; cbn.
+        ++ constructor. right.
+           remember (@go (EvAns E) _ (VisF (evans A ev ans) k )  ) as t2.
+           assert (VisF (evans A ev ans) k  = observe t2).
+           { subst. auto. }
+           rewrite H. eapply CIH. subst. pfold. auto.
+        ++ constructor. right.
+           remember (go (VisF (evempty A Hempty ev) k )  ) as t2.
+           assert (VisF (evempty A Hempty ev) k = observe t2 ).
+           { subst. auto. }
+           rewrite H. eapply CIH. subst. pfold. auto.
+  - pfold. punfold H0. red in H0. dependent induction H0.
+    + rewrite <- x0. rewrite <- x. red. cbn. constructor.
+      left. eapply paco2_mon with (r := bot2); intuition.
+      enough (@ITree.spin (EvAns E) S  ≈ ITree.spin); auto.
+      reflexivity.
+    + rewrite <- x. rewrite <- x0. red. cbn. constructor. right.
+      remember (go (VisF e k) ) as t0.
+      assert (VisF e k = observe t0).
+      { subst. auto. }
+      rewrite H. eapply CIH. pclearbot. auto.
+    + rewrite <- x0. rewrite <- x. red. destruct e; cbn.
+      * unfold observe. cbn. unfold peel_vis.
+        destruct (classicT (A = X) ).
+        ++ unfold eq_rect_r, eq_rect. remember (eq_sym e) as He.
+           dependent destruction He. cbn. constructor. intros.
+           right. eapply CIH. pclearbot. auto.
+        ++ cbn. constructor. left. eapply paco2_mon with (r := bot2); intuition.
+           enough (@ITree.spin (EvAns E) S ≈ ITree.spin ); auto.
+           reflexivity.
+      * constructor. left. contradiction.
+   + rewrite <- x. red. destruct (observe b') eqn : Heq.
+     * rewrite <- Heq. cbn. constructor; auto. eapply IHeqitF; eauto. rewrite Heq. auto.
+     * cbn. constructor. right.
+       remember (go (VisF e k) ) as t2.
+       assert (VisF e k = observe t2).
+       { subst. auto. }
+       rewrite H. eapply CIH.
+       enough (t1 ≈ Tau t0).
+       { rewrite tau_eutt in H1. auto. }
+       pfold; auto.
+     * cbn. constructor; eauto. rewrite <- Heq. eapply IHeqitF; eauto.
+       rewrite Heq. auto.
+  + rewrite <- x. red. destruct (observe b) eqn : Heq.
+     * rewrite <- Heq. cbn. constructor; auto. eapply IHeqitF; eauto. rewrite Heq. auto.
+     * cbn. constructor. right.
+       remember (go (VisF e k) ) as t1.
+       assert (VisF e k = observe t1).
+       { subst. auto. }
+       rewrite H. eapply CIH.
+       enough (Tau t0 ≈ t2).
+       { rewrite tau_eutt in H1. auto. }
+       pfold; auto.
+     * cbn. constructor; eauto. rewrite <- Heq. eapply IHeqitF; eauto.
+       rewrite Heq. auto.
+Qed.
+
+
+
+Lemma proper_peel_eutt_r : forall (E : Type -> Type) (R S : Type) 
+                             (b: itrace E R) (t t': itree E S),
+    (t ≈ t') -> (peel b t ≈ peel b t').
+Proof.
+  intros E R S. pcofix CIH. intros.
+  pfold. red. unfold peel. destruct (observe b) eqn : Heqb.
+  - punfold H0. red in H0. dependent induction H0.
+    + rewrite <- x. rewrite <- x0.  cbn. constructor. auto.
+    + rewrite <- x. rewrite <- x0. cbn. constructor. right. rewrite <- Heqb.
+      eapply CIH. pclearbot. auto.
+    + rewrite <- x0. rewrite <- x. cbn. constructor.
+      left. apply paco2_eqit_refl.
+    + rewrite <- x.  cbn. constructor; auto. eapply IHeqitF; eauto.
+    + rewrite <- x. cbn. constructor; auto. eapply IHeqitF; eauto.
+  - punfold H0. red in H0. dependent induction H0.
+    + rewrite <- x. rewrite <- x0. cbn. constructor. auto.
+    + rewrite <- x0. rewrite <- x. cbn. constructor. right.
+      pclearbot. eapply CIH; auto.
+    + rewrite <- x0. rewrite <- x. cbn. constructor. right.
+      rewrite x0. rewrite x. eapply CIH.
+      pfold. red. rewrite <- x0. rewrite <- x.
+      constructor. auto.
+    + rewrite <- x. destruct (observe t') eqn : Heqt'.
+      * cbn.  constructor; auto. clear IHeqitF.
+        dependent induction H0.
+        ++ rewrite <- x. destruct (observe t0); cbn; try (constructor; auto; fail).
+           destruct e; cbn; constructor; auto.
+        ++ rewrite <- x. cbn. destruct (observe t2) eqn : Heqt2; cbn.
+           ** constructor; eauto. rewrite <- Heqt2.  eapply IHeqitF; eauto.
+           ** constructor; auto. eapply IHeqitF; eauto.
+           ** destruct e; cbn;
+              try (constructor; auto; rewrite <- Heqt2; eapply IHeqitF; eauto).
+      * cbn. constructor. right. eapply CIH; eauto.
+        enough (t1 ≈ Tau t2).
+        { rewrite tau_eutt in H. auto. }
+        pfold. auto.
+      * cbn. constructor. rewrite <- Heqt'. right. eapply CIH.
+        pfold. red. rewrite Heqt'. auto.
+    + rewrite <- x. destruct (observe t).
+      * cbn. constructor; auto. clear IHeqitF.
+        dependent induction H0.
+        ++ rewrite <- x. destruct (observe t0); try (destruct e); cbn; constructor; auto.
+        ++ rewrite <- x. destruct (observe t1) eqn : Heqt1; cbn.
+           ** constructor; auto. rewrite <- Heqt1. eapply IHeqitF; eauto.
+           ** constructor; auto. eapply IHeqitF; eauto.
+           ** destruct e; cbn; try (constructor; auto; rewrite <- Heqt1; eapply IHeqitF; eauto).
+      * cbn. constructor. right. eapply CIH; eauto.
+        rewrite <- tau_eutt at 1. pfold. auto.
+      * cbn. constructor. right. remember ((Vis e k) ) as t1.
+        assert (VisF e k = observe t1).
+        { subst. auto. }
+        rewrite H. eapply CIH. subst. pfold. auto.
+  - punfold H0. red in H0. dependent induction H0.
+    + rewrite <- x. rewrite <- x0. destruct e; cbn; constructor; auto.
+    + rewrite <- x. rewrite <- x0. destruct e; cbn; constructor; right; rewrite <- Heqb;
+      eapply CIH; pclearbot; eauto.
+    + rewrite <- x. rewrite <- x0. destruct e0; cbn.
+      * unfold observe. cbn. unfold peel_vis.
+        destruct (classicT (A = u) ).
+        ++ unfold eq_rect_r, eq_rect. remember (eq_sym e0) as He.
+           dependent destruction He. cbn. constructor. intros.
+           right. eapply CIH. pclearbot. auto.
+        ++ cbn. constructor. left. apply paco2_eqit_refl.
+      * constructor. intuition.
+    + rewrite <- x. destruct (observe t'); destruct e; cbn.
+      * constructor; auto. clear IHeqitF. dependent induction H0.
+        ++ rewrite <- x. cbn. constructor; auto.
+        ++ rewrite <- x. cbn. constructor; eauto.
+      * constructor; auto. clear IHeqitF. dependent induction H0.
+        ++ rewrite <- x. cbn. constructor; auto.
+        ++ rewrite <- x. cbn. constructor; eauto.
+      * constructor. rewrite <- Heqb. right. eapply CIH.
+        setoid_rewrite <- tau_eutt at 2. pfold. auto.
+      * rewrite <- Heqb. constructor. right. eapply CIH.
+        setoid_rewrite <- tau_eutt at 2. pfold. auto.
+      * constructor; auto. clear IHeqitF. 
+        dependent induction H0.
+        ++ rewrite <- x. unfold observe. cbn.
+           unfold peel_vis. destruct (classicT (A = X0) ).
+           ** unfold eq_rect_r, eq_rect. 
+              remember (eq_sym e) as He. dependent destruction He.
+              cbn. constructor. intros. right. pclearbot. eapply CIH; eauto.
+           ** cbn. constructor. left. apply paco2_eqit_refl.
+        ++ rewrite <- x. cbn. constructor; auto; eapply IHeqitF; eauto.
+      * constructor; auto. clear IHeqitF.
+        dependent induction H0.
+        ++ rewrite <- x. cbn. constructor. intuition.
+        ++ rewrite <- x. cbn. constructor; auto; eapply IHeqitF; eauto.
+   + rewrite <- x. cbn. destruct (observe t) eqn : Heqt; destruct e; cbn.
+     * constructor; auto. clear IHeqitF. dependent induction H0.
+       ++ rewrite <- x. cbn. constructor; auto.
+       ++ rewrite <- x. cbn. constructor; eauto.
+     * constructor; auto. clear IHeqitF. dependent induction H0.
+       ++ rewrite <- x. cbn. constructor; auto.
+       ++ rewrite <- x. cbn. constructor; eauto.
+     * constructor. right. rewrite <- Heqb. eapply CIH; eauto. rewrite <- tau_eutt.
+       pfold. auto.
+     * constructor. rewrite <- Heqb. right. eapply CIH; eauto. rewrite <- tau_eutt.
+       pfold. auto.
+     * constructor; auto. clear IHeqitF. dependent induction H0.
+       ++ rewrite <- x. unfold observe. cbn.
+          unfold peel_vis.
+          destruct (classicT (A = X0) ).
+          ** unfold eq_rect_r, eq_rect.
+             remember (eq_sym e) as He. dependent destruction He.
+             cbn. constructor. intros. right. pclearbot. eapply CIH; apply REL.
+          ** cbn. constructor. left. apply paco2_eqit_refl.
+       ++ rewrite <- x. cbn. constructor; eauto.
+     * constructor; auto. clear IHeqitF. dependent induction H0.
+       ++ rewrite <- x. cbn. constructor. intuition.
+       ++ rewrite <- x. cbn. constructor; eauto.
+Qed.
+
+Instance proper_eutt_peel {E R S} : Proper (eutt eq ==> eutt eq ==> eutt eq) (@peel E R S).
+Proof.
+  intros ? ? ? ? ? ?. rewrite proper_peel_eutt_l with (t := x0); eauto. 
+  eapply proper_peel_eutt_r; eauto.
+Qed.
+
+Lemma not_peel_vis_ret: forall (R : Type) (E : Type -> Type) (S X : Type) (e : E X) (k : X -> itree E R) 
+                          (r : R) (t1 : itree (EvAns E) S),
+    ~ (peel t1 (Vis e k) ≈ Ret r).
+Proof.
+  intros R E S X e k r t1 Heutt.
+  punfold Heutt. unfold peel in *. red in Heutt. cbn in *.
+  dependent induction  Heutt.
+  - destruct (observe t1); cbn in x; try discriminate.
+    destruct e0; cbn in *; try discriminate.
+    unfold observe in x. cbn in x. unfold peel_vis in x.
+    destruct (classicT (A = X)); try discriminate.
+    unfold eq_rect_r, eq_rect in x. remember (eq_sym e0) as He.
+    dependent destruction He. discriminate.
+  - destruct (observe t1); cbn in x; try discriminate.
+    + injection x as Hspin. rewrite Hspin in Heutt. 
+      eapply not_spin_eutt_ret. pfold. eauto.
+    + injection x as Ht0. eapply IHHeutt; eauto. rewrite Ht0. reflexivity.
+    + destruct e0; cbn in *; try discriminate.
+      unfold observe in x. cbn in x. unfold peel_vis in *.
+      destruct (classicT (A = X) ).
+      * unfold eq_rect_r, eq_rect in x. remember (eq_sym e0) as He.
+        dependent destruction He. discriminate.
+      * cbn in x. injection x as Hspin. rewrite Hspin in Heutt.
+        eapply not_spin_eutt_ret. pfold. eauto.
+Qed.
+
+
+Lemma peel_ret_inv:
+        forall (R : Type) (r : R) (E : Type -> Type) (S : Type) (b : itrace E S) (t : itree E R),
+          (peel b t ≈ Ret r) -> (t ≈ Ret r).
+Proof.
+  intros R r E S b t H. unfold peel in H.
+  punfold H. red in H. cbn in H. pfold. red. cbn.
+  dependent induction H.
+  - unfold peel in x. destruct (observe b); destruct (observe t); cbn in *;
+                        dependent destruction x; try (constructor; auto; fail).
+    + destruct e; dependent destruction x; try (constructor; auto).
+    + destruct e; dependent destruction x.
+    + destruct e; dependent destruction x.
+      unfold observe in x. cbn in x. unfold peel_vis in x.
+      destruct (classicT (A = X0) ) eqn : Heq.
+      * unfold eq_rect_r, eq_rect in x. subst. remember (eq_sym eq_refl) as He.
+        dependent destruction He. cbn in x0. discriminate.
+      * discriminate.
+  - destruct (observe b); destruct (observe t); cbn in x; dependent destruction x.
+    + constructor; auto. eapply IHeqitF with (b := Ret r0); eauto.
+    + exfalso. eapply not_spin_eutt_ret. pfold. eauto.
+    + constructor; auto. eapply IHeqitF; eauto.
+    + exfalso. destruct (observe t0).  
+      * cbn in H. eapply not_spin_eutt_ret. 
+        inv  H. pfold. eauto.
+      * cbn in H. inv H. eapply not_peel_vis_ret.
+        pfold. eauto.
+      * destruct e0.
+        ++ clear IHeqitF. unfold observe in H. cbn in H. unfold peel_vis in H.
+           destruct (classicT (A = X) ).
+           ** unfold eq_rect_r, eq_rect in H. remember (eq_sym e0) as He.
+              dependent destruction He. inv H.
+           ** eapply not_spin_eutt_ret. pfold. eauto.
+        ++ cbn in H. inv H.
+    + destruct e; cbn in x; try discriminate.
+    + constructor; auto. eapply IHeqitF with (b := Vis e k); eauto. cbn.
+      destruct e; cbn in x; dependent destruction x; auto.
+    + destruct e; cbn in x; try discriminate.
+      unfold observe in x. cbn in x. unfold peel_vis in x.
+      destruct (classicT (A = X0) ).
+      * unfold eq_rect_r, eq_rect in x. remember (eq_sym e) as He.
+        dependent destruction He. discriminate.
+      * injection x as Hspin. cbn in Hspin. exfalso.
+        assert (t1 ≈ Ret r).
+        { pfold. auto. } 
+        rewrite Hspin in H0. eapply not_spin_eutt_ret; eauto.
+Qed.
+
+Lemma eqitF_r_refl: forall (E : Type -> Type) (R: Type) r
+    (ot: itree' E R),
+    eqitF eq true true id (upaco2 (eqit_ eq true true id) r)
+          ot ot.
+Proof.
+  intros E R r ot.
+  destruct ot; constructor; auto.
+  - left. eapply paco2_mon with (r := bot2); intuition. 
+    apply Equivalence_eutt. apply eq_equivalence.
+  - left. eapply paco2_mon with (r := bot2); intuition.
+    apply Equivalence_eutt. apply eq_equivalence.
+Qed.
+
+Lemma eqitF_mon:
+  forall (E : Type -> Type) (R : Type) (r : itree (EvAns E) R -> itree (EvAns E) R -> Prop)
+    (t1 : itree' (EvAns E) R) (t0 : itree' (EvAns E) R),
+    eqitF eq true true id (upaco2 (eqit_ eq true true id) bot2) t1 t0 ->
+    eqitF eq true true id (upaco2 (eqit_ eq true true id) r) t1 t0.
+Proof.
+  intros E R r t1 t0' REL.
+  induction REL; constructor; eauto.
+  - pclearbot. left. eapply paco2_mon; eauto; intuition.
+  - pclearbot. intros. left. eapply paco2_mon; eauto; intuition.
+Qed.
+
+Lemma eqitF_observe_peel_cont_vis:
+  forall (E : Type -> Type) (R S A : Type) (ev : E A) (ans : A)
+    (k1 k2 : unit -> itree (EvAns E) R),
+    (forall v : unit, id (upaco2 (eqit_ eq true true id) bot2) (k1 v) (k2 v)) ->
+    forall r : itree (EvAns E) R -> itree (EvAns E) R -> Prop,
+      (forall (b b' : itrace E R) (t : itree E S),
+          (b ≈ b') ->
+          r (peel_cont_ (observe b) (observe t)) (peel_cont_ (observe b') (observe t))) ->
+      forall (X : Type) (e : E X) (k : X -> itree E S),
+        eqitF eq true true id (upaco2 (eqit_ eq true true id) r)
+              (observe (peel_cont_ (VisF (evans A ev ans) k1) (VisF e k)))
+              (observe (peel_cont_ (VisF (evans A ev ans) k2) (VisF e k))).
+Proof.
+  intros E R S A ev ans k1 k2 REL r CIH X e k.
+  unfold observe. cbn. unfold peel_cont_vis.
+  destruct (classicT (A = X) ).
+  - unfold eq_rect_r, eq_rect. remember (eq_sym e0) as He.
+    dependent destruction He. cbn. constructor.
+    intros. right. pclearbot. eapply CIH. auto.
+  - cbn. apply eqitF_r_refl.
+Qed.
+
+
+Lemma proper_peel_cont_eutt_l : forall (E : Type -> Type) (R S : Type) 
+                             (b b': itrace E R) (t : itree E S) (s : S),
+    (b ≈ b') -> (peel_cont b t s ≈ peel_cont b' t s).
+Proof.
+  intros E R S. unfold peel_cont. intros b b' t _.
+  revert b b' t. pcofix CIH. intros. pfold. punfold H0. red in H0.
+  destruct (observe t) eqn : Heqt.
+  - red. destruct (observe b') eqn : Hb; destruct (observe b) eqn : Hb'; inversion H0; cbn;
+    try (constructor; auto; fail);
+    try (constructor; auto; eapply eqitF_mon; eauto; fail);
+    try (destruct e; cbn);
+    try (constructor; auto; eapply eqitF_mon; eauto; fail).
+    + constructor. pclearbot. left. eapply paco2_mon; eauto; intuition.
+    + subst. ddestruction. subst. cbn. constructor. intros. left. inv H0.
+      ddestruction. subst. pclearbot. eapply paco2_mon; eauto; intuition.
+    + ddestruction. subst. ddestruction. subst. cbn. constructor; auto. intuition.
+      (*looks like I didn't actually need to induct here ... *)
+  - dependent induction H0; try clear IHeqitF.
+    + rewrite <- x0. rewrite <- x. red. cbn. constructor. right.
+      rewrite x. eapply CIH; eauto. pfold. red. rewrite <- x. constructor; auto.
+    + rewrite <- x0. rewrite <- x. red. cbn. constructor. right.
+      eapply CIH. pclearbot. auto.
+    + rewrite <- x0. rewrite <- x. red. destruct e; cbn; constructor; right.
+      * rewrite x. rewrite x0. eapply CIH; eauto. pfold. red.
+        rewrite <- x0. rewrite <- x. constructor. auto.
+      * rewrite x. rewrite x0. eapply CIH; eauto. pfold. red.
+        rewrite <- x0. rewrite <- x. constructor. auto.
+    + rewrite <- x. red. cbn.
+      destruct (observe b') eqn : Heqb'; cbn.
+      * constructor. right. rewrite <- Heqb'. eapply CIH.
+        symmetry in Heqb'. apply simpobs in Heqb'. rewrite Heqb'.
+        pfold. auto.
+      * constructor. right. eapply CIH. setoid_rewrite <- tau_eutt at 2.
+        pfold. auto.
+      * constructor. right. rewrite <- Heqb'. eapply CIH.
+        symmetry in Heqb'. apply simpobs in Heqb'. rewrite Heqb'. pfold. auto.
+    + rewrite <- x. red. cbn. destruct (observe b) eqn : Heqb; cbn.
+      * constructor; auto. right. rewrite <- Heqb. eapply CIH.
+        pfold. red. rewrite Heqb. auto.
+      * constructor. right. eapply CIH. rewrite <- tau_eutt at 1. pfold. auto.
+      * constructor. right. rewrite <- Heqb. eapply CIH. pfold.
+        red. rewrite Heqb. auto.
+  - red. dependent induction H0; cbn.
+    +  rewrite <- x0. rewrite <- x. cbn. constructor. left. pfold. apply eqitF_r_refl.
+    + rewrite <- x0. rewrite <- x. cbn. constructor. right. rewrite <- Heqt. eapply CIH.
+      pclearbot. auto.
+    + rewrite <- x. rewrite <- x0. destruct e; cbn; try (apply eqitF_observe_peel_cont_vis; auto).
+      apply eqitF_r_refl.
+    + rewrite <- x. cbn. constructor; eauto.
+    + rewrite <- x. cbn. constructor; eauto.
+Qed.
+
+Lemma peel_cont_ret_inv : forall E R S (b : itrace E R) (t : itree E S) (s : S),
+    t ≈ Ret s -> (peel_cont_ (observe b) (observe t) ≈ b).
+Proof.
+  intros E R S. pcofix CIH. intros. punfold H0. red in H0. cbn in H0. dependent induction H0; subst.
+  - rewrite <- x. cbn. pfold. red. cbn. apply eqitF_r_refl.
+  - rewrite <- x. destruct (observe b) eqn : Hb.
+    + pfold. red. cbn. constructor; auto. 
+      
+      specialize (IHeqitF r CIH (Ret r0) t1 s ); auto.
+      assert (S = S). auto. apply IHeqitF in H; auto. rewrite Hb.
+      punfold H.
+    + pfold. red. rewrite Hb. cbn.   constructor. right. eapply CIH with (s := s).
+      pfold. auto.
+    + pfold. red. rewrite Hb. cbn. rewrite <- Hb. constructor; auto.
+      specialize (IHeqitF r CIH b t1 s ); auto.
+      assert (S = S). auto. apply IHeqitF in H; auto. punfold H.
+Qed.
+
+Lemma proper_peel_cont_eutt_r : forall (E : Type -> Type) (R S : Type) 
+                             (b: itrace E R) (t t': itree E S) (s : S),
+    (t ≈ t') -> (peel_cont b t s ≈ peel_cont b t' s).
+Proof. 
+  intros E R S. unfold peel_cont. intros b t t' _.
+  revert b t t'. pcofix CIH. intros. pfold. punfold H0. red in H0. dependent induction H0.
+  - rewrite <- x. rewrite <- x0. red. cbn. apply eqitF_r_refl.
+  - rewrite <- x. rewrite <- x0. red. destruct (observe b) eqn : Heqb; cbn.
+    + constructor. right. rewrite <- Heqb. eapply CIH. pclearbot. auto.
+    + constructor. right. eapply CIH. pclearbot. auto.
+    + constructor. right. rewrite <- Heqb. eapply CIH; pclearbot; auto.
+  - rewrite <- x. rewrite <- x0. pclearbot. destruct (observe b) eqn : Heqb; red; cbn.
+    + apply eqitF_r_refl.
+    + constructor. rewrite x. rewrite x0. right. eapply CIH.
+      pfold. red. rewrite <- x. rewrite <- x0. constructor. intros.
+      left. auto.
+    + destruct e0; cbn.
+      * unfold observe. cbn. unfold peel_cont_vis. 
+        destruct (classicT (A = u) ); try apply eqitF_r_refl.
+        unfold eq_rect_r, eq_rect. remember (eq_sym e0) as He.
+        dependent destruction He. cbn. constructor. intros. right.
+        eapply CIH. auto.
+      * apply eqitF_r_refl.
+  - rewrite <- x. destruct (observe b) eqn : Heqb; red; cbn.
+    + constructor; eauto. rewrite <- Heqb. eapply IHeqitF; eauto.
+    + cbn. destruct (observe t') eqn : Heqt'; cbn.
+      * constructor. left. eapply paco2_mon with (r := bot2); intuition.
+        eapply peel_cont_ret_inv with (s := r0). pfold. auto.
+      * constructor. right. eapply CIH; eauto. setoid_rewrite <- tau_eutt at 2.
+        pfold. auto.
+      * constructor. right. rewrite <- Heqt'. eapply CIH.
+        pfold. red. rewrite Heqt'. auto.
+    + rewrite <- Heqb. constructor; auto. eapply IHeqitF; eauto.
+ - rewrite <- x. destruct (observe b) eqn : Heqb; red; cbn.
+   + constructor; auto. rewrite <- Heqb. eapply IHeqitF; eauto.
+   + destruct (observe t) eqn : Heqt; cbn.
+     * constructor. left. eapply paco2_mon with (r := bot2); intuition. 
+       enough (t0 ≈ peel_cont_ (observe t0) (observe t2) ). auto.
+       symmetry.
+       eapply peel_cont_ret_inv with (s := r0). symmetry. pfold. auto.
+     * constructor. right. eapply CIH. rewrite <- tau_eutt at 1. pfold. auto.
+     * constructor. right. rewrite <- Heqt. eapply CIH.
+       pfold. red. rewrite Heqt. auto.
+   + rewrite <- Heqb. constructor; auto. eapply IHeqitF; eauto.
+Qed.
+
+Instance proper_eutt_peel_cont {E R S} : Proper (eutt eq ==> eutt eq ==> eq ==> eutt eq) (@peel_cont E R S).
+Proof.
+  repeat intro. subst. rewrite proper_peel_cont_eutt_l; eauto.
+  rewrite proper_peel_cont_eutt_r; eauto. reflexivity.
+Qed.
+(*
+Lemma peel_cont_bind : forall (E : Type -> Type) (R S : Type) (b : itrace E S) (t : itree E R) (f : R -> itree E S),
+    b ⊑ ITree.bind t f -> (ITree.bind (peel b t) (peel_cont b t) ≈ b).
+Proof.
+  intros E R S. pcofix CIH. intros. punfold H0. pfold. red. red in H0. cbn in *.
+  unfold ITree.bind in H0. unfold ITree.bind. cbn in *.
+  unfold observe at 1. cbn.
+*)
+(*may need an analgous lemma for *)
+Lemma vis_refine_peel : forall (E : Type -> Type) (R S A : Type) (e : E A) (a : A)
+                   (k1: unit -> itrace E S) (k2 : A -> itree E R) (k3 : unit -> itrace E R),
+        (peel (Vis (evans _ e a) k1) (Vis e k2) ≈ Vis (evans _ e a) k3) -> 
+        (k3 tt ≈ peel (k1 tt) (k2 a)).
+Proof.
+  intros E R S A. (* pcofix CIH. *) intros e a k1 k2 k3 Hpeel.
+  unfold peel in *. cbn in *. punfold Hpeel.
+  red in Hpeel. cbn in *. cbn in Hpeel.
+  unfold observe in Hpeel. cbn in Hpeel.
+  unfold peel_vis in Hpeel.
+  assert (A = A). auto.
+  destruct (classicT (A = A) ); try contradiction. unfold eq_rect_r, eq_rect in Hpeel.
+  remember (eq_sym e0) as He. dependent destruction He. cbn in *.
+  clear HeqHe e0 H. pfold. red. cbn. inv Hpeel. ddestruction.
+  pclearbot. specialize (REL tt).
+  assert (peel_ (observe (k1 tt)) (observe (k2 a)) ≈ k3 tt ). auto.
+  symmetry in H. punfold H.
+Qed.
+
+Lemma vis_refine_peel_cont :  forall (E : Type -> Type) (R S A : Type) (e : E A) (a : A)
+                   (k1: unit -> itrace E S) (k2 : A -> itree E R) (t : itrace E S),
+        (peel_cont_ (VisF (evans _ e a) k1) (VisF e k2) ≈ t) -> 
+        (t ≈ peel_cont_ (observe (k1 tt)) (observe (k2 a))).
+Proof.
+  intros E R S A e a k1 k2 t Hpeelcont. punfold Hpeelcont. red in Hpeelcont.
+  unfold observe in Hpeelcont at 1. cbn in *. unfold peel_cont_vis in *.
+  assert (A = A); auto. destruct (classicT (A = A) ); try contradiction.
+  unfold eq_rect_r, eq_rect in *. remember (eq_sym e0) as He.
+  dependent destruction He. cbn in *. symmetry.
+  assert (Tau (peel_cont_ (observe (k1 tt)) (observe (k2 a) ) )  ≈ t ).
+  { pfold. auto. }
+  rewrite tau_eutt in H0. auto.
+Qed.
+
+Lemma spin_not_vis : forall (E : Type -> Type) (R A : Type)
+                       (e : E A) (k : A -> itree E R),
+    ~ ITree.spin ≈ Vis e k.
+Proof.
+  intros E R A e k Hcontra. punfold Hcontra. red in Hcontra. cbn in *.
+  dependent induction Hcontra.
+  eapply IHHcontra; eauto.
+Qed.
+
+Lemma peel_vis_empty_contra: forall (R : Type) (E : Type -> Type) (S A0 : Type) (Hempty : A0 -> void) 
+                               (ev : E A0) (k0 : void -> itree (EvAns E) S) (t0 : itree E R) (A : Type) 
+                               (a : A) (e : E A) (k : unit -> itrace E R),
+    eqitF eq true true id (upaco2 (eqit_ eq true true id) bot2)
+          (observe (peel_ (VisF (evempty A0 Hempty ev) k0) (observe t0))) 
+          (VisF (evans A e a) k) -> False.
+Proof.
+  intros R E S A0 Hempty ev k0 t0 A a e k Hpeel.
+  dependent induction Hpeel.
+  - destruct (observe t0) eqn : Heqt0; discriminate.
+  - destruct (observe t0) eqn : Heqt0; try discriminate. cbn in x. injection x as Ht1.
+    rewrite Ht1 in IHHpeel. eapply IHHpeel; eauto.
+Qed.
+
+
+Lemma vis_peel_l : forall (E : Type -> Type) (R S A : Type) (e : E A) (a : A)
+  (b : itrace E S) (t : itree E R) (f : R -> itree E S) (k : unit -> itrace E R),
+  b ⊑ ITree.bind t f ->
+  (peel b t ≈ Vis (evans _ e a) k) -> exists k', (b ≈ Vis (evans _ e a) k').
+Proof.
+  intros E R S A e a b t f k Href Hpeel. 
+  punfold Hpeel. red in Hpeel. cbn in Hpeel. dependent induction Hpeel.
+  - unfold peel in x. 
+    destruct (observe b) eqn : Heqb; destruct (observe t) eqn : Heqt; try destruct e0; cbn in *;
+      dependent destruction x. unfold observe in x. cbn in x.
+    unfold peel_vis in x.
+    assert (A0 = X0).
+    {
+      clear x.
+      symmetry in Heqb. symmetry in Heqt. apply simpobs in Heqb. apply simpobs in Heqt.
+      rewrite Heqb in Href. rewrite Heqt in Href.
+      rewrite bind_vis in Href.
+      punfold Href. red in Href. cbn in *. inv Href.
+      ddestruction. subst. inv H1. auto.
+    } 
+    destruct (classicT (A0 = X0)); try (exfalso; auto; fail).
+    unfold eq_rect_r, eq_rect in x. remember (eq_sym e0) as He.
+    dependent destruction He. cbn in x. injection x as Hevans.
+    ddestruction. subst. ddestruction. subst. exists k0.
+    symmetry in Heqb. apply simpobs in Heqb. rewrite Heqb. reflexivity.
+  - unfold peel in x. destruct (observe b) eqn : Heqb; destruct (observe t) eqn : Heqt;
+                        try destruct e0; cbn in *; dependent destruction x.
+    + symmetry in Heqt. apply simpobs in Heqt. rewrite Heqt in Href.
+      rewrite tau_eutt in Href. eapply IHHpeel in Href; eauto. unfold peel.
+      rewrite Heqb. auto.
+    + exfalso. eapply spin_not_vis. pfold. eauto.
+    + symmetry in Heqb. symmetry in Heqt. apply simpobs in Heqt.
+      apply simpobs in Heqb. setoid_rewrite Heqb. setoid_rewrite tau_eutt.
+      rewrite Heqb in Href. rewrite Heqt in Href. repeat rewrite tau_eutt in Href.
+      eapply IHHpeel in Href; eauto.
+    + symmetry in Heqb. symmetry in Heqt. apply simpobs in Heqb. apply simpobs in Heqt.
+      setoid_rewrite Heqb. setoid_rewrite tau_eutt. rewrite Heqb in Href.
+      rewrite Heqt in Href. repeat rewrite tau_eutt in Href.
+      eapply IHHpeel in Href; eauto.
+    + symmetry in Heqt. apply simpobs in Heqt. rewrite Heqt in Href.
+      rewrite tau_eutt in Href.
+      symmetry in Heqb. apply simpobs in Heqb. rewrite Heqb in Href.
+      setoid_rewrite Heqb. eapply IHHpeel in Href; eauto.
+    + exfalso. eapply peel_vis_empty_contra; eauto.
+    + unfold observe in x. cbn in x. unfold peel_vis in x.
+      symmetry in Heqb. symmetry in Heqt. apply simpobs in Heqt.
+      apply simpobs in Heqb. rewrite Heqb in Href. rewrite Heqt in Href.
+      rewrite bind_vis in Href. punfold Href. red in Href. cbn in *.
+      inv Href. ddestruction. subst. inv H1. subst; ddestruction; subst.
+      assert (A0 = A0); auto. destruct (classicT (A0 = A0) ); try contradiction.
+      unfold eq_rect_r, eq_rect in *. remember (eq_sym e0) as He.
+      dependent destruction He. cbn in *. discriminate.
+Qed.
+
+Lemma vis_peel_r : forall (E : Type -> Type) (R S A : Type) (e : E A) (a : A)
+  (b : itrace E S) (t : itree E R) (f : R -> itree E S) (k : unit -> itrace E R),
+  b ⊑ ITree.bind t f ->
+  (peel b t ≈ Vis (evans _ e a) k) -> exists k', (t ≈ Vis e k').
+Proof.
+  intros E R S A e a b t f k Href Hpeel.
+  eapply vis_peel_l in Hpeel as Hpeell; eauto. destruct Hpeell as [k' Hb].
+  rewrite Hb in Href. rewrite Hb in Hpeel. clear Hb b. punfold Hpeel. red in Hpeel. cbn in *.
+  unfold peel in Hpeel. cbn in *. dependent induction Hpeel.
+  - destruct (observe t) eqn : Heqt; dependent destruction x.
+    symmetry in Heqt. apply simpobs in Heqt. setoid_rewrite Heqt.
+    unfold observe in x. cbn in *. unfold peel_vis in x. destruct (classicT (A = X));
+                                                           cbn in *; try discriminate.
+    unfold eq_rect_r, eq_rect in x. remember (eq_sym e1) as He.
+    dependent destruction He. cbn in *. exists k0.
+    rewrite Heqt in Href. rewrite bind_vis in Href. punfold Href. red in Href.
+    cbn in *. inv Href. ddestruction; subst. inv H1. ddestruction; subst. reflexivity.
+  - destruct (observe t) eqn : Heqt; cbn in *; dependent destruction x.
+    + symmetry in Heqt. apply simpobs in Heqt. rewrite Heqt in Href. rewrite tau_eutt in Href.
+      setoid_rewrite Heqt. setoid_rewrite tau_eutt. eapply IHHpeel; eauto.
+    + unfold observe in x. cbn in x. unfold peel_vis in x.
+      destruct (classicT (A = X) ).
+      * unfold eq_rect_r, eq_rect in x. remember (eq_sym e1) as He. dependent destruction He.
+        cbn in *. discriminate.
+      * cbn in x. injection x as Ht1. rewrite Ht1 in Hpeel.
+        exfalso. eapply spin_not_vis. pfold. eauto.
+Qed.
+
+Lemma peel_cont_vis_eutt: forall (R : Type) (r : R) (E : Type -> Type) (S A : Type) (ev : E A) 
+                            (ans : A) (kb : unit -> itree (EvAns E) S) (kt : A -> itree E R),
+    (peel_cont (Vis (evans A ev ans) kb) (Vis ev kt) r ≈ peel_cont (kb tt) (kt ans) r).
+Proof.
+  intros R r E S A ev ans kb kt.
+  pfold. cbn. red. unfold observe at 1. cbn in *. unfold peel_cont_vis.
+  assert (A = A); auto. destruct (classicT (A = A)); try contradiction.
+  unfold eq_rect_r, eq_rect. remember (eq_sym e) as He.
+  dependent destruction He. cbn. constructor; auto. unfold peel_cont.
+  apply eqitF_r_refl.
+Qed.
+
+Lemma peel_cont_refine_t : forall (E : Type -> Type) (R S : Type)
+                  (b : itrace E S) (t : itree E R) (f : R -> itree E S) (r : R)
+     (Hrutt : b ⊑ ITree.bind t f),
+    may_converge r (peel b t) -> peel_cont b t r ⊑ f r.
+Proof.
+  intros. remember (peel b t) as t'. assert (peel b t ≈ t').
+  { subst. reflexivity. }
+  clear Heqt'. generalize dependent b. generalize dependent t.
+  induction H; intros.
+  - rewrite <- H0 in H. clear H0. apply peel_ret_inv in H as Ht.
+    rewrite Ht in Hrutt.
+    rewrite bind_ret_l in Hrutt.
+    rewrite Ht in H. 
+    unfold peel_cont. cbn. rewrite peel_cont_ret_inv; eauto.
+  - rewrite H in H1. clear H.
+    destruct e; try contradiction. eapply vis_peel_l in H1 as Hb; eauto.
+    eapply vis_peel_r in H1 as Ht; eauto.
+    destruct Hb as [kb Hkb]. destruct Ht as [kt Htk].
+    rewrite Htk. rewrite Hkb.
+    rewrite Hkb in Hrutt. rewrite Htk in Hrutt.
+    rewrite Hkb in H1. rewrite Htk in H1.
+    apply vis_refine_peel in H1 as Hk.
+    rewrite peel_cont_vis_eutt. apply IHmay_converge; auto.
+    + rewrite bind_vis in Hrutt. punfold Hrutt. red in Hrutt. cbn in *.
+      inv Hrutt. ddestruction; subst.
+      assert (RAnsRef E unit A (evans A ev ans) tt ev ans ); auto.
+      apply H8 in H. pclearbot. auto.
+    + destruct b. symmetry. auto.
+Qed.
+
+Ltac fold_eutt := match goal with |- paco2 _ _ ?t1 ?t2 => 
+                                  eapply paco2_mon with (r := bot2); intuition; enough (t1 ≈ t2); auto end.
+
+Ltac fold_peel_cont r := match goal with |- context [peel_cont_ (observe ?b) (observe ?t) ] => 
+            assert (Hfpc : forall r, peel_cont_ (observe b) (observe t) = peel_cont b t r ); auto; rewrite (Hfpc r); 
+            clear Hfpc end.
+
+Lemma trace_prefix_tau_ret:
+  forall (E : Type -> Type) (R S : Type) (r : itrace E S -> itrace E R -> Prop)
+    (b : itrace E R) (t : itree E S) (f : S -> itree E R) (r0 : R),
+    b ⊑ ITree.bind t f ->
+    observe b = RetF r0 ->
+    forall t0 : itree E S,
+      observe t = TauF t0 ->
+      trace_prefixF (upaco2 trace_prefix_ r) (TauF (peel_ (RetF r0) (observe t0))) (RetF r0).
+Proof.
+  intros E R S r b t f r0 Hrutt Heqb t0 Heqt.
+  symmetry in Heqb. symmetry in Heqt.
+  apply simpobs in Heqb. apply simpobs in Heqt. rewrite Heqb in Hrutt.
+  rewrite Heqt in Hrutt. rewrite tau_eutt in Hrutt.
+  apply trace_refine_ret_inv_r in Hrutt. constructor.
+  assert (exists s, t0 ≈ Ret s).
+  {
+    punfold Hrutt. red in Hrutt. dependent induction Hrutt.
+    - unfold observe in x. cbn in *. destruct (observe t0) eqn : Ht0; cbn in *; try discriminate.
+      exists r1. pfold. red. rewrite Ht0. cbn. auto.
+    - unfold observe in x. cbn in *. destruct (observe t0) eqn : Ht0; cbn in *; try discriminate.
+      + exists r1. pfold. red. rewrite Ht0. cbn. auto.
+      + injection x as Ht1. symmetry in Ht0. apply simpobs in Ht0.
+        apply eq_sub_eutt in Ht0 as Ht0'. setoid_rewrite Ht0'.
+        setoid_rewrite tau_eutt. eapply IHHrutt; eauto.
+        rewrite Ht1. eauto. subst. cbn. unfold ITree.bind. reflexivity.
+  }
+  destruct H as [s Ht0]. punfold Ht0. red in Ht0. cbn in Ht0.
+  clear Heqt Hrutt.
+  dependent induction Ht0.
+  - rewrite <- x. cbn. punfold Heqb. red in Heqb. cbn in *. inv Heqb; try inv CHECK.
+    rewrite H0. auto.
+  - rewrite <- x. cbn. constructor. eapply IHHt0; eauto.
+Qed.
+
+Lemma trace_prefix_vis_evans: forall (E : Type -> Type) (R S : Type) (r : itrace E S -> itrace E R -> Prop) 
+                                 (A0 : Type) (ev : E A0) (ans : A0) (k : unit -> itree (EvAns E) R) 
+                                 (k' : A0 -> itree E S)
+                                 (t0 : itree E S) (f : S -> itree E R),
+    (forall (a : unit) (b : A0),
+       RAnsRef E unit A0 (evans A0 ev ans) a ev b ->
+       id
+         (upaco2 (rutt_ (REvRef E) (RAnsRef E) eq id)
+            bot2) (k a) (ITree.bind (k' b) f)) ->
+    (t0 ≈ Vis ev k') ->
+    (forall (b : itrace E R) (t : itree E S)
+          (f : S -> itree E R),
+        b ⊑ ITree.bind t f -> r (peel b t) b) ->
+            trace_prefixF (upaco2 trace_prefix_ r)
+                           (observe (peel_ (VisF (evans A0 ev ans) k) (observe t0))) (VisF (evans A0 ev ans) k).
+Proof.
+  intros E R S r A0 ev ans k k' t0 f Hk' Ht0 CIH.
+  punfold Ht0. red in Ht0. cbn in *. dependent induction Ht0.
+  - rewrite <- x. unfold observe. cbn. unfold peel_vis.
+    assert (A0 = A0); auto. destruct (classicT (A0 = A0)); try contradiction.
+    unfold eq_rect_r, eq_rect. remember (eq_sym e) as He.
+    dependent destruction He. cbn. constructor. right. eapply CIH.
+    assert (RAnsRef E unit A0 (evans A0 ev ans) tt ev ans); auto.
+    apply Hk' in H0. pclearbot. assert (k1 ans ≈ k' ans); try apply REL.
+    rewrite H1. eauto.
+  - rewrite <- x. cbn. constructor. eapply IHHt0; eauto.
+Qed.
+
+Lemma trace_prefix_vis_evempty: forall (E : Type -> Type) (R S : Type)
+                                   (r : itrace E S -> itrace E R -> Prop) 
+                                   (A0 : Type) (Hempty : A0 -> void) (ev : E A0)
+                                   (k : void -> itree (EvAns E) R) (A : Type) 
+                                   (e0 : E A) (t0 : itree E S) (k' : A -> itree E S),
+    eqitF eq true true id
+          (upaco2 (eqit_ eq true true id) bot2) 
+          (observe t0) (VisF e0 k') ->
+    trace_prefixF (upaco2 trace_prefix_ r)
+                   (observe
+                      (peel_ (VisF (evempty A0 Hempty ev) k) (TauF t0)))
+                   (VisF (evempty A0 Hempty ev) k).
+Proof.
+  intros E R S r A0 Hempty ev k A e0 t0 k' Ht0.
+  cbn. constructor.
+  dependent induction Ht0.
+  - rewrite <- x. cbn. constructor.
+  - rewrite <- x. cbn. constructor. eapply IHHt0; eauto.
+Qed.
+
+
+Lemma trace_prefix_peel_ret_vis:  forall (E : Type -> Type) (R S : Type)
+                                     (r : itrace E S -> itrace E R -> Prop) 
+                                     (A0 : Type) (ev : E A0) (ans : A0)
+                                     (k : unit -> itree (EvAns E) R) (t0 : itree E S)
+                                     (s : S),
+    t0 ≈ Ret s ->
+    trace_prefixF (upaco2 trace_prefix_ r)
+                           (observe
+                              (peel_ (VisF (evans A0 ev ans) k) (observe t0)))
+                           (VisF (evans A0 ev ans) k).
+Proof.
+  intros E R S r A0 ev ans k t0 s Ht0.
+  punfold Ht0. red in Ht0. cbn in *. dependent induction Ht0.
+  - rewrite <- x. cbn. remember (go (VisF (evans A0 ev ans) k ) ) as t.
+    enough (trace_prefixF (upaco2 trace_prefix_ r) (RetF s) (observe t) ).
+    { subst. auto. }
+     constructor.
+  - rewrite <- x. cbn. constructor. eapply IHHt0; eauto.
+Qed.
+
+Lemma trace_prefix_peel_ret_vis_empty: forall (E : Type -> Type) (R S : Type)
+                                          (r : itrace E S -> itrace E R -> Prop) 
+                                          (A0 : Type) (Hempty : A0 -> void) (ev : E A0)
+                                          (k : void -> itree (EvAns E) R) (t0 : itree E S)
+                                          (s : S),
+    t0 ≈ Ret s ->
+    trace_prefixF (upaco2 trace_prefix_ r)
+                   (observe
+                      (peel_ (VisF (evempty A0 Hempty ev) k) (observe t0)))
+                   (VisF (evempty A0 Hempty ev) k).
+Proof.
+  intros E R S r A0 Hempty ev k t0 s Ht0.
+  punfold Ht0. red in Ht0. cbn in *. dependent induction Ht0.
+  - rewrite <- x. cbn. remember (go (VisF (evempty A0 Hempty ev) k ) ) as t.
+    enough (trace_prefixF (upaco2 trace_prefix_ r) (RetF s) (observe t) ).
+    { subst. auto. }
+    constructor.
+  - rewrite <- x. cbn. constructor. eapply IHHt0; eauto.
+Qed.
+
+Lemma trace_prefix_peel : forall (E : Type -> Type) (S R : Type) (b : itrace E R) (t : itree E S)
+  (f : S -> itree E R),
+    b ⊑ ITree.bind t f ->
+    trace_prefix (peel b t) b.
+Proof.
+  intros E S R. pcofix CIH. intros b t f Href. pfold. red. unfold peel. 
+  destruct (observe b) eqn : Heqb; destruct (observe t) eqn : Heqt; cbn.
+  - rewrite <- Heqb. auto.
+  - eapply trace_prefix_tau_ret; eauto.
+  - symmetry in Heqb. symmetry in Heqt. apply simpobs in Heqb. apply simpobs in Heqt.
+    rewrite Heqb in Href. rewrite Heqt in Href. rewrite bind_vis in Href.
+    pinversion Href.
+  - rewrite <- Heqb. auto.
+  - constructor. right. eapply CIH. symmetry in Heqb. symmetry in Heqt.
+    apply simpobs in Heqb. apply simpobs in Heqt. rewrite Heqb in Href. rewrite Heqt in Href.
+    repeat rewrite tau_eutt in Href. eauto.
+  - constructor. rewrite <- Heqt. right. eapply CIH.
+    symmetry in Heqb. apply simpobs in Heqb. rewrite Heqb in Href.
+    rewrite tau_eutt in Href. eauto.
+  - destruct e; cbn; rewrite <- Heqb; auto.
+  - symmetry in Heqb. apply simpobs in Heqb.
+    rewrite Heqb in Href.
+    apply trace_refine_vis_l in Href as Hbt. destruct Hbt as [A [e0 [k0 Hvis] ]  ].
+    symmetry in Heqt. apply simpobs in Heqt. rewrite Heqt in Hvis.
+    rewrite tau_eutt in Hvis.
+    assert ((exists B, exists k', exists (e1 : E B) , t0 ≈ Vis e1 k') \/ exists s, t0 ≈ Ret s).
+    {
+      punfold Hvis. red in Hvis. clear Heqb Heqt.
+      dependent induction Hvis.
+      - unfold observe in x. cbn in *. destruct (observe t0) eqn : Heqt0; try discriminate.
+        + right. exists r0. pfold. red. cbn. rewrite Heqt0. auto.
+        + cbn in x. left. exists X0. exists k2. exists e1. symmetry in Heqt0.
+          apply simpobs in Heqt0. rewrite Heqt0. reflexivity.
+     - unfold observe in x. cbn in *. destruct (observe t0) eqn : Heqt0; try discriminate.
+       + right. exists r0. pfold. red. cbn. rewrite Heqt0. auto.
+       + injection x as Ht1. symmetry in Heqt0. apply simpobs in Heqt0.
+         setoid_rewrite Heqt0. setoid_rewrite tau_eutt. eapply IHHvis; eauto.
+         rewrite Ht1. auto.
+    }
+    destruct H as [ [B [k' [e1 Ht0] ] ] | [s Ht0] ].
+    + rewrite Heqt in Href. rewrite tau_eutt in Href. 
+      rewrite Ht0 in Href. rewrite bind_vis in Href.
+      pinversion Href. subst; ddestruction; subst.
+      rewrite Ht0 in Hvis. rewrite bind_vis in Hvis. pinversion Hvis.
+      subst; ddestruction; subst. clear Heqt Heqb.
+      punfold Ht0. red in Ht0. cbn in *.
+      destruct e.
+      * inv H1. ddestruction; subst. cbn. constructor.
+        eapply trace_prefix_vis_evans; eauto. 
+      * eapply trace_prefix_vis_evempty; eauto.
+    + rewrite Heqt in Href. rewrite Ht0 in Href.
+      rewrite tau_eutt in Href. rewrite bind_ret_l in Href. clear Hvis.
+      destruct e.
+      * cbn. constructor. eapply trace_prefix_peel_ret_vis; eauto.
+      * cbn. constructor. eapply trace_prefix_peel_ret_vis_empty; eauto.
+  - destruct e; cbn.
+    + symmetry in Heqt. apply simpobs in Heqt. rewrite Heqt in Href.
+      rewrite bind_vis in Href. symmetry in Heqb. apply simpobs in Heqb.
+      rewrite Heqb in Href. pinversion Href. subst; ddestruction; subst.
+      inversion H1. ddestruction; subst.
+      unfold observe at 1. cbn. unfold peel_vis. assert (A = A); auto.
+      destruct (classicT (A = A) ); try contradiction.
+      unfold eq_rect_r, eq_rect. remember (eq_sym e) as He.
+      dependent destruction He. cbn. constructor. right. eapply CIH.
+      ddestruction; subst.
+      assert (RAnsRef E unit A (evans A ev ans) tt ev ans ); auto.
+      apply H6 in H0. pclearbot. eauto.
+    + constructor.
+Qed.
+
+Lemma peel_bind : forall (E : Type -> Type) (S R : Type) (b : itrace E R) (t : itree E S)
+  (f : S -> itree E R),
+    b ⊑ ITree.bind t f -> exists g, (ITree.bind (peel b t) g ≈ b).
+Proof.
+  intros. apply trace_prefix_bind. eapply trace_prefix_peel; eauto.
+Qed.
+
+Lemma peel_lemma : forall E R S (b : itrace E R) (t : itree E S) (f : S -> itree E R),
+    (b ⊑ ITree.bind t f) -> trace_prefix (peel b t) b /\ (peel b t ⊑ t).
+Proof.
+  intros. split; try eapply peel_refine_t; eauto; eapply trace_prefix_peel; eauto.
+Qed.
+
+Lemma bind_peel_ret_tau_aux:
+  forall (E : Type -> Type) (S R : Type) (f : R -> itree E S) 
+    (r0 : S) (t0 : itree E R),
+    Ret r0 ⊑ ITree.bind t0 f -> exists r : R, t0 ≈ Ret r.
+Proof.
+  intros E S R f r0 t0 Hrutt.
+  punfold Hrutt. red in Hrutt. cbn in *. dependent induction Hrutt.
+  - unfold ITree.bind in x. unfold observe in x at 1. cbn in *.
+    destruct (observe t0) eqn : Ht0; try discriminate.
+    exists r. pfold. red. rewrite Ht0. constructor. auto.
+  - unfold observe in x. cbn in x. destruct (observe t0) eqn : Ht0; try discriminate.
+    + exists r. pfold. red. rewrite Ht0. constructor. auto.
+    + symmetry in Ht0. apply simpobs in Ht0. setoid_rewrite Ht0. setoid_rewrite tau_eutt.
+      cbn in x. injection x as Ht2. eapply IHHrutt; auto.
+      subst. reflexivity.
+Qed.
+
+(* maybe this should be the axiom *)
+Lemma decompose_trace_refine_bind : forall (E : Type -> Type) (R S : Type)
+                                       (b : itrace E S) (t : itree E R) (f : R -> itree E S),
+    b ⊑ t >>= f -> exists b', exists g', (ITree.bind b' g' ≈ b) /\ b' ⊑ t.
+Proof.
+  intros. exists (peel b t).
+  apply peel_bind in H as Heutt. destruct Heutt as [g Heutt].
+  exists g. split; auto; eapply peel_refine_t; apply H.
+Qed. 
+
+Lemma bind_trigger_refine : forall (E : Type -> Type) (A R : Type) (b : itree (EvAns E) R) 
+                              (e : E A) (k : A -> itree E R),
+    (exists a : A, True) ->
+    b ⊑ ITree.bind (ITree.trigger e) k -> 
+    exists a : A, exists (k' : unit -> itrace E R), b ≈ Vis (evans A e a) k' /\ k' tt ⊑ k a.
+Proof.
+  intros. rewrite bind_trigger in H0. apply trace_refine_vis in H0 as Hvis.
+  destruct Hvis as [X [e' [k' Hbvis] ] ]. setoid_rewrite Hbvis.
+  rewrite Hbvis in H0.
+  punfold H0. red in H0. cbn in *. inv H0. ddestruction. subst. inv H3; ddestruction; subst.
+  - exists a. exists k'. split; try reflexivity. pclearbot.
+    assert (RAnsRef E unit A (evans A e a) tt e a ); auto.
+    apply H8 in H0. pclearbot. auto.
+  - destruct H as [a _]. contradiction.
+Qed.

--- a/theories/ITrace/ITraceDefinition.v
+++ b/theories/ITrace/ITraceDefinition.v
@@ -1,0 +1,64 @@
+From ITree Require Import
+     ITree
+     ITreeFacts
+     Eq.Rutt
+     Props.Divergence
+.
+
+
+From Paco Require Import paco.
+
+Import Monads.
+Import MonadNotation.
+Local Open Scope monad_scope.
+
+Variant EvAns (E : Type -> Type) : Type -> Type :=
+  | evans : forall {A : Type} (ev : E A) (ans : A), EvAns E unit
+  (*if you can prove there is no answers, don't need to proved one*)
+  | evempty : forall {A : Type} (Hempty : A -> void) (ev : E A), EvAns E void
+.
+
+Arguments evans {E}.
+Arguments evempty {E}.
+
+Definition itrace (E : Type -> Type) (R : Type) := itree (EvAns E) R.
+
+Definition itrace' (E : Type -> Type) (R : Type) := itree' (EvAns E) R.
+
+Definition ev_stream (E : Type -> Type) := itrace E unit.
+
+Definition Nil {E : Type -> Type} : ev_stream E := Ret tt.
+
+Definition ev_list (E : Type -> Type) := list (EvAns E unit).
+
+Fixpoint ev_list_to_stream {E : Type -> Type} (l : ev_list E) : ev_stream E :=
+  match l with
+  | nil => Ret tt
+  | cons e t => Vis e (fun _ => ev_list_to_stream t) end.
+
+(*one append for traces and streams, get associativity for free from bind_bind*)
+Definition append {E R} (s : itrace E unit) (b : itrace E R) :=
+  ITree.bind s (fun _ => b).
+
+Notation "s ++ b" := (append s b).
+
+Variant REvRef (E : Type -> Type) : forall (A B : Type), EvAns E A -> E B -> Prop := 
+  | rer {A : Type} (e : E A) (a : A) : REvRef E unit A (evans A e a) e
+  | ree {A : Type} (e : E A) (Hempty : A -> void) : REvRef E void A (evempty A Hempty e) e
+.
+Hint Constructors REvRef.
+
+(*shouldn't need an empty case*)
+Variant RAnsRef (E : Type -> Type) : forall (A B : Type), EvAns E A -> A -> E B -> B -> Prop :=
+  | rar {A : Type} (e : E A) (a : A) : RAnsRef E unit A (evans A e a) tt e a.
+Hint Constructors RAnsRef.
+
+Definition trace_refine {E R}  (t : itree E R) (b : itrace E R)  := 
+   rutt (REvRef E) (RAnsRef E) eq b t.
+
+
+Notation "b ⊑ t" := (trace_refine t b) (at level 70).
+
+Definition finite {E : Type -> Type} (s : ev_stream E) : Prop := may_converge tt s.
+
+Global Instance itrace_eq {E} : Eq1 (itrace E) := ITreeMonad.Eq1_ITree.

--- a/theories/ITrace/ITraceFacts.v
+++ b/theories/ITrace/ITraceFacts.v
@@ -1,0 +1,724 @@
+From Coq Require Import
+     Morphisms.
+
+From ITree Require Import
+     Axioms
+     ITree
+     ITreeFacts
+     Eq.Rutt
+     Props.Divergence
+     Props.EuttDiv
+     ITrace.ITraceDefinition
+.
+
+
+From Paco Require Import paco.
+
+Import Monads.
+Import MonadNotation.
+Local Open Scope monad_scope.
+
+Lemma classic_empty : forall (A : Type), ( exists e : A + (A -> void), True ).
+Proof.
+  intros. destruct (classic (exists a : A, True)).
+  - destruct H; eauto.
+  - assert (f : A -> void); eauto. intros.
+    exfalso. apply H; eauto.
+Qed.
+
+Lemma may_converge_trace : forall (E : Type -> Type) (R : Type)
+                                   (b : itrace E R) (r1 r2 : R),
+    may_converge r1 b -> may_converge r2 b -> r1 = r2.
+Proof.
+  intros. induction H; inversion H0; subst.
+  - rewrite H in H1. pinversion H1. subst. auto.
+  - rewrite H in H1. pinversion H1.
+  - destruct e. destruct b. apply IHmay_converge. rewrite H in H0. inversion H0; subst;
+                                                                    contra_void.
+    + pinversion H3.
+    + destruct e; [ | contradiction ]. destruct b.
+      pinversion H3. ddestruction.
+      enough (k tt ≈ k0 tt); try apply REL.
+      rewrite H5. auto.
+    + contradiction.
+ - destruct e. destruct e0. destruct b. destruct b0.
+   apply IHmay_converge. rewrite H in H2.
+   pinversion H2. ddestruction.
+   subst. enough (k tt ≈ k0 tt); try apply REL.
+   rewrite H4. auto; contra_void.
+   + destruct b0.
+   + destruct b.
+Qed.
+
+Lemma finite_nil {E : Type -> Type} : finite (@Nil E).
+Proof.
+  apply conv_ret. unfold Nil. reflexivity.
+Qed.
+
+Lemma finite_list_to_stream : forall (E : Type -> Type) (l : ev_list E),
+    finite (ev_list_to_stream l).
+Proof.
+  red. intros. induction l.
+  - cbn. constructor. reflexivity.
+  - cbn. eapply conv_vis; try reflexivity. simpl. eauto.
+    Unshelve. exact tt.
+Qed.
+
+Lemma finite_stream_list : forall (E : Type -> Type) (s : ev_stream E),
+    finite s -> exists l, (s ≈ ev_list_to_stream l)%itree.
+Proof.
+  intros. red in H. induction H.
+  - exists nil. auto.
+  - destruct IHmay_converge as [l Hl]. unfold ev_list in l.
+    inversion e. subst.
+    exists (cons e l). simpl. rewrite H.
+    destruct b. pfold. red. cbn. constructor.
+    intros. destruct v. left. auto.
+    subst. contradiction.
+Qed.
+
+Lemma append_vis : forall (E : Type -> Type) (R : Type)
+                          (e : EvAns E unit) (k : unit -> ev_stream E) (b : itrace E R),
+                          Vis e k ++ b ≈ Vis e (fun a => k a ++ b).
+Proof.
+  intros E R. unfold append. intros.
+  pfold. red. cbn. constructor. intros. left.
+  enough ( (ITree.bind (k v) (fun _ : unit => b) ≈  (ITree.bind (k v) (fun _ : unit => b) ) ) ); auto.
+  reflexivity.
+Qed.
+
+Global Instance proper_append {E R} : Proper (@eutt (EvAns E) unit unit eq ==> @eutt (EvAns E) R R eq ==> eutt eq) (@append E R).
+Proof.
+  intros log1 log2 Hlog b1 b2 Hb. unfold append. rewrite Hlog.
+  eapply eutt_clo_bind; eauto. reflexivity.
+Qed.
+
+Lemma may_converge_append : forall (E : Type -> Type) (R : Type)
+                                   (log : ev_stream E) (r : R),
+      finite log -> may_converge r (log ++ Ret r).
+Proof.
+  intros. induction H.
+  - unfold append. rewrite H. rewrite bind_ret_l.
+    constructor. reflexivity.
+  - rewrite H. inversion e. subst. rewrite append_vis.
+    eapply conv_vis; eauto; try reflexivity. simpl. eauto.
+    subst. contradiction.
+Qed.
+
+Lemma converge_itrace_ev_list : forall (E : Type -> Type) (R : Type) 
+                                        (b : itrace E R) (r : R),
+    may_converge r b -> (exists log, (ev_list_to_stream log) ++ Ret r ≈ b)%itree .
+Proof.
+  intros. induction H.
+  - exists nil. cbn. rewrite H.
+    pfold. red. cbn. constructor. auto.
+  - destruct IHmay_converge as [log Hlog]. inversion e. subst.
+    exists (cons e log). cbn. rewrite append_vis. rewrite H.
+    pfold. red. cbn. constructor. cbn. intros. destruct v.
+    left. destruct b. apply Hlog. subst. contradiction.
+Qed.
+
+Lemma classic_converge_itrace : forall (E : Type -> Type) (R : Type) (b : itrace E R),
+    (exists r, exists log, ( (ev_list_to_stream log) ++ Ret r ≈ b)%itree ) \/ must_diverge b.
+Proof.
+  intros.
+  destruct (classic_converge _ _ b ); auto. destruct H as [r Hr]. left.
+  exists r. apply converge_itrace_ev_list. auto.
+Qed.
+
+Arguments classic_converge_itrace {E} {R}.
+
+Lemma append_nil : forall (E : Type -> Type) (R : Type) (b : itrace E R),
+    (Ret tt ++ b ≈ b)%itree.
+Proof.
+  intros. unfold append. rewrite bind_ret_l. reflexivity.
+Qed.
+
+Lemma append_assoc : forall (E : Type -> Type) (R : Type) (b : itrace E R)
+                            (log log' : ev_list E),
+    ev_list_to_stream (log ++ log')%list ++ b ≈ 
+                      (ev_list_to_stream log) ++ (ev_list_to_stream log') ++ b.
+Proof.
+  intros E R b log. induction log.
+  - simpl. intros. rewrite append_nil. reflexivity.
+  - cbn. intros. rewrite append_vis. setoid_rewrite IHlog.
+    rewrite append_vis. reflexivity.
+Qed.
+
+Lemma append_div : forall (E : Type -> Type) (R : Type) (b : itrace E R)
+                          (log : ev_list E),
+    must_diverge b -> must_diverge ((ev_list_to_stream log) ++ b).
+Proof.
+  intros. induction log.
+  - cbn. unfold append. rewrite bind_ret_l. auto.
+  - cbn. unfold append.
+    pfold. red. cbn. constructor. intros. left. auto.
+Qed.
+
+Lemma inv_append_eutt : forall (E : Type -> Type) (R : Type) (r1 r2 : R)
+                               (log1 log2 : ev_list E),
+    ((ev_list_to_stream log1) ++ Ret r1 ≈ (ev_list_to_stream log2) ++ Ret r2)%itree -> 
+    log1 = log2 /\ r1 = r2.
+Proof.
+  intros. generalize dependent log2. induction log1; intros.
+  - destruct log2.
+    + split; auto. cbn in H. pinversion H. cbn. unfold append in *.
+      cbn in *. subst. auto.
+    + pinversion H.
+  - destruct log2.
+    + pinversion H.
+    + cbn in H. unfold append in H. pinversion H. cbn in *. ddestruction.
+      subst.
+      enough (log1 = log2 /\ r1 = r2).
+      { destruct H0. subst. auto. }
+      apply IHlog1. apply REL. apply tt.
+Qed.
+
+Lemma trace_refine_proper_left' : forall (E : Type -> Type) (R : Type) (b1 b2 : itrace E R)
+                (t : itree E R), (b1 ≈ b2) -> rutt (REvRef E) (RAnsRef E) eq b1 t ->
+                                 rutt (REvRef E) (RAnsRef E) eq b2 t.
+Proof. 
+  intros E R. pcofix CIH. intros. pfold. red.
+  punfold H1. red in H1.  punfold H0. red in H0.
+  genobs_clear t ot3.
+  hinduction H0 before CIH; intros; clear b1 b2; eauto.
+  - remember (RetF r1) as ot1. hinduction H1 before CIH; intros; inv Heqot1; eauto with paco.
+    + constructor. auto.
+    + constructor. eapply IHruttF; eauto.
+  (* Tau Tau case causes the most problems, seems *)
+  -  assert (DEC: (exists m3, ot3 = TauF m3) \/ (forall m3, ot3 <> TauF m3)).
+    { destruct ot3; eauto; right; red; intros; inv H. }
+    destruct DEC as [EQ | EQ].
+    + destruct EQ as [m3 ?]; subst. pclearbot.
+      constructor. right. eapply CIH; eauto.
+      apply rutt_inv_tauLR. pfold. auto.
+    + inv H1; try (exfalso; eapply EQ; eauto; fail). 
+      pclearbot. constructor.
+      punfold REL. red in REL.
+      hinduction H0 before CIH; intros; subst; try (exfalso; eapply EQ; eauto; fail). 
+      * dependent induction REL; rewrite <- x.
+        ++ constructor. auto.
+        ++ constructor. eapply IHREL; eauto.
+      * eapply IHruttF; eauto. clear IHruttF.
+        dependent induction REL; try (exfalso; eapply EQ; eauto; fail).  
+        ++ pclearbot. rewrite <- x. constructor; auto. pstep_reverse.
+        ++ auto. 
+        ++ rewrite <- x. constructor; auto. eapply IHREL; eauto.
+      * dependent induction REL; rewrite <- x.
+        ++ constructor; auto. intros. apply H0 in H1. right.
+           pclearbot. eapply CIH; eauto.
+        ++ constructor. eapply IHREL; eauto.
+  - remember (VisF e k1) as ot1.
+    hinduction H1 before CIH; intros; dependent destruction Heqot1.
+    + constructor. eapply IHruttF; eauto.
+    + pclearbot. constructor; auto. intros. apply H0 in H1. 
+      pclearbot. right.
+      eapply CIH; eauto. 
+  - eapply IHeqitF. remember (TauF t1) as otf1. 
+    hinduction H1 before CIH; intros;  dependent destruction Heqotf1; eauto.
+    + constructor. pclearbot. pstep_reverse.
+    + constructor. eapply IHruttF; eauto.
+  - constructor. eapply IHeqitF. eauto.
+
+Qed. 
+
+Lemma trace_refine_proper_right' : forall (E : Type -> Type) (R : Type) (b : itrace E R)
+                                   (t1 t2 : itree E R), t1 ≈ t2 -> rutt (REvRef E) (RAnsRef E) eq b t1 ->
+                                 rutt (REvRef E) (RAnsRef E) eq b t2.
+Proof.
+  intros E R. pcofix CIH. intros. punfold H1. red in H1.
+  punfold H0. red in H0. pfold. red.
+  genobs_clear t2 ot2.
+  hinduction H0 before CIH; intros; clear t1; subst; eauto.
+  - remember (RetF r2) as ot1. hinduction H1 before CIH; intros; inv Heqot1; eauto with paco.
+    + constructor; auto.
+    + constructor. eauto.
+  - pclearbot. remember (TauF m1) as otm1.
+    hinduction H1 before CIH; intros; subst; try (inv Heqotm1).
+    + constructor. pclearbot. right. eapply CIH; eauto.
+    + constructor. right. eapply CIH; eauto.
+      apply rutt_inv_tauR. pfold. auto.
+    + punfold REL. red in REL. 
+      dependent induction REL; subst.
+      * constructor. clear IHruttF.
+        hinduction H1 before CIH; intros; dependent destruction x0.
+        ++ rewrite <- x. constructor. auto.
+        ++ constructor. auto.
+      * pclearbot. eapply IHruttF; auto. 2 : symmetry; eauto.
+        pclearbot. pfold. red. rewrite <- x. constructor; auto.
+        punfold REL.
+      * constructor. rewrite <- x.
+        clear IHruttF. hinduction H1 before CIH; intros; dependent destruction x0.
+        ++ constructor. eapply IHruttF; eauto.
+        ++ constructor; auto. intros. apply H0 in H1.
+           pclearbot. right. eapply CIH; eauto.
+      * eapply IHruttF; eauto.
+      * constructor. rewrite <- x. eapply IHREL; eauto.
+  - remember (VisF e k1) as ot1. hinduction H1 before CIH; intros; inv Heqot1.
+    + constructor. eauto.
+    + ddestruction. constructor; auto. intros. apply H0 in H1.
+      right. pclearbot. eapply CIH; eauto; apply REL.
+  - eapply IHeqitF; eauto. remember (TauF t0) as otf0.
+    hinduction H1 before CIH; intros; dependent destruction Heqotf0; eauto.
+    + constructor. pclearbot. pstep_reverse.
+    + constructor. eapply IHruttF; eauto.
+  - constructor. eapply IHeqitF. eauto.
+Qed.
+
+Instance trace_refine_proper {E R} : Proper (@eutt E R R eq ==> eutt eq ==> iff) trace_refine.
+Proof.
+  intros b1 b2 Heuttb t1 t2 Heuttt.
+  split; intros;
+  try (eapply trace_refine_proper_right'; [eauto | eapply trace_refine_proper_left'; eauto]);
+  auto; symmetry; auto.
+Qed.
+
+Lemma trace_refine_ret : forall (E : Type -> Type) (R : Type) (r : R),
+    @trace_refine E R (Ret r) (Ret r).
+Proof.
+  intros. pfold. constructor. auto.
+Qed.
+
+Lemma trace_refine_ret_inv_r : forall (E : Type -> Type) (R : Type) (r : R)
+                                     (t : itree E R),
+    Ret r ⊑ t -> t ≈ Ret r.
+Proof.
+  intros. pfold. red. punfold H. red in H. cbn in *.
+  dependent induction H; subst.
+  - rewrite <- x. constructor. auto.
+  - rewrite <- x. constructor; auto.
+Qed.
+
+Lemma trace_refine_ret_inv_l : forall (E : Type -> Type) (R : Type) (r : R)
+                                     (b : itrace E R),
+    b ⊑ Ret r -> (b ≈ Ret r)%itree.
+Proof.
+  intros. pfold. red. punfold H. red in H. cbn in *.
+  dependent induction H; subst.
+  - rewrite <- x. constructor. auto.
+  - rewrite <- x. constructor; auto.
+Qed.
+
+Lemma trace_refine_vis_inv : forall (E : Type -> Type) (R A: Type) (e : E A) (a : A)
+                                     (b :itrace E R) (k : A -> itree E R),
+    trace_refine (Vis e k) (Vis (evans A e a) (fun _ => b))  -> trace_refine (k a) b .
+Proof.
+  intros E R A e a. intros.
+  red in H. red. punfold H. red in H. inversion H. ddestruction.
+  subst. 
+  assert (RAnsRef E unit A (evans A e a) tt e a); eauto.
+  apply H7 in H0. pclearbot. auto.
+Qed.
+
+Lemma trace_refine_vis_add : forall (E : Type -> Type) (R A: Type) (e : E A) (a : A)
+                                     (b :itrace E R) (k : A -> itree E R),
+    b ⊑ k a -> Vis (evans A e a) (fun _ => b) ⊑ Vis e k.
+Proof.
+  intros. pfold. red. cbn. constructor; eauto.
+  intros. left. inversion H0. ddestruction.
+  subst. auto.
+Qed.
+
+Lemma event_ans_constr : forall (E : Type -> Type) (R : Type) (e : E R),
+    exists (A : Type), exists e' : EvAns E A, REvRef E A R e' e.
+Proof.
+  intros.
+  destruct (classic_empty R) as  [ [a | Hempty]  _ ] .
+  - exists unit. exists (evans R e a). eauto.
+  - exists void. exists (evempty R Hempty e). eauto.
+Qed.
+
+(* Here are where some of the sketchy uses of axioms are *)
+
+CoFixpoint determinize_ (E : Type -> Type) (R : Type) (ot : itree' E R) : itrace E R.
+Proof.
+  destruct ot.
+- apply (Ret r).
+- apply (Tau (determinize_ E R (observe t) ) ).
+- specialize (classic_empty X) as H. 
+  apply constructive_indefinite_description in H. destruct H as [ [x | f] _].
+  + apply (Vis (evans X e x) (fun _ =>  (determinize_ E R (observe (k x)) ) )) .
+  + apply (Vis (evempty X f e) (fun v : void => match v return itrace E R with end)  ).
+Defined.
+
+Definition determinize {E R} t := determinize_ E R (observe t).
+
+(* may be a better idea to make this an axiom *)
+Lemma itree_refine_nonempty : forall (E : Type -> Type) (R : Type) (t : itree E R),
+    exists b : itrace E R, b ⊑ t.
+Proof.
+  intros. exists (determinize t). generalize dependent t.
+  pcofix CIH. intros. pfold. red. unfold determinize. destruct (observe t).
+  - cbn. constructor. auto.
+  - cbn. constructor. right. apply CIH.
+  - unfold observe. cbn. cbn. destruct (constructive_indefinite_description (fun _ : X + (X -> void) => True)
+                   (classic_empty X)).
+    destruct x as [x | f]; cbn.
+    + constructor; eauto. intros. right. 
+      inversion H. ddestruction.
+      subst. apply CIH.
+    + constructor; auto. intros. contradiction. 
+Qed.
+
+
+Lemma refine_set_eq_to_eutt_vis_aux : forall (E : Type -> Type) (R : Type) (r : itree E R -> itree E R -> Prop)
+      (CIH : forall t1 t2 : itree E R, (forall b : itrace E R, b ⊑ t1 <-> b ⊑ t2) -> r t1 t2)
+      (t1 t2 : itree E R)
+      (H0 : forall b : itrace E R, b ⊑ t1 <-> b ⊑ t2)
+      (A B : Type) (e : E A) (e0 : E B)
+      (k : A -> itree E R) (k0 : B -> itree E R)
+      (Ht1 : t1 ≅ Vis e k) (Ht2 : t2 ≅ Vis e0 k0 ),
+      eqitF eq true true id (upaco2 (eqit_ eq true true id) r) (VisF e k) (VisF e0 k0).
+Proof.
+  intros.
+  destruct (classic_empty A) as [ [a | Ha] _ ].
+  - specialize  trace_refine_vis_add with (e := e) (k := k) (a := a) as Hbrv.
+    assert (exists b, b ⊑ (k a) ). 
+    { apply itree_refine_nonempty. }
+    destruct H as [b Hbk]. apply trace_refine_vis_add with (e := e) in Hbk.
+    rewrite <- Ht1 in Hbk.
+    apply H0 in Hbk as Hbk0.
+    rewrite Ht1 in Hbk. rewrite Ht2 in Hbk0.
+    pinversion Hbk.
+    pinversion Hbk0. ddestruction.
+    subst.
+    inversion H10. ddestruction.
+    subst. constructor.
+    intros. right. eapply CIH; eauto.
+    intros. setoid_rewrite Ht1 in H0. setoid_rewrite Ht2 in H0.
+    split; intros.
+    + apply trace_refine_vis_add with (e := e) in H. apply H0 in H.
+      apply trace_refine_vis_inv in H. auto.
+    + apply trace_refine_vis_add with (e := e) in H. apply H0 in H.
+      apply trace_refine_vis_inv in H. auto.
+  - set (fun v : void => match v return itrace E R with end) as ke.
+    set (Vis (evempty A Ha e) ke) as b.
+    assert (b ⊑ t1).
+    {
+      unfold b. rewrite Ht1. pfold. red. cbn.
+      constructor; intuition.
+    }
+    apply H0 in H as H1. unfold b in *. clear b.
+    rewrite Ht1 in H. rewrite Ht2 in H1.
+    pinversion H. pinversion H1. ddestruction.
+    subst. inversion H12. ddestruction.
+    constructor.
+    intros. right. eapply CIH.
+    intros. setoid_rewrite Ht1 in H0. setoid_rewrite Ht2 in H0.
+    split; intros; contradiction.
+Qed.
+
+Lemma trace_refine_vis : forall (E : Type -> Type) (R A : Type) (b : itrace E R)
+                                 (e : E A) (k : A -> itree E R),
+    b ⊑ Vis e k -> exists X, exists e0 : EvAns E X, exists k0, (b ≈ Vis e0 k0)%itree.
+Proof.
+  intros. punfold H. red in H. cbn in H.
+  dependent induction H.
+  - enough 
+      (exists (X : Type) (e0 : EvAns E X) (k0 : X -> itree (EvAns E) R), (t1 ≈ Vis e0 k0)%itree).
+    {
+      destruct H0 as [ X [e0 [k0 Ht1] ] ].
+      exists X. exists e0. exists k0.
+      specialize (itree_eta b) as Hb. rewrite <- x in Hb. rewrite Hb.
+      rewrite tau_eutt. auto.
+    }
+    eapply IHruttF; eauto.
+  - exists A0. exists e1. exists k1.
+    specialize (itree_eta b) as Hb. rewrite <- x in Hb.
+    rewrite Hb. reflexivity.
+Qed.
+
+Lemma trace_refine_vis_l : forall (E : Type -> Type) (R A: Type) (t : itree E R)
+                                   (e : EvAns E A) (k : A -> itrace E R),
+    Vis e k ⊑ t -> exists X, exists e0 : E X, exists k0 : X -> itree E R, t ≈ Vis e0 k0.
+Proof.
+  intros. punfold H. red in H. cbn in *.
+  dependent induction H.
+  - assert (t2 ≈ t).
+    {
+      specialize (itree_eta t). rewrite <- x. intros.
+      rewrite H0. rewrite tau_eutt. reflexivity.
+    }
+    setoid_rewrite <- H0. eapply IHruttF; eauto.
+  - exists B. exists e2.  exists k2. specialize (itree_eta t) as Ht.
+      rewrite <- x in Ht. rewrite Ht. reflexivity.
+Qed.
+
+Lemma trace_refine_may_converge_ex : forall (E : Type -> Type) (R : Type)
+                         (t : itree E R) (r : R),
+    may_converge r t -> exists b, may_converge r b /\ b ⊑ t.
+Proof.
+  intros. induction H.
+  - exists (Ret r). rewrite H. split.
+    + constructor. reflexivity.
+    + apply trace_refine_ret.
+  - destruct IHmay_converge as [br [Hrbr Hrefbr] ].
+    exists  (Vis (evans B e b) (fun _ => br) ). split.
+    + eapply conv_vis; try reflexivity. eauto. Unshelve. exact tt.
+    + rewrite H. apply trace_refine_vis_add. auto.
+Qed.
+
+Lemma trace_refine_may_converge : forall (E : Type -> Type) (R : Type)
+                         (t : itree E R) (r : R) (b : itrace E R),
+    may_converge r b -> b ⊑ t -> may_converge r t.
+Proof.
+  intros. generalize dependent t. induction H; intros.
+  - rewrite H in H0. apply trace_refine_ret_inv_r in H0.
+    rewrite H0. constructor. reflexivity.
+  - rewrite H in H1. apply trace_refine_vis_l in H1 as Ht0.
+    destruct Ht0 as [X [e0 [k0 Ht0] ] ].
+    rewrite Ht0 in H1. pinversion H1. subst.
+    ddestruction. subst. rewrite Ht0.
+    inversion H4; subst; ddestruction; subst; try contradiction.
+    eapply conv_vis; try reflexivity. Unshelve. 2 : exact a.
+    apply IHmay_converge. pclearbot.
+    specialize (H9 tt a). assert (RAnsRef E unit X (evans X e0 a) tt e0 a).
+    constructor. apply H9 in H2. pclearbot. destruct b. auto.
+Qed.
+
+Lemma trace_refine_must_diverge : forall (E : Type -> Type) (R : Type)
+                       (t : itree E R) (b : itrace E R),
+    must_diverge t -> b ⊑ t -> must_diverge b.
+Proof.
+  intros E R. pcofix CIH. intros. punfold H0. red in H0.
+  punfold H1. red in H1. pfold. red. dependent induction H1.
+  - rewrite <- x in H0. inversion H0.
+  - rewrite <- x0. constructor. right. pclearbot. eapply CIH; eauto.
+    rewrite <- x in H0. inv H0. pclearbot. auto.
+  - rewrite <- x. constructor. left.  pfold. eapply IHruttF; eauto.
+  - eapply IHruttF; auto. rewrite <- x in H0. inv H0.
+    pclearbot. punfold H2.
+  - rewrite <- x0. rewrite <- x in H0. constructor. inv H0.
+    ddestruction. subst. intros. right. pclearbot.
+    inversion H; subst; ddestruction; try contradiction. destruct b0.
+    eapply CIH; try apply H3.
+    specialize (H1 tt a). assert (RAnsRef _ _ _ (evans B e2 a) tt e2 a ).
+    constructor. apply H1 in H0. unfold id in H0.
+    destruct H0; try contradiction. eauto.
+Qed.
+
+Lemma trace_refine_converge_bind : forall (E : Type -> Type) (R S : Type)
+            (b : itrace E R) (t : itree E R) (f : R -> itrace E S) (g : R -> itree E S) (r : R),
+    may_converge r b -> b ⊑ t -> f r ⊑ g r -> ITree.bind b f ⊑ ITree.bind t g.
+Proof.
+  intros. generalize dependent t. dependent induction H; intros.
+  - rewrite H. rewrite H in H0. apply trace_refine_ret_inv_r in H0. 
+    rewrite H0. repeat rewrite bind_ret_l. auto.
+  - specialize (IHmay_converge H1).
+    rewrite H in H2. apply trace_refine_vis_l in H2 as Ht.
+    destruct Ht as [X [e0 [k0 Ht] ] ].
+    rewrite Ht in H2. punfold H2. red in H2. cbn in H2. inversion H2; subst.
+    ddestruction. subst. pclearbot.
+    inversion H5; ddestruction; subst; try contradiction.
+    ddestruction. subst. rewrite H. rewrite Ht.
+    pfold. red. cbn. constructor; auto.
+    intros. apply H10 in H3. pclearbot. left. 
+    destruct a0. destruct b. apply IHmay_converge. auto.
+Qed.
+
+Lemma trace_refine_diverge_bind : forall (E : Type -> Type) (R S : Type)
+                  (b : itrace E R) (t : itree E R) (f : R -> itrace E S) (g : R -> itree E S),
+    must_diverge b -> b ⊑ t -> ITree.bind b f ⊑ ITree.bind t g.
+Proof.
+  intros E R S b t f g. generalize dependent b. generalize dependent t.
+  pcofix CIH. intros.
+  punfold H0. red in H0.
+  punfold H1. red in H1. pfold. red. cbn. 
+  dependent induction H1.
+  - rewrite <- x0 in H0. inv H0.
+  - unfold observe. cbn. rewrite <- x0. rewrite <- x.
+    cbn. constructor. right. pclearbot. apply CIH; auto.
+    rewrite <- x0 in H0. inv H0. pclearbot. auto.
+  - unfold observe at 1. cbn. rewrite <- x. cbn. constructor.
+    eapply IHruttF; eauto. rewrite <- x in H0. inv H0. pclearbot. pstep_reverse.
+  - unfold observe at 2. cbn. rewrite <- x. cbn. constructor. 
+    eapply IHruttF; eauto.
+  - unfold observe. cbn. rewrite <- x0. rewrite <- x. cbn. constructor; auto.
+    intros.
+    rewrite <- x0 in H0. inv H0. ddestruction. subst. pclearbot.
+    apply H1 in H2. right. eapply CIH; eauto; try apply H4.
+    unfold id in H2. pclearbot. auto.
+Qed.
+
+Lemma refine_set_eq_to_eutt : forall (E : Type -> Type) (R : Type) (t1 t2 : itree E R),
+    (forall b, b ⊑ t1 <-> b ⊑ t2) -> t1 ≈ t2.
+Proof.
+  intros E R. pcofix CIH. intros.
+  pfold. red.
+  remember (observe t1) as ot1. remember (observe t2) as ot2.
+  destruct (ot1); destruct (ot2).
+    (*Ret Ret*)
+  - specialize (H0 (Ret r0) ) as Hr0.
+    specialize (itree_eta t1) as Ht1. rewrite <- Heqot1 in Ht1.
+    specialize (itree_eta t2) as Ht2. rewrite <- Heqot2 in Ht2.
+    rewrite Ht1 in Hr0. rewrite Ht2 in Hr0.
+    assert (Ret r0 ⊑ t2).
+    { rewrite Ht2. apply Hr0. pfold. constructor. auto. }
+    rewrite Ht2 in H. pinversion H. subst. constructor. auto.
+    (*Ret Tau *)
+  - specialize (itree_eta t1) as Ht1. rewrite <- Heqot1 in Ht1.
+    specialize (itree_eta t2) as Ht2. rewrite <- Heqot2 in Ht2.
+    setoid_rewrite Ht2 in H0.
+    specialize (H0 (Ret r0) ).
+    rewrite tau_eutt in H0. constructor; auto.
+    assert (Ret r0 ⊑ t1).
+    { rewrite Ht1. pfold. constructor. auto. }
+    apply H0 in H. punfold H. red in H. cbn in H.
+    clear H0 Ht1 Ht2 Heqot1 Heqot2. dependent induction H.
+    + rewrite <- x. constructor; auto.
+    + rewrite <- x. constructor; auto.
+    (*Ret Vis*)
+  - exfalso.
+    specialize (itree_eta t1) as Ht1. rewrite <- Heqot1 in Ht1.
+    specialize (itree_eta t2) as Ht2. rewrite <- Heqot2 in Ht2.
+    assert (Ret r0 ⊑ t1).
+    { rewrite Ht1. pfold. constructor. auto. }
+    apply H0 in H. rewrite Ht2 in H. pinversion H.
+    (*Tau Ret*)
+  - specialize (itree_eta t1) as Ht1. rewrite <- Heqot1 in Ht1.
+    specialize (itree_eta t2) as Ht2. rewrite <- Heqot2 in Ht2.
+    setoid_rewrite Ht1 in H0. setoid_rewrite Ht2 in H0.
+    assert (Ret r0 ⊑ t2).
+    { rewrite Ht2. pfold. constructor. auto. }
+     rewrite Ht2 in H. apply H0 in H as H1. punfold H1.
+    clear Heqot1 Heqot2 Ht1 Ht2 H H0. red in H1. cbn in *.
+    constructor; auto. inv H1. dependent induction H2; intros; subst.
+    + rewrite <- x. auto.
+    + rewrite <- x. constructor; auto.
+    (*Tau Tau*)
+  - constructor. right. eapply CIH. 
+    intros. 
+    specialize (itree_eta t1) as Ht1. rewrite <- Heqot1 in Ht1.
+    specialize (itree_eta t2) as Ht2. rewrite <- Heqot2 in Ht2.
+    assert (t1 ≈ t). { rewrite Ht1. rewrite tau_eutt. reflexivity. }
+    assert (t2 ≈ t0). { rewrite Ht2. rewrite tau_eutt. reflexivity. }
+    rewrite <- H. rewrite <- H1. auto.
+    (*Tau Vis*)
+  - specialize (itree_eta t1) as Ht1. rewrite <- Heqot1 in Ht1.
+    specialize (itree_eta t2) as Ht2. rewrite <- Heqot2 in Ht2. 
+    specialize (itree_refine_nonempty _ _ (t1) ) as [b Hbt1].
+    apply H0 in Hbt1 as Hbt2. rewrite Ht1 in Hbt1.
+    rewrite tau_eutt in Hbt1. 
+    rewrite Ht2 in Hbt2.
+    apply trace_refine_vis in Hbt2 as Hb.
+    destruct Hb as [Y [e0 [k0 Hb] ] ].
+    rewrite Hb in Hbt2.
+    rewrite Hb in Hbt1. clear Hb b.
+    constructor; auto. 
+    setoid_rewrite Ht1 in H0. setoid_rewrite tau_eutt in H0.
+    clear Heqot1 Heqot2. clear Ht1 t1.
+    punfold Hbt1. red in Hbt1. cbn in *.
+    dependent induction Hbt1.
+    + rewrite <- x. constructor; auto. eapply IHHbt1; eauto.
+      assert (t0 ≈ t).
+      { 
+        specialize (itree_eta t) as Ht. rewrite <- x in Ht. rewrite Ht.
+        rewrite tau_eutt. reflexivity. 
+      }
+      setoid_rewrite H. auto.
+    + rewrite <- x.
+      specialize (itree_eta t) as Ht. rewrite <- x in Ht.
+      eapply refine_set_eq_to_eutt_vis_aux; eauto.
+    (*Vis Ret*)
+  - exfalso.
+    specialize (itree_eta t1) as Ht1. rewrite <- Heqot1 in Ht1.
+    specialize (itree_eta t2) as Ht2. rewrite <- Heqot2 in Ht2.
+    assert (Ret r0 ⊑ t2).
+    { rewrite Ht2. pfold. constructor. auto. }
+    apply H0 in H. rewrite Ht1 in H. pinversion H.
+    (*Vis Tau*)
+  - specialize (itree_eta t1) as Ht1. rewrite <- Heqot1 in Ht1.
+    specialize (itree_eta t2) as Ht2. rewrite <- Heqot2 in Ht2. 
+    specialize (itree_refine_nonempty _ _ (t2) ) as [b Hbt2].
+    apply H0 in Hbt2 as Hbt1. rewrite Ht1 in Hbt1.
+    rewrite Ht2 in Hbt2.
+    rewrite tau_eutt in Hbt2. 
+    apply trace_refine_vis in Hbt1 as Hb.
+    destruct Hb as [Y [e0 [k0 Hb] ] ].
+    rewrite Hb in Hbt2.
+    rewrite Hb in Hbt1. clear Hb b.
+    constructor; auto. 
+    setoid_rewrite Ht2 in H0. setoid_rewrite tau_eutt in H0.
+    clear Heqot1 Heqot2. clear Ht2 t2.
+    punfold Hbt2. red in Hbt2. cbn in *.
+    dependent induction Hbt2.
+    + rewrite <- x. constructor; auto. eapply IHHbt2; eauto.
+      assert (t2 ≈ t).
+      { 
+        specialize (itree_eta t) as Ht. rewrite <- x in Ht. rewrite Ht.
+        rewrite tau_eutt. reflexivity. 
+      }
+      setoid_rewrite H. auto.
+    + rewrite <- x.
+      specialize (itree_eta t) as Ht. rewrite <- x in Ht.
+      eapply refine_set_eq_to_eutt_vis_aux; eauto.
+    (*Vis Vis*)
+  - specialize (itree_eta t1) as Ht1. rewrite <- Heqot1 in Ht1.
+    specialize (itree_eta t2) as Ht2. rewrite <- Heqot2 in Ht2.
+    eapply refine_set_eq_to_eutt_vis_aux; eauto.
+Qed.
+
+Lemma trace_set_complete : forall E R (t1 t2 : itree E R), (forall b, b ⊑ t1 <-> b ⊑ t2) <-> t1 ≈ t2.
+Proof.
+  intros. split; intros; try apply refine_set_eq_to_eutt; auto.
+  rewrite H. split; auto.
+Qed.
+
+Lemma trace_refine_bind_cont_inv : forall (E : Type -> Type) (R S : Type)
+         (b : itrace E R) (m : itree E R) (g : R -> itrace E S)
+         (f : R -> itree E S) (r : R),
+    may_converge r b -> b ⊑ m -> ITree.bind b g ⊑ ITree.bind m f -> g r ⊑ f r.
+Proof.
+  intros E R S. pcofix CIH. intros b m g f a Hconv Hrefb Hrefbind.
+  generalize  dependent m.
+  dependent induction  Hconv; intros m Hrefb Hrefbind.
+  - rewrite H in Hrefbind. rewrite bind_ret_l in Hrefbind. rewrite H in Hrefb.
+    apply trace_refine_ret_inv_r in Hrefb. rewrite Hrefb in Hrefbind.
+    rewrite bind_ret_l in Hrefbind. eapply paco2_mon; eauto. intuition.
+  - (*m must be a vis, the continuations must refine then continuation in the m I use in the 
+      inductive hypothesis *)
+    destruct e; try contradiction. rewrite H in Hrefb.
+    rewrite H in Hrefbind. rewrite bind_vis in Hrefbind.
+    apply trace_refine_vis_l in Hrefb as Hvis. destruct Hvis as [X [e' [k' Hvis ] ] ].
+    rewrite Hvis in Hrefbind. rewrite bind_vis in Hrefbind.
+    punfold Hrefbind. red in Hrefbind. cbn in Hrefbind. inv Hrefbind.
+    ddestruction. inv H2. ddestruction; subst.
+    rewrite Hvis in Hrefb. punfold Hrefb. red in Hrefb. cbn in Hrefb. inv Hrefb.
+    ddestruction.
+    assert (RAnsRef E unit A (evans _ e' ans) tt e' ans ); try (constructor; auto; fail).
+    specialize (IHHconv (k' ans) ). apply IHHconv.
+    + apply H8 in H0. pclearbot. destruct b. auto.
+    + apply H7 in H0. pclearbot. destruct b. auto.
+Qed.
+
+Lemma may_converge_two_list:
+  forall (E : Type -> Type) (A B : Type) (log : ev_list E) (b : itrace E A) 
+    (a : A) (log' : ev_list E),
+    (ev_list_to_stream log) ++ b ≈ (ev_list_to_stream log') ++ Ret a -> may_converge a b.
+Proof.
+  intros. generalize dependent log'.
+  induction log; cbn; intros.
+  - simpl in H. setoid_rewrite bind_ret_l in H. rewrite H.
+    apply may_converge_append. apply finite_list_to_stream.
+  - assert ((Vis a0 (fun _ => ev_list_to_stream log)) ≈ ev_list_to_stream (cons a0 log) )%itree.
+    { cbn. reflexivity. }
+    rewrite H0 in H.
+    destruct log' as [ | h t ].
+    + setoid_rewrite bind_ret_l in H. simpl in H. pinversion H.
+    + simpl in H. unfold append in H. repeat rewrite bind_vis in H. pinversion H.
+      ddestruction; subst.
+      assert (ev_list_to_stream log ++ b ≈ ev_list_to_stream t ++ Ret a).
+      { apply REL. apply tt. }
+      eapply IHlog; eauto.
+Qed.
+
+Lemma must_diverge_bind_append: forall (E : Type -> Type) (A : Type) 
+                                  (log : ev_list E) (b' : itree (EvAns E) A),
+    must_diverge (ev_list_to_stream log ++ b') -> must_diverge b'.
+Proof.
+  intros E A log b' Hdiv. induction log.
+  - cbn in Hdiv. setoid_rewrite bind_ret_l in Hdiv. auto.
+  - apply IHlog. simpl in Hdiv. unfold append in Hdiv.
+    rewrite bind_vis in Hdiv. pinversion Hdiv. ddestruction. subst. apply H0.
+    apply tt.
+Qed.

--- a/theories/ITrace/ITracePreds.v
+++ b/theories/ITrace/ITracePreds.v
@@ -1,0 +1,176 @@
+From Coq Require Import
+     Morphisms
+.
+
+From ITree Require Import
+     Axioms
+     ITree
+     ITreeFacts
+     ITrace.ITraceDefinition
+     ITrace.ITraceFacts
+     ITrace.ITraceBind
+.
+
+From Paco Require Import paco.
+
+Import Monads.
+Import MonadNotation.
+Local Open Scope monad_scope.
+
+(* Defines some useful predicates over ITraces *)
+
+Variant trace_forallF {E : Type -> Type} {R : Type} (F : itrace E R -> Prop) 
+        (PE : forall A, EvAns E A -> Prop) (PR : R -> Prop) : itrace' E R -> Prop :=
+| trace_forall_ret (r : R) : PR r -> trace_forallF F PE PR (RetF r)
+| trace_forall_tau (b : itrace E R) : F b -> trace_forallF F PE PR (TauF b)
+| trace_forall_vis {A : Type} (e : EvAns E A) (k : A -> itrace E R) :
+    PE A e -> (forall (a :A), F (k a) ) -> trace_forallF F PE PR (VisF e k)
+.
+
+Hint Constructors trace_forallF.
+
+Definition trace_forall_ {E R} PE PR F (b : itrace E R) :=
+  trace_forallF F PE PR (observe b).
+
+Lemma trace_forall_monot {E R} PE PR : monotone1 (@trace_forall_ E R PE PR).
+Proof.
+  repeat intro. red in IN. red. induction IN; auto.
+Qed.
+
+Hint Resolve trace_forall_monot : paco.
+
+Definition trace_forall {E R} PE PR := paco1 (@trace_forall_ E R PE PR) bot1.
+
+Lemma trace_forall_proper_aux: forall (E : Type -> Type) (R : Type) (PE : forall A : Type, EvAns E A -> Prop)
+                                  (PR : R -> Prop) (b1 b2 : itree (EvAns E) R),
+    (b1 ≈ b2) -> trace_forall PE PR b1 -> trace_forall PE PR b2.
+Proof.
+  intros E R PE PR. pcofix CIH. intros b1 b2 Heutt Hforall.
+  pfold. red. punfold Hforall. red in Hforall.
+  punfold Heutt. red in Heutt. induction Heutt; subst; auto.
+  - inv Hforall. auto.
+  - inv Hforall. pclearbot. constructor. right. eapply CIH; eauto.
+  - inv Hforall. ddestruction. subst. pclearbot.
+    constructor; auto. intros. right. eapply CIH; eauto. apply H3.
+  - apply IHHeutt. inv Hforall. pclearbot. punfold H0.
+  - constructor. left. pfold. red. apply IHHeutt. auto.
+Qed.
+
+Global Instance trace_forall_proper_eutt {E R PE PR} : Proper (eutt eq ==> iff) (@trace_forall E R PE PR).
+Proof.
+  intros b1 b2 Heutt. split; intros.
+  - eapply trace_forall_proper_aux; eauto.
+  - symmetry in Heutt. eapply trace_forall_proper_aux; eauto.
+Qed.
+    
+      
+
+Lemma forall_spin : forall E R PE PR, trace_forall PE PR (@ITree.spin (EvAns E) R).
+Proof.
+  intros. pcofix CIH. pfold. red. cbn. constructor.
+  right. auto.
+Qed.
+
+Inductive trace_inf_oftenF {E : Type -> Type} {R : Type} (PE : forall A, EvAns E A -> Prop)
+        (F : itrace E R -> Prop) : itrace' E R -> Prop :=
+| trace_inf_often_tau (b : itrace E R) : trace_inf_oftenF PE F (observe b) -> 
+                                             trace_inf_oftenF PE F (TauF b)
+| trace_inf_often_vis_neg (e : EvAns E unit) (k : unit -> itrace E R) : 
+    trace_inf_oftenF PE F (observe (k tt)) -> trace_inf_oftenF PE F (VisF e k)
+| trace_inf_often_vis_pos (e : EvAns E unit) (k : unit -> itrace E R) : 
+    F (k tt) -> PE unit e -> trace_inf_oftenF PE F (VisF e k)
+.
+
+Hint Constructors trace_inf_oftenF.
+
+Definition trace_inf_often_ {E R} PE F (b : itrace E R) :=
+  trace_inf_oftenF PE F (observe b).
+
+Lemma trace_inf_often_monot {E R} PE : monotone1 (@trace_inf_often_ E R PE).
+Proof.
+  repeat intro. red in IN. red. induction IN; auto.
+Qed.
+
+Hint Resolve trace_inf_often_monot : paco.
+
+Definition trace_inf_often {E R} PE := paco1 (@trace_inf_often_ E R PE) bot1.
+
+Inductive front_and_last {E : Type -> Type} {R : Type} (PEF : forall A, EvAns E A -> Prop)
+          (PEL : forall A, EvAns E A -> Prop) (PR : R -> Prop) : itrace E R -> Prop :=
+| front_and_last_base (e : EvAns E unit) (r : R) (b : itree (EvAns E) R) :
+    b ≈ Vis e (fun u => Ret r) -> PEL unit e -> PR r -> front_and_last PEF PEL PR b
+  | front_and_last_cons (e : EvAns E unit) (k : unit -> itrace E R) (b : itree (EvAns E) R ) :
+      b ≈ Vis e k -> PEF unit e -> front_and_last PEF PEL PR (k tt) -> front_and_last PEF PEL PR b
+      
+.
+
+Lemma fal_proper_aux: forall (E : Type -> Type) (R : Type) (PEF PEL : forall A : Type, EvAns E A -> Prop)
+                        (PR : R -> Prop) (b1 b2 : itree (EvAns E) R),
+    (b1 ≈ b2) -> front_and_last PEF PEL PR b1 -> front_and_last PEF PEL PR b2.
+Proof.
+  intros E R PEF PEL PR b1 b2 Heutt Hfal.
+  generalize dependent b2. induction Hfal; intros.
+  - eapply front_and_last_base; eauto.
+    rewrite <- Heutt. auto.
+  - eapply front_and_last_cons; eauto. rewrite <- Heutt. auto.
+Qed.
+
+Global Instance front_and_last_proper_eutt {E R PEF PEL PR} : Proper (eutt eq ==> iff) (@front_and_last E R PEF PEL PR).
+Proof.
+  intros b1 b2 Heutt. split; intros.
+  - eapply fal_proper_aux; eauto.
+  - symmetry in Heutt. eapply fal_proper_aux; eauto.
+Qed.
+     
+Section StateMachine.
+(*Note that this state machine definition is not able to deal with empty event parameter types*)
+(*Nor can it encode predicates that can accept silent divergence under certain conditions *)
+(*Pretty sure it could be extended to handle that,but that is a job for another day*)
+Context {E : Type -> Type}.
+Context {R : Type}.
+Context (EvTrans : forall A, E A -> A -> forall B, E B -> B -> Prop).
+Context (RetTrans : forall A, E A -> A -> R -> Prop).
+
+Inductive state_machineF (PEv : forall A, E A -> A -> Prop) (PRet : R -> Prop) 
+          (F : (forall A, E A -> A -> Prop) -> (R -> Prop) -> itrace E R -> Prop) : itrace' E R -> Prop :=
+  | smRet r : PRet r -> state_machineF PEv PRet F (RetF r)
+  | smTau t : state_machineF PEv PRet F (observe t) -> state_machineF PEv PRet F (TauF t)
+  | smVis A (e : E A) (a : A) (k : unit -> itrace E R) : 
+      PEv A e a -> F (EvTrans A e a) (RetTrans A e a) (k tt) -> state_machineF PEv PRet F (VisF (evans A e a) k)
+.
+
+Hint Constructors state_machineF.
+
+Definition state_machine_ F PEv PRet (tr : itrace E R) :=
+  state_machineF PEv PRet F (observe tr).
+
+Lemma monotone_state_machine : monotone3 state_machine_.
+Proof.
+  red. intros. red. red in IN. induction IN; auto.
+Qed.
+Hint Resolve trace_inf_often_monot : paco.
+Definition state_machine PEv PRet (tr : itrace E R) :  Prop := paco3 (state_machine_) bot3 PEv PRet tr.
+
+Lemma state_machine_proper_aux : forall PEv PRet (t1 t2 : itrace E R), 
+    (t1 ≈ t2) -> state_machine PEv PRet t1 -> state_machine PEv PRet t2.
+Proof.
+  pcofix CIH. intros PEV PREt t1 t2 Heutt Hsm. pfold. red.
+  punfold Hsm; try apply monotone_state_machine.
+  punfold Heutt. red in Heutt. red in Hsm. 
+  induction Hsm.
+  - remember (RetF r0) as ot1. induction Heutt; subst; auto; try discriminate.
+    injection Heqot1; intros; subst; auto.
+  - apply IHHsm. pstep_reverse. assert (Tau t ≈ t2); auto.
+    rewrite tau_eutt in H. auto.
+  - remember (VisF (evans A e a) k ) as ot1. induction Heutt; subst; auto; try discriminate.
+    injection Heqot1; intros; subst. dependent destruction H1.
+    subst. constructor; auto. right. pclearbot. eapply CIH; eauto.
+    destruct H0; tauto.
+Qed.
+
+Global Instance state_machine_proper_eutt {PEv PRet} : Proper (eutt eq ==> iff) (@state_machine PEv PRet).
+Proof.
+  intros t1 t2 Heutt. split; intros; try eapply state_machine_proper_aux; eauto; symmetry; auto.
+Qed.
+
+End StateMachine.

--- a/theories/ITrace/ITracePrefix.v
+++ b/theories/ITrace/ITracePrefix.v
@@ -1,0 +1,344 @@
+From Coq Require Import
+     Morphisms
+.
+
+From ITree Require Import
+     Axioms
+     ITree
+     ITreeFacts
+     Eq.Rutt
+     Props.Divergence
+     Props.EuttDiv
+     ITrace.ITraceDefinition
+     ITrace.ITraceFacts
+.
+
+
+From Paco Require Import paco.
+
+Import Monads.
+Import MonadNotation.
+Local Open Scope monad_scope.
+
+(* Defines and explores a notion of traces being prefixes of other traces *)
+
+Inductive trace_prefixF {E : Type -> Type} {R S : Type} (F : itrace E R -> itrace E S -> Prop) : itrace' E R -> itrace' E S ->  Prop :=
+  | ret_prefix (r : R) (b : itrace E S) : trace_prefixF F (RetF r) (observe b)
+  | tau_prefix (br : itrace E R) (bs : itrace E S) : F br bs -> trace_prefixF F (TauF br) (TauF bs)
+  | tau_r_prefix (br : itrace E R) (obs : itrace' E S) : trace_prefixF F (observe br) obs -> trace_prefixF F (TauF br) obs
+  | tau_l_prefix (obr : itrace' E R) (bs : itrace E S) : trace_prefixF F (obr) (observe bs) -> trace_prefixF F (obr) (TauF bs)
+  | tau_vis_empty {A : Type} (e : E A) (H: A -> void) (kr : void -> itrace E R) (ks : void -> itrace E S) : 
+      trace_prefixF F (VisF (evempty A H e) kr) (VisF (evempty A H e) ks )
+  | tau_vis_ans {A : Type} (e : E A) (ans : A) (kr : unit -> itrace E R) (ks : unit -> itrace E S) :
+      F (kr tt) (ks tt) -> trace_prefixF F (VisF (evans A e ans) kr ) (VisF (evans A e ans) ks)
+.
+
+Hint Constructors trace_prefixF.
+
+Definition trace_prefix_ {E R S} F (br : itrace E R) (bs : itrace E S) := trace_prefixF F (observe br) (observe bs).
+
+Hint Unfold trace_prefix_.
+
+Lemma trace_prefix_monot {E R S} : monotone2 (@trace_prefix_ E R S).
+Proof.
+  repeat intro. red. red in IN. induction IN; eauto.
+Qed.
+
+Hint Resolve trace_prefix_monot : paco.
+
+Definition trace_prefix {E R S} : itrace E R -> itrace E S -> Prop := paco2 trace_prefix_ bot2.
+
+Lemma prefix_vis : forall E R S A (e : E A) (ans : A) (k : unit -> itrace E R) (t : itrace E S), 
+                     trace_prefix (Vis (evans _ e ans) k ) t -> exists k', (t ≈ Vis (evans _ e ans) k' )%itree.
+Proof.
+  intros E R S A e ans k t Hbp. punfold Hbp. red in Hbp. cbn in *.
+  dependent induction Hbp.
+  - apply simpobs in x. enough (exists k', bs ≈ (Vis (evans A e ans) k' ))%itree.
+    + destruct H as [k' Hk']. exists k'. rewrite x. rewrite tau_eutt. auto.
+    + eapply IHHbp; eauto.
+  - exists ks. apply simpobs in x. rewrite x. reflexivity.
+Qed.
+
+Lemma trace_prefix_ret : forall E R S F (ob : itrace' E S) (r : R), trace_prefixF F (RetF r) ob.
+Proof.
+  intros. remember (go ob) as b. assert (observe b = ob).
+  { subst. auto. }
+  rewrite <- H. auto.
+Qed.
+
+Lemma trace_prefix_proper_aux_vis: forall (E : Type -> Type) (S R : Type)
+                                  (t1 : itree (EvAns E) R) (b2 : itrace E R),
+    eqitF eq true true id
+          (upaco2 (eqit_ eq true true id) bot2)
+          (observe t1) (observe b2) ->
+    forall (r : itrace E R -> itrace E S -> Prop)
+      (X : Type) (e : EvAns E X)
+      (k : X -> itree (EvAns E) S),
+      trace_prefixF (upaco2 trace_prefix_ bot2)
+                     (observe t1) (VisF e k) ->
+      (forall (b1 b2 : itrace E R)
+         (b : itrace E S),
+          (b1 ≈ b2) ->
+          trace_prefix b1 b -> r b2 b) ->
+        trace_prefixF (upaco2 trace_prefix_ r)
+        (observe b2) (VisF e k).
+Proof.
+  intros E S R t1 b2 Heutt r X e k H0 CIH.
+  dependent induction H0.
+  - rewrite <- x0 in Heutt. dependent induction Heutt.
+    + rewrite <- x. apply trace_prefix_ret.
+    + rewrite <- x. constructor. eapply IHHeutt; eauto.
+  - eapply IHtrace_prefixF; auto.
+    apply simpobs in x. assert (t1 ≈ b2); auto.
+    rewrite x in H. rewrite tau_eutt in H. punfold H.
+  - rewrite <- x in Heutt. dependent induction Heutt.
+    + rewrite <- x. constructor.
+    + rewrite <- x. constructor. eapply IHHeutt; eauto.
+  - pclearbot. rewrite <- x in Heutt. dependent induction Heutt.
+    + rewrite <- x. constructor. right. pclearbot. eapply CIH; eauto.
+    + rewrite <- x. constructor. eapply IHHeutt; eauto.
+Qed.
+
+Lemma trace_prefix_tau_inv:
+  forall (E : Type -> Type) (S R : Type)
+    (m1 : itree (EvAns E) R) (t : itree (EvAns E) S),
+    trace_prefixF (upaco2 trace_prefix_ bot2)
+                   (TauF m1) (TauF t) -> trace_prefix m1 t.
+Proof.
+  intros E S R m1 t Hbp.
+  dependent induction  Hbp.
+  - pclearbot. auto.
+  - pfold. red. clear IHHbp. dependent induction Hbp.
+    + rewrite <- x0. auto.
+    + rewrite <- x. constructor. pclearbot. punfold H.
+    + rewrite <- x. constructor. eapply IHHbp; eauto.
+    + auto.
+  - pfold. red. clear IHHbp. dependent induction Hbp.
+    + rewrite <- x. constructor. pclearbot. punfold H.
+    + auto.
+    + rewrite <- x. constructor. eapply IHHbp; eauto.
+Qed.
+
+Lemma trace_prefix_proper_l : forall E R S (b1 b2 : itrace E R) (b : itrace E S),
+    (b1 ≈ b2) -> trace_prefix b1 b -> trace_prefix b2 b.
+Proof.
+  intros E R S. pcofix CIH. intros b1 b2 b Heutt Hbp.
+  pfold. red. punfold Heutt. red in Heutt. punfold Hbp. red in Hbp.
+  dependent induction Heutt.
+  - rewrite <- x. constructor.
+  - rewrite <- x. rewrite <- x0 in Hbp. clear x0 x. pclearbot. 
+    destruct (observe b) eqn : Heqb.
+    + inv Hbp. constructor. dependent induction  H0. 
+      * apply simpobs in x0. assert (m1 ≈ m2); auto.
+        rewrite x0 in H. clear x x0 Heqb CIH REL.
+        punfold H. red in H. cbn in *. dependent induction H.
+        ++ rewrite <- x. apply trace_prefix_ret.
+        ++ rewrite <- x. constructor. eapply IHeqitF; eauto.
+      * eapply IHtrace_prefixF; auto.
+        apply simpobs in x. assert (m1 ≈ m2); auto.
+        rewrite x in H. rewrite tau_eutt in H. auto.
+    + constructor. right. eapply CIH; eauto. eapply trace_prefix_tau_inv; eauto.
+    + constructor. clear Heqb. inv Hbp. dependent induction H0. 
+      * apply simpobs in x0. assert (m1 ≈ m2); auto.
+        rewrite x0 in H. punfold H. red in H. cbn in *.
+        dependent induction H.
+       ++ rewrite <- x. apply trace_prefix_ret.
+       ++ rewrite <- x. constructor. eapply IHeqitF; eauto.
+          assert (m1 ≈ m2); auto.
+          apply simpobs in x. rewrite x in H0. rewrite tau_eutt in H0. auto.
+      * eapply IHtrace_prefixF; auto.
+        assert (m1 ≈ m2); auto. apply simpobs in x.
+        rewrite x in H. rewrite tau_eutt in H. auto.
+      * assert (m1 ≈ m2); auto. apply simpobs in x.
+        rewrite x in H0.
+        punfold H0. red in H0. cbn in *.
+        dependent induction H0.
+        ++ rewrite <- x. constructor.
+        ++ rewrite <- x. constructor. eapply IHeqitF; eauto.
+           assert (m1 ≈ m2); auto.
+           apply simpobs in x. rewrite x in H1. rewrite tau_eutt in H1. auto.
+      * pclearbot. apply simpobs in x. assert (m1 ≈ m2); auto.
+        rewrite x in H0. punfold H0. red in H0. cbn in *.
+        dependent induction H0.
+        ++ rewrite <- x. constructor. right. pclearbot. eapply CIH; eauto.
+        ++ rewrite <- x. constructor. eapply IHeqitF; eauto. 
+           assert (m1 ≈ m2); auto.
+           apply simpobs in x. rewrite x in H1. rewrite tau_eutt in H1. auto.
+  - rewrite <- x. rewrite <- x0 in Hbp. clear x x0. pclearbot.
+    dependent induction Hbp.
+    + rewrite <- x. constructor. eapply IHHbp; eauto.
+    + rewrite <- x. constructor.
+    + rewrite <- x. pclearbot. constructor. right. eapply CIH; eauto.
+  - rewrite <- x in Hbp.
+    destruct (observe b) eqn : Heqb.
+    + clear IHHeutt. inv Hbp. clear Heqb x.
+      dependent induction H0.
+      * rewrite <- x0 in Heutt. clear CIH x0 x.
+        dependent induction  Heutt.
+        ++ rewrite <- x. apply trace_prefix_ret.
+        ++ rewrite <- x. constructor. eapply IHHeutt; eauto.
+       * eapply IHtrace_prefixF; auto.
+         assert (t1 ≈ b2); auto.
+         apply simpobs in x. rewrite x in H. rewrite tau_eutt in H. punfold H.
+    + constructor. eapply IHHeutt; eauto. pstep_reverse. eapply trace_prefix_tau_inv; eauto.
+    + clear IHHeutt. inv Hbp. eapply trace_prefix_proper_aux_vis; eauto.
+  - rewrite <- x. constructor. eapply IHHeutt; eauto.
+Qed.
+
+Lemma trace_prefixF_tau_inv_r:
+  forall (E : Type -> Type) (S R : Type)
+    (t1 : itree (EvAns E) S) (b : itrace E R),
+    trace_prefixF (upaco2 trace_prefix_ bot2)
+                   (observe b) (TauF t1) ->
+    trace_prefixF (upaco2 trace_prefix_ bot2)
+                   (observe b) (observe t1).
+Proof.
+  intros E S R t1 b Hbp.
+  dependent induction  Hbp.
+  - rewrite <- x0. apply trace_prefix_ret.
+  - pclearbot. rewrite <- x. constructor. punfold H.
+  - rewrite <- x. constructor. eapply IHHbp; eauto.
+  - auto.
+Qed.
+  
+Lemma trace_prefixF_vis_l:
+  forall (E : Type -> Type) (S R : Type)
+    (m1 m2 : itree (EvAns E) S),
+    paco2 (eqit_ eq true true id) bot2 m1 m2 ->
+    forall (r : itrace E R -> itrace E S -> Prop)
+      (X : Type) (e : EvAns E X)
+      (k : X -> itree (EvAns E) R),
+      trace_prefixF (upaco2 trace_prefix_ bot2)
+                     (VisF e k) (observe m1) ->
+      (forall (b : itrace E R)
+         (b1 b2 : itrace E S),
+          (b1 ≈ b2) ->
+          trace_prefix b b1 -> r b b2 ) ->
+      trace_prefixF (upaco2 trace_prefix_ r) 
+                     (VisF e k) (observe m2).
+Proof.
+  intros E S R m1 m2 REL r X e k H1 CIH.
+  punfold REL. red in REL.
+  dependent induction H1.
+  - eapply IHtrace_prefixF; auto. rewrite <- x in REL.
+    assert (Tau bs ≈ m2).
+    { pfold. auto. }
+    rewrite tau_eutt in H. punfold H.
+  - rewrite <- x in REL. dependent induction REL.
+    + rewrite <- x. constructor.
+    + rewrite <- x. constructor. eapply IHREL; eauto.
+  - pclearbot. rewrite <- x in REL. dependent induction REL.
+    + rewrite <- x. constructor. right. pclearbot. eapply CIH; eauto. 
+    + rewrite <- x. constructor. eapply IHREL; eauto.
+Qed.
+
+Lemma trace_prefix_proper_r : forall E R S (b : itrace E R) (b1 b2 : itrace E S),
+    (b1 ≈ b2) -> trace_prefix b b1 -> trace_prefix b b2.
+Proof.
+  intros E R S. pcofix CIH. intros b b1 b2 Heutt Hbp.
+  punfold Heutt. red in Heutt. punfold Hbp. red in Hbp.
+  pfold. red. dependent induction Heutt.
+  - rewrite <- x. rewrite <- x0 in Hbp. clear x0 x. induction Hbp; auto.
+    + pclearbot. constructor. right. eapply CIH; eauto. reflexivity.
+    + constructor. pclearbot. left. eapply paco2_mon; eauto. intuition.
+  - pclearbot. rewrite <- x0 in Hbp. rewrite <- x. clear x0 x.
+    destruct (observe b).
+    + apply trace_prefix_ret.
+    + constructor. right. pclearbot. eapply CIH; eauto. apply trace_prefix_tau_inv. auto.
+    + inv Hbp. constructor. eapply trace_prefixF_vis_l; eauto.
+  - rewrite <- x. rewrite <- x0 in Hbp. pclearbot. clear x x0. dependent induction Hbp.
+    + rewrite <- x0. apply trace_prefix_ret.
+    + rewrite <- x. constructor. eapply IHHbp; eauto.
+    + rewrite <- x. constructor.
+    + rewrite <- x. constructor. right. pclearbot. eapply CIH; eauto.
+  - eapply IHHeutt; auto. rewrite <- x in Hbp. eapply trace_prefixF_tau_inv_r; eauto.
+  - rewrite <- x. constructor. eapply IHHeutt; eauto.
+Qed.
+  
+Instance trace_prefix_proper {E R S} : Proper (eutt eq ==> eutt eq ==> iff) (@trace_prefix E R S).
+Proof.
+  repeat intro. split; intros.
+  - eapply trace_prefix_proper_l; eauto.
+    eapply trace_prefix_proper_r; eauto.
+  - symmetry in H. symmetry in H0.
+    eapply trace_prefix_proper_l; eauto.
+    eapply trace_prefix_proper_r; eauto.
+Qed.
+
+Inductive ind_comb {E R S} : itrace E R -> itrace E S -> itrace E S -> Prop :=
+  | left_ret_comb (r : R) b1 b2 b : (b1 ≈ Ret r)%itree -> (b2 ≈ b)%itree -> ind_comb b1 b2 b
+  | left_vis_comb {A : Type} (e : E A) (ans : A) (k1 : unit -> itrace E R) (k2 : unit -> itrace E S) b1 b2 b 
+    : (b1 ≈ Vis (evans _ e ans) k1) -> (b ≈ (Vis (evans _ e ans) k2 ))%itree -> ind_comb (k1 tt) b2 (k2 tt) -> 
+    ind_comb b1 b2 b.
+
+
+Lemma ind_comb_bind : forall E R S (b1 : itrace E R) (b2 : itrace E S) (b : itrace E S),
+    ind_comb b1 b2 b -> (ITree.bind b1 (fun x => b2) ≈ b)%itree.
+Proof.
+  intros E R S b1 b2 b Hind. induction Hind.
+  - rewrite H. rewrite bind_ret_l. auto.
+  - rewrite H. rewrite H0. rewrite bind_vis. pfold. red. constructor. intros.
+    left. destruct v. apply IHHind.
+Qed.
+
+Inductive trace_prefix_ind {E R S} : itrace E R -> itrace E S -> Prop :=
+  | left_ret_bp (r : R) b1 b2 : (b1 ≈ Ret r)%itree -> trace_prefix_ind b1 b2
+  | left_vis_bp {A : Type} (e : E A) (ans : A) (k1 : unit -> itrace E R) (k2 : unit -> itrace E S) b1 b2 :
+      (b1 ≈ Vis (evans _ e ans) k1)%itree -> (b2 ≈ Vis (evans _ e ans) k2 )%itree -> trace_prefix_ind (k1 tt) (k2 tt) ->
+      trace_prefix_ind b1 b2
+.
+
+Lemma trace_prefix_ind_comb : forall E R S (b1 : itrace E R) (b2 : itrace E S), trace_prefix_ind b1 b2 ->
+                                                                          exists b3, ind_comb b1 b3 b2.
+Proof.
+  intros E R S b1 b2 Hpre. induction Hpre.
+  - exists b2. econstructor; eauto. reflexivity.
+  - destruct IHHpre as [b3 Hb3].
+    exists b3. eapply left_vis_comb; eauto.
+Qed.
+
+Lemma trace_prefix_ind_bind : forall E R S (b1 : itrace E R) (b2 : itrace E S), trace_prefix_ind b1 b2 -> 
+  exists g, (ITree.bind b1 g ≈ b2)%itree.
+Proof.
+  intros. apply trace_prefix_ind_comb in H. destruct H as [b3 Hb3].
+  apply ind_comb_bind in Hb3. exists (fun _ => b3). auto.
+Qed.
+
+Lemma converge_trace_prefix : forall E R S (b1 : itrace E R) (b2 : itrace E S) (r : R), 
+    trace_prefix b1 b2 -> may_converge r b1 -> trace_prefix_ind b1 b2.
+Proof.
+  intros E R S b1 b2 r Hbp Hconv. generalize dependent b2. induction Hconv; intros.
+  - eapply left_ret_bp; eauto.
+  - rewrite H in Hbp. destruct e; try contradiction.
+    apply prefix_vis in Hbp as Hb2.
+    destruct Hb2 as [k' Hk']. rewrite Hk' in Hbp.
+    eapply left_vis_bp; eauto. destruct b. apply IHHconv.
+    punfold Hbp. red in Hbp. cbn in *. inversion Hbp. subst; ddestruction; subst.
+    pclearbot. auto.
+Qed.
+
+Lemma trace_prefix_div : forall E R S (b1 : itrace E R) (b2 : itrace E S),
+    must_diverge b1 -> trace_prefix b1 b2 -> eutt_div b1 b2.
+Proof.
+  intros E R S. pcofix CIH. intros b1 b2 Hdiv Hbf. pfold. red.
+  punfold Hbf. red in Hbf. punfold Hdiv. red in Hdiv. induction Hbf.
+  - inv Hdiv.
+  - constructor. inv Hdiv. pclearbot. right. apply CIH; auto.
+  - constructor; auto. apply IHHbf. pstep_reverse. inv Hdiv. pclearbot. auto.
+  - constructor; auto. 
+  - constructor. intuition.
+  - pclearbot. constructor. intros. right. pclearbot. inv Hdiv. ddestruction; subst.
+    pclearbot. destruct v. apply CIH; auto. apply H1.
+Qed.
+
+Lemma trace_prefix_bind : forall E R S (b1 : itrace E R) (b2 : itrace E S),
+    trace_prefix b1 b2 -> exists g, (ITree.bind b1 g ≈ b2).
+Proof.
+  intros. destruct (classic_converge _ _ b1).
+  - destruct H0 as [r Hconv]. eapply converge_trace_prefix in Hconv; eauto.
+    apply trace_prefix_ind_bind. auto.
+  - eapply trace_prefix_div in H0 as Heuttdiv; eauto.
+    exists (fun _ => ITree.spin). apply eutt_div_subrel. apply eutt_div_sym. 
+    eapply div_bind_nop with (f := (fun _ => ITree.spin) ) in H0 as H1.
+    eapply eutt_div_trans; try apply H1. apply eutt_div_sym. auto.
+Qed.

--- a/theories/Props/Divergence.v
+++ b/theories/Props/Divergence.v
@@ -1,0 +1,192 @@
+(* begin hide *)
+From Coq Require Import
+     Program
+     Setoid
+     Morphisms
+     RelationClasses.
+
+From Paco Require Import paco.
+
+From ITree Require Import
+     Axioms
+     Basics
+     Core.ITreeDefinition
+     Eq.Eq
+     Eq.Shallow.
+(* end hide *)
+
+Import ITreeNotations.
+Local Open Scope itree.
+
+(** ** Divergence * *)
+
+Inductive may_divergeF {E X} (P : itree E X -> Prop) : itree' E X -> Prop :=
+  | DivTau : forall (t : itree E X), P t -> may_divergeF P (TauF t)
+  | DivVis : forall {A} (k : A -> itree E X) (e: E A), (forall (a : A), P (k a)) -> may_divergeF P (VisF e k).
+Hint Constructors may_divergeF.
+
+Definition may_diverge_ {E X} sim :=
+  fun t1 => @may_divergeF E X sim (observe t1).
+Hint Unfold may_diverge_.
+
+Lemma may_divergeF_mono {E X} sim sim' x0
+      (IN: may_divergeF sim x0)
+      (LE: sim <1= sim'):
+  @may_divergeF E X sim' x0.
+Proof.
+  intros. induction IN; eauto.
+Qed. 
+
+Lemma may_divergeF__mono {E X} :
+  monotone1 (@may_diverge_ E X).
+Proof.
+  do 2 red. intros. eapply may_divergeF_mono; eauto.
+Qed. 
+Hint Resolve may_divergeF__mono : paco.
+
+Definition may_diverge {E A} : itree E A -> Prop :=
+  paco1 (@may_diverge_ E A) bot1.
+
+Instance may_diverge_proper_eutt {E X R} : Proper (eutt R ==> iff) (@may_diverge E X).
+Proof.
+  repeat intro. split.
+  - revert x y H. pcofix CH. intros.
+    punfold H0. unfold_eqit. pfold. red. punfold H1. red in H1.
+    induction H0.
+    + inversion H1.
+    + apply DivTau. inversion H1; subst. right. eapply CH.
+      red in H0. pclearbot. apply REL.
+      pclearbot. apply H0.
+    + inversion H1; subst. dependent destruction H3. eapply DivVis. 
+      pclearbot. right. eapply CH. apply REL. eapply H0.
+    + apply IHeqitF. inversion H1; subst.
+      pclearbot. punfold H2.
+    + econstructor. left. pfold. red.
+      apply IHeqitF. apply H1.
+  - revert x y H. pcofix CH. intros.
+    punfold H0. unfold_eqit. pfold. red. punfold H1. red in H1.
+    induction H0.
+    + inversion H1.
+    + apply DivTau. inversion H1; subst. right. eapply CH.
+      red in H0. pclearbot. apply REL.
+      pclearbot. apply H0.
+    + inversion H1; subst. dependent destruction H3. eapply DivVis.
+      pclearbot. right. eapply CH. apply REL. eapply H0.
+    + econstructor. left. pfold. red.
+      apply IHeqitF. apply H1.
+    + apply IHeqitF. inversion H1; subst.
+      pclearbot. punfold H2.
+Qed.
+
+Theorem spin_diverge {E A} : @may_diverge E A ITree.spin.
+Proof.
+  unfold may_diverge, ITree.spin.
+  pcofix H. pfold. constructor. right. apply H.
+Qed. 
+
+Variant must_divergeF {E : Type -> Type} {A : Type} (F : itree E A -> Prop) : itree' E A -> Prop :=
+  | MDivTau (t : itree E A) : F t -> must_divergeF F (TauF t)
+  | MDivVis (B : Type) (k : B -> itree E A) (e : E B) :
+      (forall b, F (k b)) -> must_divergeF F (VisF e k).
+Hint Constructors must_divergeF.
+
+Definition must_diverge_ {E A} (sim : itree E A -> Prop) t := must_divergeF sim (observe t).
+
+Lemma must_divergeF_mono {E A} (sim sim' : itree E A -> Prop) t
+      (IN : must_divergeF sim t)
+      (LE : sim <1= sim') : must_divergeF sim' t.
+Proof.
+  induction IN; eauto.
+Qed.
+
+Lemma must_divergeF_mono' {E A} : monotone1 (@must_diverge_ E A).
+Proof.
+  unfold must_diverge_.
+  red. intros. eapply must_divergeF_mono; eauto.
+Qed.
+Hint Resolve must_divergeF_mono' : paco.
+
+Definition must_diverge {E A} := paco1 (@must_diverge_ E A) bot1.
+
+Inductive may_converge {E : Type -> Type} {A : Type} (a : A) : itree E A -> Prop :=
+| conv_ret (t : itree E A) : t ≈ Ret a -> may_converge a t
+| conv_vis (t : itree E A ) {B : Type} (e : E B) (k : B -> itree E A) (b : B) :
+    t ≈ Vis e k -> may_converge a (k b) -> may_converge a t.
+Hint Constructors may_converge.
+
+Global Instance eutt_proper_con_converge {A E} {a : A} : Proper (eutt eq ==> iff) (@may_converge E _ a).
+Proof.
+  intros t1 t2 Ht. split; intros.
+  - induction H.
+    + apply conv_ret; auto. rewrite <- Ht. auto.
+    + eapply conv_vis; eauto. rewrite <- H.
+      symmetry. auto.
+  - induction H.
+    + apply conv_ret; auto. rewrite Ht. auto.
+    + eapply conv_vis; eauto. rewrite Ht.
+      eauto.
+Qed.
+
+Ltac contra_void := try match goal with | a : void |- _ => contradiction end.
+
+Global Instance eutt_proper_must_diverge {E A R} : Proper (eutt R ==> iff) (@must_diverge E A).
+Proof.
+  intros t1 t2 Ht. split.
+  - revert t1 t2 Ht. pcofix CIH. intros t1 t2 Ht Hdiv.
+    punfold Ht. unfold_eqit. pfold. red. punfold Hdiv. red in Hdiv.
+    induction Ht.
+    + inversion Hdiv.
+    + constructor. inversion Hdiv. subst. right.
+      pclearbot.
+      eapply CIH; eauto.
+    + constructor. inversion Hdiv. subst. ddestruction.
+      subst. intros. right. inversion Hdiv. ddestruction.
+      subst. pclearbot. eapply CIH; eauto. apply H1.
+    + apply IHHt. inversion Hdiv. subst. pclearbot. punfold H0.
+    + constructor. left. pfold. apply IHHt. auto.
+  - revert t1 t2 Ht. pcofix CIH. intros t1 t2 Ht Hdiv.
+    punfold Ht. unfold_eqit. pfold. red. punfold Hdiv. red in Hdiv.
+    induction Ht.
+    + inversion Hdiv.
+    + constructor. inversion Hdiv. subst. right.
+      pclearbot.
+      eapply CIH; eauto.
+    + constructor. inversion Hdiv. subst. ddestruction.
+      subst. intros. right. inversion Hdiv. subst. ddestruction.
+      subst. pclearbot. eapply CIH; eauto. apply H1.
+    +  constructor. left. pfold. apply IHHt. auto.
+    +  apply IHHt. inversion Hdiv. subst. pclearbot. punfold H0.
+Qed.
+
+Lemma not_converge_to_must_diverge : forall (E : Type -> Type) (A : Type) (t : itree E A),
+    (forall a, ~ may_converge a t) -> must_diverge t.
+Proof.
+  intros E A. pcofix CIH. intros t Hcon. pfold.
+  red. destruct (observe t) eqn : Heq;
+         specialize (itree_eta t) as Ht; rewrite Heq in Ht.
+  - exfalso. apply (Hcon r0). rewrite Ht. constructor. reflexivity.
+  - constructor. right. apply CIH.
+    setoid_rewrite Ht in Hcon. setoid_rewrite tau_eutt in Hcon.
+    auto.
+  - constructor. right. apply CIH.
+    intros a Hcontra. setoid_rewrite Ht in Hcon.
+    apply (Hcon a). eapply conv_vis; try reflexivity; eauto.
+Qed.
+
+Lemma classic_converge : forall (E : Type -> Type) (A : Type) (t : itree E A),
+    (exists a, may_converge a t) \/ must_diverge t.
+Proof.
+  intros. destruct (classic (exists a, may_converge a t) ); auto.
+  right. apply not_converge_to_must_diverge. intros a Hcontra.
+  apply H. exists a. auto.
+Qed.
+
+Lemma must_diverge_not_converge : forall (E : Type -> Type) (R : Type) (t : itree E R) (r : R),
+    may_converge r t -> ~ must_diverge t.
+Proof.
+  intros E R t r Hc Hd. induction Hc.
+  - rewrite H in Hd. pinversion Hd.
+  - apply IHHc. rewrite H in Hd. pinversion Hd.
+    ddestruction. subst.
+    apply H1.
+Qed.

--- a/theories/Props/EuttDiv.v
+++ b/theories/Props/EuttDiv.v
@@ -1,0 +1,172 @@
+From Coq Require Import
+     Morphisms
+.
+
+From ITree Require Import
+     Axioms
+     ITree
+     ITreeFacts
+     Props.Divergence
+.
+
+From Paco Require Import paco.
+
+Import Monads.
+Import MonadNotation.
+Local Open Scope monad_scope.
+
+(** Defines eutt_div, a relation for relating ITrees 
+    over different return types, that never return and whose events are bisimilar. Also contains div_cast, a function that casts ITrees that never return from one return type to another while preserving its events.
+*)
+
+Definition eutt_div {E} {A B : Type} (ta : itree E A) (tb : itree E B) := 
+  eutt (fun a b => False) ta tb.
+
+
+Lemma eutt_div_spin : forall (E : Type -> Type) (A B : Type), @eutt_div E A B ITree.spin ITree.spin.
+Proof.
+  intros. pcofix CIH. pfold. red. cbn. constructor. right.
+  eauto.
+Qed.
+
+Lemma div_bind_nop : forall (E : Type -> Type) (A B : Type) (t : itree E A) (f : A -> itree E B),
+    must_diverge t -> eutt_div t (t >>= f).
+Proof.
+  intros. einit. generalize dependent t. ecofix CIH. intros t Hdivt. pinversion Hdivt.
+  - specialize (itree_eta t) as Ht. rewrite <- H in Ht.
+    cbn. rewrite Ht.
+    assert (ITree.bind (Tau t0) f ≅ Tau (ITree.bind t0 f)); try apply bind_tau.
+    setoid_rewrite H1. etau.
+  - specialize (itree_eta t) as Ht. rewrite <- H in Ht.
+    cbn. rewrite Ht. rewrite bind_vis. evis. intros.
+    apply euttG_base. left. apply CIHH. apply H0.
+Qed.   
+
+Lemma eutt_div_subrel : forall (E : Type -> Type) (A B : Type) (R : A -> B -> Prop) 
+                               (ta : itree E A) (tb : itree E B), 
+    eutt_div ta tb -> eutt R ta tb.
+Proof.
+  intros.
+  eapply eutt_subrel with (R1 := fun a b => False); tauto.
+Qed.
+
+
+Lemma eutt_imp_div : forall (E : Type -> Type) (A B : Type) (R : A -> B -> Prop) 
+                            (ta : itree E A) (tb : itree E B),
+    must_diverge ta -> eutt R ta tb -> eutt_div ta tb.
+Proof.
+  (* oddly had trouble doing this with euttG, maybe I should reread the gpaco paper*)
+  intros E A B R. pcofix CIH. pstep. intros ta tb Hdiv Heutt.
+  punfold Heutt. unfold_eqit. dependent induction Heutt; pclearbot.
+  - exfalso. clear CIH. specialize (itree_eta ta) as Hta.
+    rewrite <- x0 in Hta. rewrite Hta in Hdiv. pinversion Hdiv.
+  - rewrite <- x0. rewrite <- x. constructor. right.
+    assert (m1 ≈ ta).
+    { specialize (itree_eta ta) as Hta. rewrite <- x0 in Hta.
+      rewrite Hta. rewrite tau_eutt. reflexivity. }
+    assert (m2 ≈ tb).
+    { specialize (itree_eta tb) as Htb. rewrite <- x in Htb.
+      rewrite Htb. rewrite tau_eutt. reflexivity. }
+    apply CIH; auto.
+    rewrite H. auto.
+  - rewrite <- x0. rewrite <- x. constructor.
+    intros. right. apply CIH; auto.
+    specialize (itree_eta ta) as Hta. rewrite <- x0 in Hta.
+    rewrite Hta in Hdiv. pinversion Hdiv.
+    dependent destruction H2. apply H0.
+  - rewrite <- x. constructor; auto. eapply IHHeutt; eauto.
+    assert (t1 ≈ ta).
+    { specialize (itree_eta ta) as Hta. rewrite <- x in Hta.
+      rewrite Hta. rewrite tau_eutt. reflexivity. }
+    rewrite H. auto.
+  - rewrite <- x. constructor; auto.
+Qed.
+     
+Lemma eutt_div_imp_div : forall (E : Type -> Type) (A B : Type) (t1 : itree E A) (t2 : itree E B),
+    eutt_div t1 t2 -> must_diverge t1.
+Proof.
+  intros A B. pcofix CIH. intros. pfold. red.
+  punfold H0.
+  unfold_eqit.
+  dependent induction H0; try contradiction; pclearbot.
+  - rewrite <- x0. constructor. right. eapply CIH; eauto.
+  - rewrite <- x0. constructor. intros. right. eapply CIH; eauto. eapply REL.
+  - rewrite <- x. constructor. right. eapply CIH with (t2 := t2); eauto. 
+    pfold. auto.
+  -  eapply IHeqitF; eauto.
+Qed.
+
+
+Lemma eutt_div_sym : forall (E : Type -> Type) (A B : Type) (t1 : itree E A) (t2 : itree E B),
+    eutt_div t1 t2 -> eutt_div t2 t1.
+Proof.
+  intros E A B. pcofix CIH. intros. pfold. red.
+  punfold H0. unfold_eqit.
+  dependent induction H0; try contradiction; pclearbot.
+  - rewrite <- x0. rewrite <- x. constructor. right. auto.
+  - rewrite <- x0. rewrite <- x. constructor. intros. unfold id.
+    right. apply CIH. apply REL.
+  - rewrite <- x. constructor; auto.
+  - rewrite <- x. constructor; auto.
+Qed.
+
+Lemma must_diverge_bind : forall (E : Type -> Type) (R U: Type) (t : itree E R) 
+                                 (f : R -> itree E U),
+    must_diverge t -> must_diverge (bind t f).
+Proof.
+  intros. apply div_bind_nop with (B := U) (f := f) in H.
+  apply eutt_div_sym in H. apply eutt_div_imp_div in H. auto.
+Qed.
+     
+Lemma eutt_div_trans : forall (E : Type -> Type) (A B C : Type) (t1 : itree E A) 
+                              (t2 : itree E B) (t3 : itree E C),
+    eutt_div t1 t2 -> eutt_div t2 t3 -> eutt_div t1 t3.
+Proof.
+  intros. unfold eutt_div in *.
+  apply eutt_subrel with (R1 := @rcompose A B C (fun a b => False) (fun b c => False) ).
+  - intros. inversion H1; contradiction.
+  - eapply eqit_trans; eauto.
+Qed.
+
+
+Global Instance proper_eutt_div {E A B} {R R'} : Proper ( (@eutt E A A R) ==> (@eutt E B B R') ==> iff) (eutt_div).
+Proof.
+  intros t1 t2 Ht12 t3 t4 Ht34. split; intros.
+  - apply eutt_div_imp_div in H as Ht1. apply eutt_div_sym in H. 
+    apply eutt_div_imp_div in H as Ht3.
+    apply eutt_div_trans with (t2 := t3).
+    + apply eutt_div_trans with (t2 := t1).
+      * apply eutt_div_sym. eapply eutt_imp_div; eauto.
+      * apply eutt_div_sym. auto.
+    + eapply eutt_imp_div; eauto.
+  - apply eutt_div_imp_div in H as Ht2. 
+    apply eutt_div_sym in H. apply eutt_div_imp_div in H as Ht3.
+    assert (eutt_div t1 t2).
+    { 
+      apply eutt_div_sym. apply eutt_flip in Ht12. 
+      eapply eutt_imp_div; eauto.
+    }
+    assert (eutt_div t3 t4).
+    {
+      apply eutt_div_sym. apply eutt_flip in Ht34.
+      eapply eutt_imp_div; eauto.
+    }
+    apply eutt_div_sym in H.
+    apply eutt_div_trans with (t2 := t4).
+    + apply eutt_div_trans with (t2 := t2); auto.
+    + apply eutt_div_sym. auto.
+Qed.
+
+Definition div_cast {E A B} (t : itree E A) : itree E B :=
+  t >>= fun _ => ITree.spin.
+
+Lemma div_cast_nop : forall (E : Type -> Type) (A : Type) (t : itree E A),
+    must_diverge t -> t ≈ div_cast t.
+Proof.
+  intros. apply eutt_div_subrel. apply div_bind_nop. auto.
+Qed.
+
+Global Instance proper_div_cast {E R1 R2} : Proper (@eutt E R1 R1 eq ==> @eutt E R2 R2 eq) div_cast.
+Proof.
+  intros t1 t2 Heutt. unfold div_cast. cbn. rewrite Heutt. reflexivity.
+Qed.

--- a/tutorial/Asm.v
+++ b/tutorial/Asm.v
@@ -54,6 +54,10 @@ Variant instr : Set :=
 | Iadd   (dest : reg) (src : reg) (o : operand)
 | Isub   (dest : reg) (src : reg) (o : operand)
 | Imul   (dest : reg) (src : reg) (o : operand)
+| IEq    (dest : reg) (src : reg) (o : operand)
+| ILe    (dest : reg) (src : reg) (o : operand)
+| IAnd   (dest : reg) (src : reg) (o : operand)
+| INot   (dest : reg) (o : operand)
 | Iload  (dest : reg) (addr : addr)
 | Istore (addr : addr) (val : operand).
 
@@ -182,12 +186,27 @@ Section Denote.
         lv <- trigger (GetReg l) ;;
         rv <- denote_operand r ;;
         trigger (SetReg d (lv * rv))
+      | IEq d l r =>
+        lv <- trigger (GetReg l) ;;
+        rv <- denote_operand r ;;
+        trigger (SetReg d (if Nat.eqb lv rv then 1 else 0))
+      | ILe d l r =>
+        lv <- trigger (GetReg l) ;;
+        rv <- denote_operand r ;;
+        trigger (SetReg d (if Nat.leb lv rv then 1 else 0))
+      | INot d r =>
+        rv <- denote_operand r ;;
+        trigger (SetReg d (match rv with | 0 => 1 | _ => 0 end))
+      | IAnd d l r =>
+        lv <- trigger (GetReg l) ;;
+        rv <- denote_operand r ;;
+        trigger (SetReg d (match lv,rv with | 0,0 | 0,1 | 1,0 => 0 | _,_ => 1 end))
       | Iload d addr =>
         val <- trigger (Load addr) ;;
-        trigger (SetReg d val)
+            trigger (SetReg d val)
       | Istore addr v =>
         val <- denote_operand v ;;
-        trigger (Store addr val)
+            trigger (Store addr val)
       end.
 
     (** A [branch] returns the computed label whose set of possible values [B]

--- a/tutorial/AsmOptimization.v
+++ b/tutorial/AsmOptimization.v
@@ -144,13 +144,12 @@ Proof.
   }
   intros.
   inversion H; subst.
-  inversion H3. subst.
+  inversion H3; subst.
   unfold interp_asm.
   unfold interp_map.
   rewrite interp_ret.
   do 2 rewrite interp_state_ret.
-  apply eqit_Ret. constructor. auto. destruct b3.
-  assumption.
+  apply eqit_Ret. destruct b3. auto.
 Qed.
 
 Lemma interp_asm_ret {E A} (x:A) mem reg :
@@ -273,6 +272,16 @@ Proof.
   rewrite bind_vis, interp_state_vis. cbn. rewrite !bind_ret_l, !tau_eutt.
   rewrite interp_state_ret, bind_ret_l; cbn.
   reflexivity.
+Qed.
+
+Lemma interp_state_iter' {E F } S (f : E ~> Monads.stateT S (itree F)) {I A}
+      (t  : I -> itree E (I + A))
+  : forall i, state_eq (State.interp_state f (ITree.iter t i))
+                       (Basics.iter (fun i => State.interp_state f (t i)) i).
+Proof.
+  eapply interp_state_iter.
+  intros i.
+  red. reflexivity.
 Qed.
 
 (* peephole optimizations --------------------------------------------------- *)

--- a/tutorial/_CoqProject.make
+++ b/tutorial/_CoqProject.make
@@ -14,5 +14,4 @@ Imp2Asm.v
 Imp2AsmCorrectness.v
 AsmOptimization.v
 PrintAssumptions.v
-
 extract-imptest/ImpTest.v


### PR DESCRIPTION
One of 3 partial commits to bring the secure branch into master. This branch adds the ITraces, a linear, coinductive trace data type built on top of ITrees. ITraces are implemented as ITrees over a specialized event type family. This branch introduces a trace refinement relation, creating a trace model for ITrees that is proven sound and complete over eutt.

(Note that the Coq 8.13 + make build is breaking on this pull request. However, the dijkstra_pull_request and secure branches do not have this problem, so it is probably not worth tracking down)