### PR TITLE
Secure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,9 +67,6 @@ workflows:
   build:
     jobs:
     - test:
-        name: "Coq 8.12"
-        coq: "8.12"
-    - test:
         name: "Coq 8.13"
         coq: "8.13"
     - test:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: clean all coq test tests examples tutorial hoare_example install uninstall depgraph for-dune
+.PHONY: clean all coq test tests examples tutorial hoare_example secure_example install uninstall depgraph for-dune
 
 COQPATHFILE=$(wildcard _CoqPath)
 
@@ -11,6 +11,7 @@ all:
 	$(MAKE) coq
 	$(MAKE) test
 	$(MAKE) hoare_example
+	$(MAKE) secure_example
 
 install: Makefile.coq coq
 	$(MAKE) -f $< $@
@@ -33,6 +34,8 @@ tutorial:
 hoare_example:
 	$(MAKE) -C hoare_example
 
+secure_example:
+	$(MAKE) -C secure_example
 
 clean: clean-coq
 	$(RM) _CoqProject
@@ -40,6 +43,7 @@ clean: clean-coq
 	$(MAKE) -C examples clean
 	$(MAKE) -C tutorial clean
 	$(MAKE) -C hoare_example clean
+	$(MAKE) -C secure_example clean
 
 _CoqProject: $(COQPATHFILE) _CoqConfig Makefile
 	@ echo "# Generating _CoqProject"

--- a/_CoqConfig
+++ b/_CoqConfig
@@ -90,3 +90,17 @@ theories/Dijkstra/StateDelaySpec.v
 theories/Dijkstra/TracesIT.v
 theories/Dijkstra/ITreeDijkstra.v
 theories/Dijkstra/StateIOTrace.v
+
+theories/Secure/Labels.v
+theories/Secure/StrongBisimProper.v
+theories/Secure/SecureEqHalt.v
+theories/Secure/SecureEqHaltProgInsens.v
+theories/Secure/SecureEqEuttHalt.v
+theories/Secure/SecureEqEuttTrans.v
+theories/Secure/SecureEqWcompat.v
+theories/Secure/SecureEqBind.v
+
+theories/Secure/SecureEqProgInsens.v
+theories/Secure/SecureEqProgInsensFacts.v
+theories/Secure/SecureStateHandler.v
+theories/Secure/SecureStateHandlerPi.v

--- a/hoare_example/ImpHoare.v
+++ b/hoare_example/ImpHoare.v
@@ -338,27 +338,28 @@ Proof.
     + unfold reassoc. unfold body.
       destruct (eutt_reta_or_div (interp_imp (denote_com c) s ) );
       destruct (classic_bool b s); basic_solve.
-      *  do 4 red in H1. unfold interp_imp, interp_map in H1.
-         destruct a as [s'' [] ].
-         eapply Hq.
-         -- cbn. setoid_rewrite bind_bind. rewrite H1.
-            setoid_rewrite bind_ret_l. simpl.
-            setoid_rewrite bind_bind. rewrite <- H0.
-            tau_steps. reflexivity.
-         -- unfold q. left. exists s''. left. reflexivity.
-      * do 4 red in H1. unfold interp_imp, interp_map in H1.
+      * do 2 red in H1. unfold interp_imp, interp_map in H1.
+        destruct a as [s'' [] ].
+        eapply Hq.
+        -- cbn. setoid_rewrite bind_bind.
+           rewrite H1.
+           setoid_rewrite bind_ret_l. simpl.
+           setoid_rewrite bind_bind. rewrite <- H0.
+           tau_steps. reflexivity.
+        -- unfold q. left. exists s''. left. reflexivity.
+      * do 2 red in H1. unfold interp_imp, interp_map in H1.
         destruct a as [s'' [] ].
         eapply Hq.
         -- cbn. rewrite H1. setoid_rewrite bind_bind. setoid_rewrite bind_ret_l.
            simpl. tau_steps. reflexivity.
         -- unfold q. left. exists s. right. split; auto. reflexivity.
-      * do 4 red in H1. unfold interp_imp, interp_map in H1.
+      * do 2 red in H1. unfold interp_imp, interp_map in H1.
         eapply Hq.
         -- cbn. rewrite H1. setoid_rewrite bind_bind. setoid_rewrite bind_ret_l.
            simpl. apply div_spin_eutt in H0. rewrite H0. setoid_rewrite bind_bind.
            rewrite <- spin_bind. reflexivity.
         -- red. right. apply spin_diverge.
-      * do 4 red in H1. unfold interp_imp, interp_map in H1.
+      * do 2 red in H1. unfold interp_imp, interp_map in H1.
         eapply Hq.
         -- cbn. rewrite H1. setoid_rewrite bind_bind. setoid_rewrite bind_ret_l.
            simpl. apply div_spin_eutt in H0.
@@ -382,30 +383,30 @@ Proof.
       try (destruct (eutt_reta_or_div (interp_imp (denote_com c) s0 ) )); basic_solve.
     * eapply Hq.
       -- cbn. rewrite H0. setoid_rewrite bind_ret_l.
-         setoid_rewrite bind_bind. do 4 red in H1. unfold interp_imp, interp_map in H1.
+         setoid_rewrite bind_bind. do 2 red in H1. unfold interp_imp, interp_map in H1.
          rewrite H1. setoid_rewrite bind_ret_l. simpl.
          destruct a as [s1 [] ]. rewrite <- H2. setoid_rewrite bind_bind.
          setoid_rewrite bind_ret_l. simpl. tau_steps. reflexivity.
       -- red. left. destruct a as [s'' [] ]. exists s''. left. reflexivity.
     * eapply Hq.
       -- cbn. rewrite H0. setoid_rewrite bind_ret_l. setoid_rewrite bind_bind.
-         do 4 red in H1. unfold interp_imp, interp_map in H1. rewrite H1.
+         do 2 red in H1. unfold interp_imp, interp_map in H1. rewrite H1.
          setoid_rewrite bind_ret_l. simpl. apply div_spin_eutt in H2. rewrite H2.
          setoid_rewrite bind_bind. rewrite <- spin_bind. reflexivity.
       -- right. apply spin_diverge.
     * destruct a as [s'' [] ]. eapply Hq.
       -- cbn.  rewrite H0. setoid_rewrite bind_ret_l.
-         do 4 red in H1. unfold interp_imp, interp_map in H1. rewrite H1.
+         do 2 red in H1. unfold interp_imp, interp_map in H1. rewrite H1.
          setoid_rewrite bind_bind. setoid_rewrite bind_ret_l. simpl. tau_steps. reflexivity.
       -- left. exists s0. right. split; auto. reflexivity.
     * eapply Hq.
       -- cbn.  rewrite H0. setoid_rewrite bind_ret_l.
-         do 4 red in H1. unfold interp_imp, interp_map in H1. rewrite H1.
+         do 2 red in H1. unfold interp_imp, interp_map in H1. rewrite H1.
          setoid_rewrite bind_bind. setoid_rewrite bind_ret_l. simpl. tau_steps. reflexivity.
       -- left. exists s0. right. split; auto. reflexivity.
-    * do 4 red in H1. do 4 red in H2. rewrite H1 in H2.
+    * do 2 red in H1. do 2 red in H2. rewrite H1 in H2.
       apply eutt_inv_Ret in H2. injection H2. discriminate.
-    * do 4 red in H1. do 4 red in H2. rewrite H1 in H2.
+    * do 2 red in H1. do 2 red in H2. rewrite H1 in H2.
       apply eutt_inv_Ret in H2. injection H2. discriminate.
     * eapply Hq.
       -- cbn.  rewrite H0. setoid_rewrite bind_ret_l.  reflexivity.
@@ -503,7 +504,7 @@ Proof.
           destruct (eutt_reta_or_div (interp_imp (denote_com c) s'' )); basic_solve;
         eapply Hq.
         -- rewrite <- H0. setoid_rewrite bind_ret_l.
-           setoid_rewrite bind_bind. do 4 red in H1.
+           setoid_rewrite bind_bind. do 2 red in H1.
            unfold interp_imp, interp_map in H1. rewrite H1. setoid_rewrite bind_ret_l.
            simpl. setoid_rewrite bind_bind.
            rewrite <- H2. setoid_rewrite bind_ret_l. destruct a as [s3 [] ].
@@ -516,7 +517,7 @@ Proof.
            ++ rewrite H3 in H0. cbn in *; basic_solve; pinversion H0; try discriminate; basic_solve.
            ++ rewrite <- H0 in H3. pinversion H3.
         -- rewrite <- H0. setoid_rewrite bind_ret_l. setoid_rewrite bind_bind.
-           do 4 red in H1. unfold interp_imp, interp_map in H1. rewrite H1.
+           do 2 red in H1. unfold interp_imp, interp_map in H1. rewrite H1.
            setoid_rewrite bind_ret_l. simpl. apply div_spin_eutt in H2.
            setoid_rewrite bind_bind. rewrite H2.
            rewrite <- spin_bind. reflexivity.
@@ -532,7 +533,7 @@ Proof.
            ++ rewrite <- H0 in H3. pinversion H3.
         -- rewrite <- H0. setoid_rewrite bind_ret_l.
            setoid_rewrite bind_bind.
-           do 4 red in H1. unfold interp_imp, interp_map in H1.
+           do 2 red in H1. unfold interp_imp, interp_map in H1.
            rewrite H1. setoid_rewrite bind_ret_l. simpl. tau_steps.
            reflexivity.
         -- unfold q. left. exists s''.
@@ -851,7 +852,7 @@ Section SQRTEx.
     destruct (lookup_default i 0 s * lookup_default i 0 s =? lookup_default n 0 s); simpl.
     - tau_steps. reflexivity.
     - unfold denote_imp. rewrite compute_assign_sc_tree. rewrite bind_ret_l.
-      cbn. tau_steps. rewrite plus_comm. reflexivity.
+      cbn. tau_steps. rewrite Nat.add_comm. reflexivity.
   Qed.
 
   Let body_arrow (s : env) : Delay (env * (unit + unit) ) :=

--- a/secure_example/CatTheory.v
+++ b/secure_example/CatTheory.v
@@ -1,0 +1,63 @@
+(* begin hide *)
+From Coq Require Import
+     Morphisms.
+
+From ITree Require Import
+     Basics.Category
+     Basics.CategorySub.
+
+Require Import SecureExample.KTreeFin.
+
+Import CatNotations.
+Local Open Scope cat.
+(* end hide *)
+
+Section CategoryTheory.
+
+  Context
+    {obj : Type} {C : obj -> obj -> Type}
+    {bif : obj -> obj -> obj}
+    {Eq2_C : Eq2 C}
+    `{forall a b, Equivalence (eq2 (a := a) (b := b))}
+    `{Category obj C (Eq2C := _)}
+    `{Coproduct obj C (Eq2_C := _) (Cat_C := _) bif}.
+
+  Lemma aux_app_asm_correct1 (I J A B : obj) :
+    (assoc_r >>>
+       bimap (id_ I) (assoc_l >>> bimap swap (id_ B) >>> assoc_r) >>>
+       assoc_l)
+    ⩯ bimap swap (id_ (bif A B)) >>>
+      (assoc_r >>>
+      (bimap (id_ J) assoc_l >>>
+      (assoc_l >>> (bimap swap (id_ B) >>> assoc_r)))).
+  Proof. cat_auto. Qed.
+
+  Lemma aux_app_asm_correct2 (I J B D : obj) :
+    (assoc_r >>>
+             bimap (id_ I) (assoc_l >>> bimap swap (id_ D) >>> assoc_r) >>>
+             assoc_l)
+      ⩯ assoc_l >>>
+      (bimap swap (id_ D) >>>
+             (assoc_r >>>
+                      (bimap (id_ J) assoc_r >>>
+                             (assoc_l >>> bimap swap (id_ (bif B D)))))).
+  Proof. cat_auto. Qed.
+
+End CategoryTheory.
+
+(** [(A + B) + (C + D) -> (A + C) + (B + D)]*)
+Notation swap4 :=
+(assoc_r >>> bimap (id_ _) (assoc_l >>> bimap swap (id_ _) >>> assoc_r) >>> assoc_l).
+
+Lemma subpure_swap4 {E A B C D} :
+  subpure (E := E) (n := (A + B) + (C + D)) swap4 ⩯ swap4.
+Proof.
+  rewrite !fmap_cat0, !fmap_assoc_r, !fmap_assoc_l.
+  do 2 (apply category_proper_cat; try reflexivity).
+  rewrite fmap_bimap, fmap_id0.
+  rewrite fmap_cat0.
+  apply (bifunctor_proper_bimap _ _); try reflexivity.
+  rewrite fmap_cat0, fmap_assoc_l, fmap_assoc_r, fmap_bimap.
+  rewrite fmap_swap, fmap_id0.
+  reflexivity.
+Qed.

--- a/secure_example/Fin.v
+++ b/secure_example/Fin.v
@@ -1,0 +1,224 @@
+(** * Finite types *)
+
+(* [fin n : Type] is a type with [n] inhabitants. It is isomorphic to
+   [Coq.Vector.Fin.t] from the standard library, but we found this formulation
+   easier to reason about. *)
+
+(* In this compiler, we use [fin n] as the type of "block labels" in [Asm]
+   programs (program locations that can be jumped to). In an earlier version, labels
+   could be any type, but this restriction makes [Asm] programs easier to introspect
+   for defining optimizations (though the current development doesn't make use of it).
+  *)
+
+(* The instances at the end derive categorical operations for the subcategories of
+   [Fun] and [ktree] on finite types (instead of arbitrary types). *)
+
+(* begin hide *)
+From Coq Require Import
+     Arith
+     Lia.
+
+From ITree Require Import
+     ITree
+     ITreeFacts
+     Basics.Category
+     Basics.CategorySub.
+(* end hide *)
+
+(* Type with [n] inhabitants. *)
+Definition fin (n : nat) : Type := { x : nat | x < n }.
+
+(* Hide proof terms. *)
+(* N.B.: [x < n] unfolds to [S x < n], which is why we don't make the first
+   field more precise. *)
+Notation fi' i := (exist (fun j : nat => _) i _).
+
+Program Definition f0 {n} : fin (S n) := fi' 0.
+Next Obligation. lia. Defined.
+
+Lemma unique_fin : forall n (i j : fin n),
+    proj1_sig i = proj1_sig j -> i = j.
+Proof.
+  intros ? [] [] w. simpl in w; destruct w. f_equal; apply le_unique.
+Qed.
+
+Lemma unique_f0 : forall (a : fin 1), a = f0.
+Proof.
+  destruct a. apply unique_fin; simpl. lia.
+Qed.
+
+Program Definition fS {n} : fin n -> fin (S n) :=
+  fun i => fi' (S (proj1_sig i)).
+Next Obligation.
+  destruct i; simpl; lia.
+Defined.
+
+Lemma fin_0 {A} : fin 0 -> A.
+Proof.
+  intros [].
+  apply PeanoNat.Nat.nlt_0_r in l.
+  contradiction.
+Qed.
+
+Instance FinInitial {E} : Initial (sub (ktree E) fin) 0 := fun _ => fin_0.
+
+Lemma split_fin_helper:
+  forall n m x : nat, x < n + m -> ~ x < n -> x - n < m.
+Proof.
+  intros n m x l n0.
+  lia.
+Defined.
+
+Program Definition split_fin_sum (n m : nat)
+  : fin (n + m) -> (fin n) + (fin m) := fun x =>
+    match lt_dec (proj1_sig x) n with
+    | left _ => inl (fi' (proj1_sig x))
+    | right _ => inr (fi' (proj1_sig x - n))
+    end.
+Next Obligation.
+  apply split_fin_helper. eapply proj2_sig. assumption.
+Defined.
+
+Program Definition L {n} (m : nat) (a : fin n) : fin (n + m) := _.
+Next Obligation.
+  destruct a.
+  exists x. apply PeanoNat.Nat.lt_lt_add_r.  assumption.
+Defined.
+
+Program Definition R {m} (n:nat) (a:fin m) : fin (n + m) := _.
+Next Obligation.
+  destruct a.
+  exists (n + x). lia.
+Defined.
+
+Lemma R_0_a : forall (n:nat) (a : fin n), R 0 a = a.
+Proof.
+  intros; destruct a; apply unique_fin; reflexivity.
+Qed.
+
+Lemma R_1_a : forall (n:nat) (a : fin n), R 1 a = fS a.
+Proof.
+  intros; destruct a; apply unique_fin; reflexivity.
+Qed.
+
+Lemma split_fin_sum_0_a : forall m (a : fin (0 + m)),
+    (@split_fin_sum 0 m a) = inr a.
+Proof.
+  intros.
+  unfold split_fin_sum, split_fin_sum_obligation_1.
+  destruct (Compare_dec.lt_dec _ 0) as [H | H].
+  - inversion H.
+  - f_equal. destruct a; apply unique_fin. simpl; lia.
+Qed.
+
+Lemma split_fin_sum_FS_inr :
+  (@split_fin_sum (S O) (S O) (fS f0) = inr f0).
+Proof.
+  cbn; f_equal; apply unique_f0.
+Qed.
+
+Lemma split_fin_sum_f1_inl :
+  (@split_fin_sum 1 1 (@f0 1)) = inl f0.
+Proof.
+  cbn; f_equal; apply unique_f0.
+Qed.
+
+Lemma L_1_f1 : (L 1 (@f0 0)) = f0.
+Proof.
+  apply unique_fin; reflexivity.
+Qed.
+
+Lemma split_fin_sum_L_L_f1 :
+  (@split_fin_sum _ _ (L 1 (L 1 (@f0 0)))) = inl f0.
+Proof.
+  cbn; f_equal; apply unique_fin; reflexivity.
+Qed.
+
+Lemma split_fin_sum_R_2 : split_fin_sum 2 1 (R 2 (@f0 0)) = inr f0.
+Proof.
+  cbn; f_equal; apply unique_fin; reflexivity.
+Qed.
+
+Lemma split_fin_sum_R n m (x : fin m) : split_fin_sum n m (R n x) = inr x.
+Proof.
+  destruct x; simpl. unfold split_fin_sum; simpl.
+  destruct lt_dec.
+  - exfalso. lia.
+  - f_equal. apply unique_fin; simpl; lia.
+Qed.
+
+Lemma split_fin_sum_L n m (x : fin n) : split_fin_sum n m (L m x) = inl x.
+Proof.
+  destruct x; simpl. unfold split_fin_sum; simpl.
+  destruct lt_dec.
+  - f_equal. apply unique_fin; simpl; lia.
+  - exfalso. lia.
+Qed.
+
+Definition merge_fin_sum (n m: nat) : fin n + fin m -> fin (n + m) :=
+  fun v =>
+    match v with
+    | inl v => L m v
+    | inr v => R n v
+    end.
+
+Lemma merge_fin_sum_inr : (merge_fin_sum 1 1 (inr f0)) = (fS f0).
+Proof.
+  apply unique_fin; reflexivity.
+Qed.
+
+Lemma merge_fin_sum_inl_1 f : (merge_fin_sum 1 1 (inl f)) = f0.
+Proof.
+  rewrite (unique_f0 f); apply unique_fin; reflexivity.
+Qed.
+
+Lemma merge_split:
+  forall (n m : nat) (a : fin (n + m)), merge_fin_sum n m (split_fin_sum n m a) = a.
+Proof.
+  intros n m []. unfold split_fin_sum; simpl.
+  destruct (lt_dec x n); apply unique_fin; simpl; reflexivity + lia.
+Qed.
+
+Lemma split_merge:
+  forall (n m : nat) (a : fin n + fin m), split_fin_sum n m (merge_fin_sum n m a) = a.
+Proof.
+  intros n m [[] | []]; unfold split_fin_sum; simpl; destruct lt_dec; simpl;
+    try (f_equal; apply unique_fin; simpl; reflexivity + lia);
+    try contradiction + exfalso; lia.
+Qed.
+
+Instance ToBifunctor_ktree_fin {E} : ToBifunctor (ktree E) fin sum Nat.add :=
+  fun n m y => Ret (split_fin_sum n m y).
+
+Instance FromBifunctor_ktree_fin {E} : FromBifunctor (ktree E) fin sum Nat.add :=
+  fun n m y => Ret (merge_fin_sum n m y).
+
+Instance IsoBif_ktree_fin {E}
+  : forall a b, Iso (ktree E) (a := fin (Nat.add a b)) to_bif from_bif.
+Proof.
+  unfold to_bif, ToBifunctor_ktree_fin, from_bif, FromBifunctor_ktree_fin.
+  constructor; intros x.
+  - unfold cat, Cat_sub, Cat_Kleisli. cbn. rewrite bind_ret_l.
+    apply eqit_Ret, merge_split.
+  - unfold cat, Cat_sub, Cat_Kleisli. cbn. rewrite bind_ret_l.
+    apply eqit_Ret, split_merge.
+Qed.
+
+Instance ToBifunctor_Fun_fin : ToBifunctor Fun fin sum Nat.add :=
+  fun n m y => split_fin_sum n m y.
+
+Instance FromBifunctor_Fun_fin : FromBifunctor Fun fin sum Nat.add :=
+  fun n m y => merge_fin_sum n m y.
+
+Instance IsoBif_Fun_fin
+  : forall a b, Iso Fun (a := fin (Nat.add a b)) to_bif from_bif.
+Proof.
+  constructor; intros x.
+  - apply merge_split.
+  - apply split_merge.
+Qed.
+
+Instance InitialObject_ktree_fin {E} : InitialObject (sub (ktree E) fin) 0.
+Proof.
+  intros n f x; apply fin_0; auto.
+Qed.

--- a/secure_example/KTreeFin.v
+++ b/secure_example/KTreeFin.v
@@ -1,0 +1,122 @@
+(** * Subcategory of KTrees indexed by finite types *)
+
+(* Definition of the [subpure] function, mapping [sub Fun fin] (functions between finite
+   types) to [sub (ktree E) fin] (KTrees between finite types) and proves that
+   it commutes with the various combinators from [ITree.Basics.Category].
+ *)
+
+(* begin hide *)
+From Coq Require Import
+     Setoid
+     Morphisms.
+
+From ITree Require Import
+     ITree
+     ITreeFacts
+     Basics.CategorySub
+.
+
+Require Import Fin.
+
+Import CatNotations.
+Local Open Scope cat_scope.
+(* end hide *)
+
+(* General theory. Functors which preserve coproducts.
+   Here we assume that the functor's object mapping is the identity function.
+ *)
+Section CocartesianFunctor.
+
+Context
+  {obj : Type} {C D : obj -> obj -> Type}
+  {bif : obj -> obj -> obj}
+  `{Eq2 _ C} `{Case _ C bif} `{Inl _ C bif} `{Inr _ C bif}
+  `{Eq2 _ D} `{Case _ D bif} `{Inl _ D bif} `{Inr _ D bif}
+  {fmap : forall a b, C a b -> D a b}.
+
+Arguments fmap {a b}.
+
+Class CocartesianFunctor : Prop :=
+  { fmap_case : forall a b c (f : C a c) (g : C b c),
+      fmap (case_ f g) ⩯ case_ (fmap f) (fmap g)
+  ; fmap_inl : forall a b,
+      fmap (inl_ (a := a) (b := b)) ⩯ inl_
+  ; fmap_inr : forall a b,
+      fmap (inr_ (a := a) (b := b)) ⩯ inr_
+  }.
+
+Context
+  `{forall a b, Equivalence (eq2 (C := D) (a := a) (b := b))}
+  `{Id_ _ C} `{Cat _ C}
+  `{Id_ _ D} `{Cat _ D}
+  `{forall a b c, Proper (eq2 ==> eq2 ==> eq2) (cat (C := D) (a := a) (b := b) (c := c))}
+  `{@Coproduct _ D _ _ bif _ _ _}
+  `{@Functor _ _ C D (fun x => x) (@fmap) _ _ _ _ _ _}
+  `{CocartesianFunctor}.
+
+Lemma fmap_swap {n m}
+  : fmap swap ⩯ swap (a := n) (b := m).
+Proof.
+  unfold swap, Swap_Coproduct.
+  rewrite fmap_case, fmap_inl, fmap_inr.
+  reflexivity.
+Qed.
+
+Lemma fmap_bimap {n m p q} (f : C n m) (g : C p q)
+  : fmap (bimap f g) ⩯ bimap (fmap f) (fmap g).
+Proof.
+  unfold bimap, Bimap_Coproduct.
+  rewrite fmap_case, !fmap_cat0, fmap_inl, fmap_inr.
+  reflexivity.
+Qed.
+
+Lemma fmap_assoc_l {n m p}
+  : fmap (a := (bif n (bif m p))) assoc_l ⩯ assoc_l.
+Proof.
+  unfold assoc_l, AssocL_Coproduct.
+  rewrite !fmap_case, !fmap_cat0, !fmap_inl, !fmap_inr.
+  reflexivity.
+Qed.
+
+Lemma fmap_assoc_r {n m p}
+  : fmap (a := (bif (bif n m) p)) assoc_r ⩯ assoc_r.
+Proof.
+  unfold assoc_r, AssocR_Coproduct.
+  rewrite !fmap_case, !fmap_cat0, !fmap_inl, !fmap_inr.
+  reflexivity.
+Qed.
+
+End CocartesianFunctor.
+
+Notation Fun_fin := (sub Fun fin).
+Notation ktree_fin E := (sub (ktree E) fin).
+
+Section PureKF.
+
+Context {E : Type -> Type}.
+
+Definition subpure {n m} (f : Fun_fin n m) : ktree_fin E n m :=
+  subm (pure (unsubm f)).
+
+Global Instance Functor_pure : Functor _ _ _ (@subpure).
+Proof.
+  constructor; intros.
+  - reflexivity.
+  - unfold subpure. rewrite fmap_cat, fmap_cat0. reflexivity.
+  - hnf; intros. apply Proper_subm, Proper_pure. auto.
+Qed.
+
+Global Instance CocartesianFunctor_pure : CocartesianFunctor (fmap := @subpure).
+Proof.
+  constructor; intros.
+  - intros []; cbn.
+    unfold unsubm, case_, Case_Kleisli, case_sum, Case_sub, case_.
+    unfold cat, Cat_sub, Cat_Fun.
+    unfold to_bif, ToBifunctor_ktree_fin, ToBifunctor_Fun_fin.
+    rewrite bind_ret_l.
+    destruct split_fin_sum; reflexivity.
+  - intros ?; cbn. rewrite bind_ret_l. reflexivity.
+  - intros ?; cbn; rewrite bind_ret_l; reflexivity.
+Qed.
+
+End PureKF.

--- a/secure_example/LabelledAsm.v
+++ b/secure_example/LabelledAsm.v
@@ -1,0 +1,378 @@
+(** * The Asm language  *)
+
+(** We now consider as a target a simple control-flow-graph language, so-called
+    _Asm_.  Computations are represented as a collection of basic blocks linked
+    by jumps.  *)
+
+(* begin hide *)
+From Coq Require Import Arith String Setoid.
+
+  (* SAZ: Should we add ITreeMonad to ITree? *)
+From ITree Require Import
+     ITree
+     ITreeFacts
+     Basics.CategorySub
+     Events.State
+     Events.Exception
+.
+
+Require Import Lattice LabelledImp.
+Require Import Fin.
+
+Import Monads.
+Import MonadNotation.
+Local Open Scope monad_scope.
+(* end hide *)
+
+Variant sensitivity : Type :=
+  | Public
+  | Private.
+
+Definition meet_sense l1 l2 :=
+  match l1 with
+  | Public => Public
+  | Private => l2 end.
+
+Definition join_sense l1 l2 :=
+  match l1 with
+  | Public => l2
+  | Private => Private end.
+
+Instance sensitivity_lat : Lattice :=
+  {|
+  T := sensitivity;
+  eqlat := eq;
+  join := join_sense;
+  meet := meet_sense;
+  top := Private;
+  bot := Public
+
+  |}.
+
+Instance sensitivity_latlaws : LatticeLaws sensitivity_lat.
+Proof.
+  constructor.
+  - apply eq_equivalence.
+  - unfold eqlat. cbn. repeat intro. subst. auto.
+  - unfold eqlat. cbn. repeat intro. subst. auto.
+  - intros l1 l2. cbn. destruct l1; destruct l2; eauto; right; intro; discriminate.
+  - cbn. intros [ | ] [ | ]; auto.
+  - cbn. intros [ | ] [ | ] [| ]; auto.
+  - cbn. intros [ | ] [ | ]; auto.
+  - cbn. intros [ | ] [ | ] [| ]; auto.
+  - cbn. intros [ | ]; auto.
+  - cbn. intros [ | ]; auto.
+  - cbn. intros [ | ] [ | ]; auto.
+  - cbn. intros [ | ] [ | ]; auto.
+Qed.
+(** ** Syntax *)
+
+(** We define a countable set of memory addresses, represented as [string]s: *)
+Definition addr : Set := string.
+
+(** We define a set of register names (for this simple example, we identify them
+with [nat]). *)
+Definition reg : Set := nat.
+
+(** For simplicity, _Asm_ manipulates [nat]s as values too. *)
+Definition value : Set := nat.
+
+(** We consider constants and variables as operands. *)
+Variant operand : Set :=
+| Oimm (_ : value)
+| Oreg (_ : reg).
+
+(** The instruction set covers moves and arithmetic operations, as well as load
+    and stores to the heap.  *)
+Variant instr : Set :=
+| Imov   (dest : reg) (src : operand)
+| Iadd   (dest : reg) (src : reg) (o : operand)
+| Isub   (dest : reg) (src : reg) (o : operand)
+| Imul   (dest : reg) (src : reg) (o : operand)
+| IEq    (dest : reg) (src : reg) (o : operand)
+| ILe    (dest : reg) (src : reg) (o : operand)
+| IAnd   (dest : reg) (src : reg) (o : operand)
+| INot   (dest : reg) (o : operand)
+| Iload  (dest : reg) (addr : addr)
+| Istore (addr : addr) (val : operand)
+| IOutput (s : sensitivity) (src : reg)
+.
+
+(** We consider both direct and conditional jumps *)
+Variant branch {label : Type} : Type :=
+| Bjmp (_ : label)                (* jump to label *)
+| Bbrz (_ : reg) (yes no : label) (* conditional jump *)
+| BRaise (s : sensitivity)
+.
+Global Arguments branch _ : clear implicits.
+
+(** A basic [block] is a sequence of straightline instructions followed by a
+    branch that either halts the execution, or transfers control to another
+    [block]. *)
+Inductive block {label : Type} : Type :=
+| bbi (_ : instr) (_ : block)
+| bbb (_ : branch label).
+Global Arguments block _ : clear implicits.
+
+
+
+(** A piece of code should expose the set of labels allowing to enter into it,
+    as well as the set of outer labels it might jump to.  To this end, [bks]
+    represents a collection of blocks labeled by [F A], with branches in [F B].
+*)
+
+Definition bks A B := fin A -> block (fin B).
+
+
+(** An [asm] program represents the control flow of the computation.  It is a
+    collection of labelled [blocks] such that its labels are classified into
+    three categories:
+
+    - [A]: (visible) entry points
+
+    - [B]: (visible) exit points
+
+    - [internal]: (hidden) internal linked labels
+
+    Note that they uniformly represent open and closed programs, the latter
+    corresponding to an [asm] program with a unique entry point and no exit
+    labels, i.e. a [asm unit void].  Note that using [void] to describe the exit
+    points means that closed program must either diverge (go into an infinite
+    loop) or somehow generate an event that terminates them.  (See the
+    denotation of [Bhalt] below.)  *)
+
+Record asm (A B: nat) : Type :=
+  {
+    internal : nat;
+    code     : bks (internal + A) (internal + B)
+  }.
+
+Arguments internal {A B}.
+Arguments code {A B}.
+
+(* ========================================================================== *)
+(** ** Semantics *)
+
+(** _Asm_ produces two kind of events for manipulating its two kinds of state:
+    registers and the heap.
+*)
+Variant Reg : Type -> Type :=
+| GetReg (x : reg) : Reg value
+| SetReg (x : reg) (v : value) : Reg unit.
+
+Inductive Memory : Type -> Type :=
+| Load  (a : addr) : Memory value
+| Store (a : addr) (val : value) : Memory unit.
+
+
+Section Denote.
+
+  (** Once again, [asm] programs shall be denoted as [itree]s. *)
+
+  (* begin hide *)
+  Import ExtLib.Structures.Monad.
+  Import MonadNotation.
+  Local Open Scope monad_scope.
+  (* end hide *)
+
+
+  Section with_event.
+    (* Context (Labels : Lattice). *)
+    (* could use a slight generalization sensitivity_lat to Lattice *)
+
+    (** As with _Imp_, we parameterize our semantics by a universe of events
+        that shall encompass all the required ones. *)
+    Context {E : Type -> Type}.
+    Context {HasExc : impExcE sensitivity_lat -< E}.
+    Context {HasReg : Reg -< E}.
+    Context {HasMemory : Memory -< E}.
+    Context {HasIOE : IOE sensitivity_lat -< E}.
+
+    Arguments LabelledPrint {Labels}.
+    (** Operands are trivially denoted as [itree]s returning values *)
+    Definition denote_operand (o : operand) : itree E value :=
+      match o with
+      | Oimm v => Ret v
+      | Oreg v => trigger (GetReg v)
+      end.
+
+    (** Instructions offer no suprises either. *)
+    Definition denote_instr (i : instr) : itree E unit :=
+      match i with
+      | Imov d s =>
+        v <- denote_operand s ;;
+        trigger (SetReg d v)
+      | Iadd d l r =>
+        lv <- trigger (GetReg l) ;;
+        rv <- denote_operand r ;;
+        trigger (SetReg d (lv + rv))
+      | Isub d l r =>
+        lv <- trigger (GetReg l) ;;
+        rv <- denote_operand r ;;
+        trigger (SetReg d (lv - rv))
+      | Imul d l r =>
+        lv <- trigger (GetReg l) ;;
+        rv <- denote_operand r ;;
+        trigger (SetReg d (lv * rv))
+      | IEq d l r =>
+        lv <- trigger (GetReg l) ;;
+        rv <- denote_operand r ;;
+        trigger (SetReg d (if Nat.eqb lv rv then 1 else 0))
+      | ILe d l r =>
+        lv <- trigger (GetReg l) ;;
+        rv <- denote_operand r ;;
+        trigger (SetReg d (if Nat.leb lv rv then 1 else 0))
+      | INot d r =>
+        rv <- denote_operand r ;;
+        trigger (SetReg d (match rv with | 0 => 1 | _ => 0 end))
+      | IAnd d l r =>
+        lv <- trigger (GetReg l) ;;
+        rv <- denote_operand r ;;
+        trigger (SetReg d (match lv,rv with | 0,0 | 0,1 | 1,0 => 0 | _,_ => 1 end))
+      | Iload d addr =>
+        val <- trigger (Load addr) ;;
+            trigger (SetReg d val)
+      | Istore addr v =>
+        val <- denote_operand v ;;
+            trigger (Store addr val)
+      | IOutput s r =>
+        val <- trigger (GetReg r);;
+            trigger (LabelledPrint s val)
+      end.
+
+    (** A [branch] returns the computed label whose set of possible values [B]
+        is carried by the type of the branch.  If the computation halts
+        instead of branching, we return the [exit] tree.  *)
+    Definition denote_br {B} (b : branch B) : itree E B :=
+      match b with
+      | Bjmp l => ret l
+      | Bbrz v y n =>
+        val <- trigger (GetReg v) ;;
+        if val:nat then ret y else ret n
+      | BRaise s => v <- trigger (Throw s);; match v : void with end
+      end.
+
+
+    (** The denotation of a basic [block] shares the same type, returning the
+        [label] of the next [block] it shall jump to.  It recursively denote
+        its instruction before that.  *)
+    Fixpoint denote_bk {B} (b : block B) : itree E B :=
+      match b with
+      | bbi i b =>
+        denote_instr i ;; denote_bk b
+      | bbb b =>
+        denote_br b
+      end.
+
+    (** A labelled collection of blocks, [bks], is simply the pointwise
+        application of [denote_bk].  Crucially, its denotation is therefore
+        a [ktree], whose structure will be useful in the proof of
+        the compiler.
+
+        The type [sub (ktree E) fin A B] is shorthand for
+        [fin A -> itree E (fin B)], and we can think of them as "continuations"
+        with events in E, with input values in [fin A] and output values in [fin B].
+        They have a nice algebraic structure, supported by the library,
+        including a [loop] combinator that we can use to link collections of
+        basic blocks. (See below.) *)
+    Definition denote_bks {A B : nat} (bs: bks A B): sub (ktree E) fin A B :=
+      fun a => denote_bk (bs a).
+
+  (** One can think of an [asm] program as a circuit/diagram where wires
+      correspond to jumps/program links.  [denote_bks] computes the meaning of
+      each basic block as an [itree] that returns the label of the next block to
+      jump to, laying down all our elementary wires.  In order to denote an [asm
+      A B] program as a [ktree E A B], it therefore remains to wire all those
+      denoted blocks together while hiding the internal labels.  Luckily, that
+      is exactly what traced monoidal category are good for.  We therefore
+      accomplish this with the same [loop] combinator we used to denote _Imp_'s
+      [while] loop.  It directly takes our [denote_bks (code s): ktree E (I + A)
+      (I + B)] and hides [I] as desired.  *)
+    Definition denote_asm {A B} : asm A B -> sub (ktree E) fin A B :=
+      fun s => loop (denote_bks (code s)).
+
+  End with_event.
+End Denote.
+
+(* ========================================================================== *)
+(** ** Interpretation *)
+
+(* begin hide *)
+From ITree Require Import
+     Basics.Category
+     Events.MapDefault.
+
+From ExtLib Require Import
+     Core.RelDec
+     Data.String
+     Structures.Maps
+     Data.Map.FMapAList.
+
+(* begin hide *)
+(** These enable typeclass instances for Maps keyed by strings and registers *)
+Instance RelDec_string : RelDec (@eq string) :=
+  { rel_dec := fun s1 s2 => if string_dec s1 s2 then true else false}.
+
+Instance RelDec_string_Correct: RelDec_Correct RelDec_string.
+Proof.
+  constructor; intros x y.
+  split.
+  - unfold rel_dec; simpl.
+    destruct (string_dec x y) eqn:EQ; [intros _; apply string_dec_sound; assumption | intros abs; inversion abs].
+  - intros EQ; apply string_dec_sound in EQ; unfold rel_dec; simpl; rewrite EQ; reflexivity.
+Qed.
+
+(* SAZ: Annoyingly, typeclass resolution picks the wrong map instance for nats by default, so
+   we create an instance for [reg] that hides the wrong instance with the right one. *)
+Instance RelDec_reg : RelDec (@eq reg) := RelDec_from_dec eq Nat.eq_dec.
+(* end hide *)
+
+(** Both environments and memory events can be interpreted as "map" events,
+    exactly as we did for _Imp_. *)
+(*
+Definition h_reg {E: Type -> Type}
+  : Reg ~> stateT (itree E) :=
+  fun _ e s =>
+    match e with
+    | GetReg x => lookup_def x
+    | SetReg x v => insert x v
+    end.
+
+Definition h_memory {E : Type -> Type} `{mapE addr 0 -< E} :
+  Memory ~> itree E :=
+  fun _ e =>
+    match e with
+    | Load x => lookup_def x
+    | Store x v => insert x v
+    end.
+*)
+(** Once again, we implement our Maps with a simple association list *)
+Definition registers := nat -> value.
+Definition memory    := map.
+
+Definition get_reg (n : nat) (s : registers) := s n.
+Definition update_reg (n : nat) (v : value) (s : registers) :=
+  fun m => if n =? m then v else s m.
+
+Definition h_reg {E : Type -> Type} : Reg ~> stateT (registers * memory) (itree E) :=
+  fun _ e => match e with
+          | GetReg n => fun '(regs,mem) => Ret (regs, mem, get_reg n regs)
+          | SetReg n v => fun '(regs, mem) => Ret (update_reg n v regs, mem, tt) end.
+
+Definition h_mem {E : Type -> Type} : Memory ~> stateT (registers * memory) (itree E) :=
+  fun _ e => match e with
+          | Load x => fun '(regs,mem) => Ret (regs, mem, get x mem)
+          | Store x v => fun '(regs, mem) => Ret (regs, update x v mem, tt) end.
+
+Definition asm_handler {E1 E2} : (E1 +' Reg +' Memory +' E2) ~> stateT (registers * memory) (itree (E1 +' E2)) :=
+  fun _ e => match e with
+          | inr1 (inl1 reg_e) => h_reg _ reg_e
+          | inr1 (inr1 (inl1 mem_e)) =>  h_mem _ mem_e
+          | inl1 e' =>  (fun s => v <- ITree.trigger (inl1 e') ;; Ret (s, v))
+          | inr1 (inr1 (inr1 e')) =>  (fun s => v <- ITree.trigger (inr1 e') ;; Ret (s, v))
+
+end.
+
+Definition interp_asm {E1 E2 A} (t : itree (E1 +' Reg +' Memory +' E2) A ) :
+  stateT (registers * memory) (itree (E1 +' E2)) A :=
+  fun '(mem, regs) => interp_state asm_handler t (mem, regs).

--- a/secure_example/LabelledAsmCombinators.v
+++ b/secure_example/LabelledAsmCombinators.v
@@ -1,0 +1,457 @@
+(** * Composition of [asm] programs *)
+
+(** We develop in this file a theory of linking for [asm] programs.
+    To this end, we will equip them with four main combinators:
+    - [pure_asm], casting pure functions into [asm].
+    - [app_asm], linking them vertically
+    - [loop_asm], hiding internal links
+    - [relabel_asm], allowing to rename labels
+    Viewing [asm] units as diagrams, whose entry wires are the exposed labels of
+    its blocks, and exit wires the external labels to which it may jump, this
+    theory can be seen in particular as showing that they enjoy a structure of
+    _traced monoidal category_.
+    We do so by thinking of [ktree]s as a theory of linking at the denotational
+    level. Each linking combinator is therefore proved correct by showing that
+    the denotation of the resulting [asm], a [ktree], can be swapped with the
+    corresponding [ktree] combinator.
+    It is interesting to notice that while the [ktree] theory, provided by the
+    library, required heavy use of coinduction, it provides sufficient reasoning
+    principles so that we do not need to write any cofix here.
+ *)
+
+(* begin hide *)
+From Coq Require Import
+     Arith
+     List
+     Program.Basics
+     Morphisms.
+Import ListNotations.
+
+From ExtLib Require Import
+     Structures.Monad.
+
+From ITree Require Import
+     ITree
+     ITreeFacts
+     ITreeMonad
+     Basics.Category
+     Basics.CategorySub
+.
+
+From SecureExample Require Import
+     LabelledAsm
+     LabelledImp
+     CatTheory
+     Fin
+     KTreeFin
+     Utils_tutorial
+.
+
+Import CatNotations.
+Local Open Scope cat_scope.
+(* end hide *)
+
+(* ================================================================= *)
+(** ** Internal structures *)
+
+(** A utility function to apply a renaming function [f] to the exit label of a [branch]. *)
+Definition fmap_branch {A B : Type} (f: A -> B): branch A -> branch B :=
+  fun b =>
+    match b with
+    | Bjmp a => Bjmp (f a)
+    | Bbrz c a a' => Bbrz c (f a) (f a')
+    | BRaise s => BRaise s
+    end.
+
+(** A utility function to apply a renaming function [f] to the exit label of a [block]. *)
+Definition fmap_block {A B: Type} (f: A -> B): block A -> block B :=
+  fix fmap b :=
+    match b with
+    | bbb a => bbb (fmap_branch f a)
+    | bbi i b => bbi i (fmap b)
+    end.
+
+(** A utility function to apply renaming functions [f] and [g] respectively to
+    the entry and exit labels of a [bks]. *)
+Definition relabel_bks {A B C D : nat} (f : sub Fun fin A B) (g : sub Fun fin C D)
+           (b : bks B C) : bks A D :=
+  fun a => fmap_block g (b (f a)).
+
+Definition app_bks {A B C D : nat} (ab : bks A B) (cd : bks C D)
+  : bks (A + C) (B + D) :=
+  fun ac =>
+    match split_fin_sum _ _ ac with
+    | inl a => fmap_block (L _) (ab a)
+    | inr c => fmap_block (R _) (cd c)
+    end.
+
+(** Simple combinator to build a [block] from its instructions and branch operation. *)
+Fixpoint after {A: Type} (is : list instr) (bch : branch A) : block A :=
+  match is with
+  | nil => bbb bch
+  | i :: is => bbi i (after is bch)
+  end.
+
+(* SAZ: rationalize the names of the combinators? *)
+(** Another combinator that appends a list of instructions to the beginning of a
+    block *)
+Fixpoint blk_append {lbl} (l:list instr) (b:block lbl) : block lbl :=
+  match l with
+  | [] => b
+  | i :: l' => bbi i (blk_append l' b)
+  end.
+
+
+(* ================================================================= *)
+(** ** Low-level interface with [asm] *)
+
+(** Any collection of blocks forms an [asm] program with no hidden blocks. *)
+Definition raw_asm {A B} (b : bks A B) : asm A B :=
+  {| internal := 0;
+     code := fun l => b l
+  |}.
+
+(** And so does a single [block] in particular. *)
+Definition raw_asm_block {A: nat} (b : block (fin A)) : asm 1 A :=
+  raw_asm (fun _ => b).
+
+(** ** [asm] combinators *)
+
+(** We now turn to the proper [asm] combinators. *)
+
+(** An [asm] program made only of external jumps.
+    This is useful to connect programs with [app_asm]. *)
+Definition pure_asm {A B: nat} (f : sub Fun fin A B) : asm A B :=
+  raw_asm (fun a => bbb (Bjmp (f a))).
+
+Definition id_asm {A} : asm A A := pure_asm id.
+
+
+(** The [app_asm] combinator joins two [asm] programs,
+    preserving their internal links.
+    Since the three ambient domains of labels are extended,
+    the only tricky part is to rename all labels appropriately.
+ *)
+
+(** Combinator to append two asm programs, preserving their internal links.
+    Can be thought of as a "vertical composition", or a tensor product.
+ *)
+(* We build a function from F X into block (F Y), we hence cannot use case_ whether over iFun or sktree.
+   Can we do better?
+ *)
+Definition app_asm {A B C D} (ab : asm A B) (cd : asm C D) :
+  asm (A + C) (B + D) :=
+  {| internal := ab.(internal) + cd.(internal);
+     code := relabel_bks swap4 swap4 (app_bks ab.(code) cd.(code))
+  |}.
+
+(** Rename visible program labels.
+    Having chosen to represent labels as binary trees encoded in [Type],
+    we, for instance, typically need to rename our visible labels through
+    associators.
+    The following generic combinator allow any relabelling.
+ *)
+Definition relabel_asm {A B C D} (f : sub Fun fin A B) (g : sub Fun fin C D)
+           (bc : asm B C) : asm A D :=
+  {| code := relabel_bks (bimap id f) (bimap id g)  bc.(code); |}.
+
+(** Labels that are exposed both as entry and exit points can be internalized.
+    This operation can be seen as linking two programs internal to [ab] together.
+ *)
+Definition loop_asm {I A B} (ab : asm (I + A) (I + B)) : asm A B :=
+  {| internal := ab.(internal) + I;
+     code := relabel_bks assoc_r assoc_l ab.(code);
+  |}.
+
+(* ================================================================= *)
+(** ** Correctness *)
+(** We show the combinators correct by proving that their denotation
+    map to their [ktree] counterparts.
+    Since these combinators are the basic blocks we'll use in the
+    compiler to link compiled subterms, these correctness lemmas
+    will provide an equational theory sufficient to conduct
+    all needed reasoning.
+    Interestingly, [ktree] provides a sufficiently rich theory to
+    prove all these results involving [denote_asm], which is expressed
+    as a [loop], equationally.
+ *)
+
+(* begin hide *)
+Import MonadNotation.
+Import ITreeNotations.
+Import CatNotations.
+Local Open Scope cat.
+(* end hide *)
+
+Section Correctness.
+
+  Context {E : Type -> Type}.
+  Context {HasExc : impExcE sensitivity_lat -< E}.
+  Context {HasRegs : Reg -< E}.
+  Context {HasMemory : Memory -< E}.
+  Context {HasIO : IOE sensitivity_lat -< E}.
+
+  (** *** Internal structures *)
+
+  Lemma fmap_block_map:
+    forall  {L L'} b (f: fin L -> fin L'),
+      denote_bk (fmap_block f b) ≅ ITree.map f (denote_bk b).
+  Proof.
+    (* Induction over the structure of the [block b] *)
+    induction b as [i b | br]; intros f.
+    - (* If it contains an instruction (inductive case). *)
+      cbn.
+      rewrite map_bind.
+      eapply eqit_bind; try reflexivity.
+      intros []; apply IHb.
+    - (* If it's a jump, we consider the three cases. *)
+      simpl.
+      destruct br; simpl.
+      + rewrite map_ret; reflexivity.
+      + rewrite map_bind.
+        eapply eqit_bind; try reflexivity.
+        intros ?. destruct a; setoid_rewrite map_ret; reflexivity.
+      + rewrite map_bind. eapply eqit_bind; try reflexivity.
+        intros [].
+  Qed.
+
+  (** Denotes a list of instruction by binding the resulting trees. *)
+  Definition denote_list: list instr -> itree E unit :=
+    traverse_ denote_instr.
+
+  (** Correctness of the [after] operator.
+      Its denotation binds the denotation of the instructions
+      with the one of the branch.
+   *)
+  Lemma denote_after :
+    forall {label} instrs (b: branch (fin label)),
+      denote_bk (after instrs b) ≅ (denote_list instrs ;; denote_br b).
+  Proof.
+    induction instrs as [| i instrs IH]; intros b.
+    - simpl; rewrite bind_ret_l; reflexivity.
+    - simpl; rewrite bind_bind.
+      eapply eqit_bind; try reflexivity.
+      intros []; apply IH.
+  Qed.
+
+  Lemma denote_blk_append : forall lbl (l:list instr) (b:block (fin lbl)),
+      denote_bk (blk_append l b) ≈ (x <- denote_list l ;; denote_bk b).
+  Proof.
+    intros lbl.
+    induction l; intros b; simpl.
+    - rewrite bind_ret_l. reflexivity.
+    - rewrite bind_bind.
+      eapply eqit_bind'; try reflexivity.
+      intros; apply IHl.
+  Qed.
+
+  (** Utility: denoting the [app] of two lists of instructions binds the denotations. *)
+  Lemma denote_list_app:
+    forall is1 is2,
+      @denote_list (is1 ++ is2) ≅ (@denote_list is1;; denote_list is2).
+  Proof.
+    intros is1 is2; induction is1 as [| i is1 IH]; simpl; intros; [rewrite bind_ret_l; reflexivity |].
+    rewrite bind_bind; setoid_rewrite IH; reflexivity.
+  Qed.
+
+  Lemma unit_l'_id_sktree {n : nat}
+    : (unit_l' (C := sub (ktree E) fin) (bif := Nat.add) (i := 0)) ⩯ id_ n.
+  Proof.
+    intros ?. tau_steps; symmetry; tau_steps. rewrite R_0_a. unfold id.
+    reflexivity.
+  Qed.
+
+  Lemma unit_l_id_sktree {n : nat}
+    : (unit_l (C := sub (ktree E) fin) (bif := Nat.add) (i := 0)) ⩯ id_ n.
+  Proof.
+    intros ?. tau_steps; symmetry; tau_steps.
+    replace (fi' _) with a by
+      (apply unique_fin; simpl; auto using Nat.sub_0_r).
+    reflexivity.
+  Qed.
+
+  Lemma raw_asm_correct {A B} (b : bks A B) :
+    denote_asm (raw_asm b) ⩯ (fun a => denote_bk (b a)).
+  Proof.
+    unfold denote_asm; cbn.
+    rewrite loop_vanishing_1.
+    rewrite unit_l'_id_sktree.
+    rewrite unit_l_id_sktree.
+    rewrite cat_id_l, cat_id_r.
+    reflexivity.
+  Qed.
+
+  (** Correctness of the [raw_asm] operator.
+      Its denotation is the same as the denotation of the block.
+      Since it is hybrid between the level of [ktree]s (asm) and
+      [itree]s (block), the correctness is established at both
+      level for convenience.
+      Note that the ⩯ notation in the scope of [ktree] desugars to [eutt_ktree],
+      i.e. pointwise [eutt eq].
+   *)
+  Lemma raw_asm_block_correct_lifted {A} (b : block (fin A)) :
+    denote_asm (raw_asm_block b) ⩯
+               ((fun _  => denote_bk b) : sub (ktree _) fin _ _).
+  Proof.
+    unfold raw_asm_block.
+    rewrite raw_asm_correct.
+    reflexivity.
+  Qed.
+
+  Lemma raw_asm_block_correct {A} (b : block (fin A)) :
+    (denote_asm (raw_asm_block b) f0) ≈ (denote_bk b).
+  Proof.
+    apply raw_asm_block_correct_lifted.
+  Qed.
+
+  (** *** [asm] combinators *)
+
+  (** Correctness of the [pure_asm] combinator.
+      Its denotation is the lifting of a pure function
+      into a [ktree].
+   *)
+  Theorem pure_asm_correct {A B} (f : sub Fun fin A B) :
+    denote_asm (pure_asm f) ⩯ subpure f.
+  Proof.
+    unfold pure_asm.
+    rewrite raw_asm_correct.
+    reflexivity.
+  Qed.
+
+  (** The identity gets denoted as the identity. *)
+  Theorem id_asm_correct {A} :
+    denote_asm (pure_asm id)
+               ⩯ id_ A.
+  Proof.
+    rewrite pure_asm_correct; reflexivity.
+  Defined.
+
+  (** Correctness of the [relabel_asm] combinator.
+      Its denotation is the same as denoting the original [asm],
+      and composing it on both sides with the renaming functions
+      lifted as [ktree]s.
+   *)
+  Lemma relabel_bks_correct: forall {A B C D: nat} (f: sub Fun fin A B) (g: sub Fun fin C D) k,
+      denote_bks (relabel_bks f g k)
+    ⩯ subpure f >>> denote_bks k >>> subpure g.
+  Proof.
+    intros. intros a.
+    unfold relabel_bks, denote_bks.
+    unfold subpure, subm, cat, Cat_sub.
+    unfold pure, cat, Cat_Kleisli.
+    unfold bind, ret; simpl.
+    rewrite fmap_block_map, bind_ret_l.
+    reflexivity.
+  Qed.
+
+  Lemma app_bks_correct: forall {A B C D: nat} (ab: bks A B) (cd: bks C D),
+    denote_bks (app_bks ab cd) ⩯ bimap (denote_bks ab) (denote_bks cd).
+  Proof.
+    intros. rewrite bimap_case_unfold.
+    intros ?.
+    unfold app_bks, denote_bks.
+
+    unfold case_, Case_sub, inl_, Inl_sub, cat, Cat_sub.
+
+    unfold case_, Case_Kleisli, case_sum, inl_, Inl_Kleisli, pure, cat, Cat_Kleisli.
+
+    unfold from_bif, FromBifunctor_ktree_fin, to_bif, ToBifunctor_ktree_fin; cbn.
+
+    rewrite bind_ret_l.
+
+    destruct split_fin_sum.
+    all: rewrite fmap_block_map.
+    all: setoid_rewrite bind_ret_l.
+    all: reflexivity.
+  Qed.
+
+  (** Correctness of the [app_asm] combinator.
+      The resulting [asm] gets denoted to the bimap of its subcomponent.
+      The proof is a bit more complicated. It makes a lot more sense if drawn.
+   *)
+  Theorem app_asm_correct {A B C D} (ab : asm A B) (cd : asm C D) :
+    denote_asm (app_asm ab cd)
+               ⩯ bimap (denote_asm ab) (denote_asm cd).
+  Proof with try typeclasses eauto.
+    unfold denote_asm.
+    (*
+      On the left-hand-side, we have a [loop] of two [asm] mashed together.
+      On the right-hand-side however we have two [loop]s combined together.
+      The game is to massage them through successive rewriting until they
+      line up.
+     *)
+
+    (* We first work on the rhs to reduce it to a single loop.
+       The textual explanations are fairly cryptic. The key intuition comes
+       by drawing the state of the circuit and using the rewiring laws
+       the categorical structure provides, as represented for instance here:
+       https://en.wikipedia.org/wiki/Traced_monoidal_category
+       [bimap_ktree_loop] and [loop_bimap_ktree] are the _superposing_ laws.
+       [compose_loop] and [loop_compose] are the _naturality_ in _X_ and _Y_.
+       [loop_loop] is the second _vanishing_ law.
+     *)
+    match goal with | |- ?x ⩯ _ => set (lhs := x) end.
+    rewrite loop_superposing.   (* a loop superposed atop another diagram can englob the latter *)
+    rewrite loop_superposing_2. (* as well as if the loop is under... But it takes a bit more rewiring! *)
+    rewrite loop_natural_left.  (* a loop append to diagrams can swallow them... *)
+    rewrite loop_natural_right. (* ... from either side. *)
+    rewrite loop_vanishing_2.   (* Finally, two nested loop can be combined. *)
+
+    (* Remain now to relate the bodies of the loops on each side. *)
+    (* First by some more equational reasoning. *)
+
+    rewrite <- (loop_dinatural' swap swap) by apply swap_involutive.
+    subst lhs.
+    apply Proper_loop.
+    rewrite !cat_assoc.
+    repeat rewrite <- (cat_assoc _ _ (bimap (denote_bks _) (denote_bks _) >>> _)).
+    cbn. rewrite relabel_bks_correct, app_bks_correct.
+    rewrite cat_assoc.
+
+    rewrite <- aux_app_asm_correct1, <- aux_app_asm_correct2.
+
+    rewrite 2 subpure_swap4; reflexivity.
+  Qed.
+
+  Theorem relabel_asm_correct {A B C D}
+          (f : sub Fun fin A B) (g : sub Fun fin C D)
+          (bc : asm B C)
+    : denote_asm (relabel_asm f g bc)
+    ⩯ subpure f >>> denote_asm bc >>> subpure g.
+  Proof.
+    unfold denote_asm.
+    simpl.
+    rewrite relabel_bks_correct.
+    rewrite loop_natural_left, loop_natural_right.
+    apply Proper_loop.
+    rewrite 2 fmap_bimap.
+    reflexivity.
+  Qed.
+
+  (** Correctness of the [loop_asm] combinator.
+      Linking is exactly looping, it hides internal labels/wires.
+   *)
+  Theorem loop_asm_correct {I A B} (ab : asm (I + A) (I + B)) :
+    denote_asm (loop_asm ab) ⩯ loop (denote_asm ab).
+  Proof.
+    unfold denote_asm.
+    rewrite loop_vanishing_2.
+    apply Proper_loop.
+    simpl.
+    rewrite relabel_bks_correct.
+    rewrite fmap_assoc_l, fmap_assoc_r.
+    reflexivity.
+  Qed.
+
+
+End Correctness.
+
+(** We have defined four low-level combinators allowing us to combine [asm]
+    programs together. These combinators are correct in the sense that
+    their denotation is bisimilar to their denotational counterparts at the
+    [ktree] level.
+    This theory of linking is only tied to _Asm_, and can therefore be reused
+    either for other compilers targeting Asm, or for optimizations over Asm.
+    We now turn to its specific use to finally define our compiler, defined
+    in [Imp2Asm.v].
+ *)

--- a/secure_example/LabelledAsmHandler.v
+++ b/secure_example/LabelledAsmHandler.v
@@ -1,0 +1,79 @@
+From Coq Require Import
+     List
+     Morphisms.
+
+From ITree Require Import
+     ITree
+     ITreeFacts
+     Secure.SecureEqHalt
+.
+
+From SecureExample Require Import
+     LabelledImp
+     LabelledAsm
+     LabelledImpHandler.
+
+Import Monads.
+Import MonadNotation.
+Local Open Scope monad_scope.
+
+From Paco Require Import paco.
+
+(* Note that this definition sets considers all registers to be private *)
+
+Definition priv_asm (priv : privacy_map sensitivity_lat) (A : Type) (e : (Reg +' Memory +' (IOE sensitivity_lat)) A ) :=
+  match e with
+  | inl1 _ => Private
+  | inr1 (inl1 (Load x)) => priv x
+  | inr1 (inl1 (Store x _ )) => priv x
+  | inr1 (inr1 (LabelledPrint _ s _ ) ) => s
+  end.
+
+Definition low_reg_mem_equiv (priv : privacy_map sensitivity_lat) : (registers * memory) -> (registers * memory) -> Prop := fun '(reg1, mem1) '(reg2, mem2) => forall x, priv x = Public -> mem1 x = mem2 x.
+
+Definition reg_mem : Type := registers * memory.
+
+#[local] Notation lat := sensitivity_lat.
+
+Definition low_eqit_secure_asmstate (b1 b2 : bool) (priv : var -> sensitivity) {R1 R2 : Type} (RR : R1 -> R2 -> Prop )
+           (m1 : stateT reg_mem (itree (IOE lat)) R1) (m2 : stateT reg_mem (itree (IOE lat)) R2) : Prop :=
+  forall s1 s2, low_reg_mem_equiv priv s1 s2 -> eqit_secure (Lattice.PreOrderOfLattice lat) (priv_io _) (product_rel (low_reg_mem_equiv priv) RR) b1 b2 Public (m1 s1) (m2 s2).
+
+Lemma low_reg_mem_equiv_update_public:
+  forall (priv_map : privacy_map lat) (x : addr) (v : value),
+    priv_map x = Public ->
+    forall (reg1 : registers) (mem1 : memory) (reg2 : registers) (mem2 : memory),
+      low_reg_mem_equiv priv_map (reg1, mem1) (reg2, mem2) ->
+      low_reg_mem_equiv priv_map (reg1, update x v mem1) (reg2, update x v mem2).
+Proof.
+  intros priv_map x v Hx reg1 mem1 reg2 mem2 Hs.
+  red. red in Hs. intros. unfold update. rewrite Hs; auto.
+Qed.
+
+Lemma low_reg_mem_equiv_update_priv_l:
+  forall (priv_map : privacy_map lat) (x : addr) (v : value),
+    priv_map x = Private ->
+    forall (reg1 : registers) (mem1 : memory) (reg2 : registers) (mem2 : memory),
+      low_reg_mem_equiv priv_map (reg1, mem1) (reg2, mem2) ->
+      low_reg_mem_equiv priv_map (reg1, update x v mem1) (reg2, mem2).
+Proof.
+  intros priv_map x v Hx reg1 mem1 reg2 mem2 Hs.
+  red. red in Hs. intros. unfold update.
+  assert (x <> x0).
+  { intro. subst. rewrite Hx in H. discriminate. }
+  apply String.eqb_neq in H0. rewrite H0. auto.
+Qed.
+
+Lemma low_reg_mem_equiv_update_priv_r:
+  forall (priv_map : privacy_map lat) (x : addr) (v : value),
+    priv_map x = Private ->
+    forall (reg1 : registers) (mem1 : memory) (reg2 : registers) (mem2 : memory),
+      low_reg_mem_equiv priv_map (reg1, mem1) (reg2, mem2) ->
+      low_reg_mem_equiv priv_map (reg1, mem1) (reg2, update x v mem2).
+Proof.
+  intros priv_map x v Hx reg1 mem1 reg2 mem2 Hs.
+  red. red in Hs. intros. unfold update.
+  assert (x <> x0).
+  { intro. subst. rewrite Hx in H. discriminate. }
+  apply String.eqb_neq in H0. rewrite H0. auto.
+Qed.

--- a/secure_example/LabelledImp.v
+++ b/secure_example/LabelledImp.v
@@ -1,0 +1,135 @@
+From Coq Require Import String.
+
+From ITree Require Import
+     ITree
+     ITreeFacts
+     Events.MapDefault
+     Events.StateFacts
+     Events.Exception
+.
+
+From SecureExample Require Import
+     Lattice.
+
+Import Monads.
+Import MonadNotation.
+Local Open Scope monad_scope.
+Local Open Scope string_scope.
+
+Section LabelledImp.
+
+Definition var : Set := string.
+
+Definition value : Type := nat.
+
+(** Expressions are made of variables, constant literals, and arithmetic operations. *)
+Inductive expr : Type :=
+| Var (_ : var)
+| Lit (_ : value)
+| Plus  (_ _ : expr)
+| Minus (_ _ : expr)
+| Mult  (_ _ : expr).
+
+(** The statements are straightforward. The [While] statement is the only
+ potentially diverging one. *)
+
+Context (Labels : Lattice).
+
+Notation label := (@T Labels).
+
+Inductive stmt : Type :=
+| Assign (x : var) (e : expr)    (* x = e *)
+| Seq    (a b : stmt)            (* a ; b *)
+| If     (i : expr) (t e : stmt) (* if (i) then { t } else { e } *)
+| While  (t : expr) (b : stmt)   (* while (t) { b } *)
+| Skip                           (* ; *)
+| Output (s : label) (e : expr)
+(* exceptions *)
+| Raise (s : label)
+| TryCatch (t c : stmt)
+.
+
+
+
+Definition privacy_map : Type := var -> label.
+
+Variant stateE : Type -> Type :=
+  | Get (x : var) : stateE value
+  | Put (x : var) (v : value) : stateE unit.
+
+Variant IOE : Type -> Type :=
+  | LabelledPrint : label -> value -> IOE unit.
+
+Definition impExcE : Type -> Type := exceptE label.
+
+Fixpoint denote_expr (e : expr) : itree (impExcE +' stateE +' IOE) value :=
+  match e with
+  | Var x => trigger (Get x)
+  | Lit v => Ret v
+  | Plus e1 e2 => x <- denote_expr e1;;
+                 y <- denote_expr e2;;
+                 Ret (x + y)
+  | Minus e1 e2 => x <- denote_expr e1;;
+                 y <- denote_expr e2;;
+                 Ret (x - y)
+  | Mult e1 e2 => x <- denote_expr e1;;
+                 y <- denote_expr e2;;
+                 Ret (x * y) end.
+
+
+Definition is_true (v : value) : bool :=
+  Nat.ltb 0 v.
+
+Definition while {E} (t : itree E (unit + unit) ) : itree E unit :=
+  ITree.iter (fun _ => t) tt.
+
+Fixpoint denote_stmt (s : stmt) : itree (impExcE +' stateE +' IOE) unit :=
+  match s with
+  | Assign x e => y <- denote_expr e;; trigger (Put x y)
+  | Seq s1 s2 => denote_stmt s1 ;; denote_stmt s2
+  | If e c1 c2 => b <- denote_expr e;;
+                 if (is_true b)
+                 then denote_stmt c1
+                 else denote_stmt c2
+  | Skip => Ret tt
+  | Output s e => v <- denote_expr e;; trigger (LabelledPrint s v)
+  | While b c => while (
+                    b <- denote_expr b;;
+                    if (is_true b)
+                    then denote_stmt c;; Ret (inl tt)
+                    else Ret (inr tt) )
+  | Raise s => trigger (Throw s);; Ret tt
+  | TryCatch t c => try_catch (denote_stmt t) (fun _ => denote_stmt c)
+   end.
+
+(* very inefficient, but not sure I really care about extraction so whatever *)
+Definition map : Type := var -> value.
+
+Definition get (x : var) (s : map) := s x.
+Definition update (x : var) (v : value) (s : map) :=
+  fun y => if x =? y then v else s y .
+
+Definition handleState {E} (A : Type) (e : stateE A) : stateT map (itree E ) A :=
+  match e with
+  | Get x => fun s => Ret (s, get x s)
+  | Put x v => fun s => Ret (update x v s, tt) end.
+
+
+Definition priv_imp (p : privacy_map) (A : Type) (e : (impExcE +' stateE +' IOE) A ) : label :=
+  match e with
+  | inl1 (Throw s) => s
+  | inr1 (inl1 (Get x)) => p x
+  | inr1 (inl1 (Put x _)) => p x
+  | inr1 (inr1 (LabelledPrint s _ )) => s
+  end.
+
+End LabelledImp.
+
+Arguments Skip {Labels}.
+Arguments Output {Labels}.
+Arguments While {Labels}.
+Arguments Raise {Labels}.
+Arguments TryCatch {Labels}.
+Arguments Assign {Labels}.
+Arguments Seq {Labels}.
+Arguments If {Labels}.

--- a/secure_example/LabelledImp2Asm.v
+++ b/secure_example/LabelledImp2Asm.v
@@ -1,0 +1,253 @@
+(** * Compilation of Imp to Asm *)
+
+(** We are now ready to define our compiler.
+    The compilation of [expr]essions is of little interest.
+    The interesting part is in the structure of the
+    compilation of instructions: we build higher level
+    [asm] combinators from the primitive ones defined
+    in [AsmCombinators.v]. Each of these combinator
+    transcribes a control flow construct of the _Imp_
+    language as a linking operation over _Asm_.
+    Their correctness will be shown in the same style as
+    the elementary combinators, isolating the control
+    flow reasoning.
+    Additionally, although naturally their choice here
+    is tied to _Imp_, they are fairly generic constructs
+    and could therefore be reused.
+*)
+
+(* begin hide *)
+From Coq Require Import List.
+Import ListNotations.
+
+From ITree Require Import ITree.
+
+From SecureExample Require Import
+     LabelledImp
+     LabelledAsm
+     LabelledAsmCombinators
+     Fin
+     Utils_tutorial.
+
+Import CatNotations.
+Local Open Scope cat_scope.
+(* end hide *)
+
+(* ================================================================= *)
+(** ** Compilation of expressions *)
+
+Section compile_assign.
+
+  (** Expressions are compiled straightforwardly.
+      The argument [l] is the number of registers already introduced to compile
+      the expression, and is used for the name of the next one.
+      The result of the computation [compile_expr l e] always ends up stored in [l].
+   *)
+  Fixpoint compile_expr (l:reg) (e: expr): list instr :=
+    match e with
+    | Var x => [Iload l x]
+    | Lit n => [Imov l (Oimm n)]
+    | Plus e1 e2 =>
+      let instrs1 := compile_expr l e1 in
+      let instrs2 := compile_expr (1 + l) e2 in
+      instrs1 ++ instrs2 ++ [Iadd l l (Oreg (1 + l))]
+    | Minus e1 e2 =>
+      let instrs1 := compile_expr l e1 in
+      let instrs2 := compile_expr (1 + l) e2 in
+      instrs1 ++ instrs2 ++ [Isub l l (Oreg (1 + l))]
+    | Mult e1 e2 =>
+      let instrs1 := compile_expr l e1 in
+      let instrs2 := compile_expr (1 + l) e2 in
+      instrs1 ++ instrs2 ++ [Imul l l (Oreg (1 + l))]
+      end.
+
+  (** Compiles the expression and then moves the result (in register [0]) to address
+      [x].  Note: here we assume a one-to-one mapping of _Imp_ global variable names
+      and _Asm_ addresses.
+  *)
+  Definition compile_assign (x: var) (e: expr): list instr :=
+    let instrs := compile_expr 0 e in
+    instrs ++ [Istore x (Oreg 0)].
+
+  Definition compile_output (s : sensitivity) (e : expr) : list instr :=
+    let instrs := compile_expr 0 e in
+    instrs ++  [IOutput s 0].
+
+End compile_assign.
+
+(* ================================================================= *)
+(** ** Control flow combinators *)
+
+
+(** Sequencing of blocks: the program [seq_asm ab bc] links the
+    exit points of [ab] with the entry points of [bc].
+
+[[
+           B
+   A---ab-----bc---C
+]]
+
+   ... can be implemented using just [app_asm], [relabel_asm] and [loop_asm].
+
+  Indeed, [app_asm ab bc] can be visualized as:
+[[
+  A---ab---B
+  B---bc---C
+]]
+ i.e. a [asm (A + B) (B + C)]. To link them, we need first to swap the entry points.
+
+We obtain the following diagram:
+[seq_asm ab bc]
+[[
+       +------+
+       |      |
+   A------ab--+B
+       |
+      B+--bc------C
+]]
+
+Which translates to:
+ *)
+Definition seq_asm {A B C} (ab : asm A B) (bc : asm B C)
+  : asm A C :=
+  loop_asm (relabel_asm swap (id_ _) (app_asm ab bc)).
+
+Section seq_asm_exc.
+Context {A B C D : nat}.
+Context (ab : asm A (B + C)).
+Context (bd : asm B (D + C)).
+(* so what I need to do is get this to the form some swapping should get this the rest of the
+   way to the other *)
+Definition comb : asm (A + B) ((B + C) + (D + C)) := app_asm ab bd.
+
+
+
+Definition swap_and_merge : CategorySub.sub Fun fin (C + (D + C) ) (D + C) :=
+  cat (cat ( cat (bimap (id_ _) (swap) ) assoc_l) (bimap merge (id_ _) )) swap.
+
+Definition expose_linking_labels : asm (B + A) (B + (D + C) )  := relabel_asm swap (cat (cat assoc_r (id_ _)) (bimap (id_ _ ) swap_and_merge) ) comb.
+
+Definition seq_asm_exc : asm A (D + C) := loop_asm expose_linking_labels.
+
+End seq_asm_exc.
+
+(** Location of temporary for [if]. *)
+Definition tmp_if := 0.
+
+(** Turns the list of instructions resulting from the conditional
+    expression of a _if_ to a block with two exit points.
+ *)
+Definition cond_asm (e : list instr) : asm 1 2 :=
+  raw_asm_block (after e (Bbrz tmp_if (fS f0) f0)).
+
+
+(** Conditional branch of blocks.
+    The program [if_asm e tp fp] creates a block out of [e] jumping
+    either left or right.
+    Using [seq_asm], this block is sequenced with the vertical
+    composition [app_asm] of [tp] and [fp].
+    Remains one mismatch: [app_asm] duplicates the domain of outputs,
+    although they share the same. We hence use [relabel_asm] to collapse
+    them together.
+
+ [if_asm e tp fp]
+[[
+           true
+       /ee-------tp---A\
+    1--                 --A
+       \ee-------fp---A/
+           false
+]]
+ *)
+Definition if_asm {A}
+           (e : list instr) (tp : asm 1 A) (fp : asm 1 A) :
+  asm 1 A :=
+  seq_asm (cond_asm e)
+          (relabel_asm (id_ _) merge (app_asm tp fp)).
+
+
+
+(* Conditional looping of blocks.
+   The program [while_asm e p] composes vertically two programs:
+   an [if_asm] construct with [p] followed by a jump on the true branch,
+   and a unique jump on the false branch.
+   The loop is then closed with [loop_asm] by matching the jump from the
+   true branch to the entry point.
+
+[while_asm e p]
+[[
+      +-------------+
+      |             |
+      |    true     |
+      |  e-------p--+
+  1---+--e--------------1
+           false
+]]
+*)
+Definition while_asm (e : list instr) (p : asm 1 1) :
+  asm 1 1 :=
+  loop_asm (relabel_asm (id_ _) merge
+    (app_asm (if_asm e
+                (relabel_asm (id_ _) inl_ p)
+                (pure_asm inr_))
+            (pure_asm inl_))).
+
+
+
+
+Definition pure_ret_asm : asm 1 3 :=
+  pure_asm (fun _ => f0).
+
+Definition pure_exc_asm (s : sensitivity) : asm 1 3 :=
+  pure_asm (fun _ => match s with Public => fS (f0) | Private => (fS (fS f0)) end).
+
+
+Section while_asm_exc.
+  Context (e : list instr).
+  Context (p : asm 1 (1 + 2) ).
+  (* part of the problem is I am thinking about it wrong, because only a success signal in the body loop  gets fed back into the loop, either *)
+  (*Definition direct_output_while_exc : asm (1 + 2) (1 + (1 + 2) ) := app_asm (pure_asm (id_ _)) (pure_asm inr_). *)
+  Definition direct_output_while_exc : asm 1 (1 + (1 + 2)) :=
+    relabel_asm (id_ _) (bimap inl_ inr_) p.
+
+  Definition while_asm_exc : asm 1 3 :=
+    loop_asm (relabel_asm (id_ _) merge (app_asm
+                                           (if_asm e direct_output_while_exc (pure_asm (fun _ => fS (f0)) ))
+                                           (pure_asm inl_))).
+
+(*
+  I should refactor these to just use local let definitions
+*)
+
+End while_asm_exc.
+(* probably can refact seq_asm_exc to be simpler *)
+
+
+Definition trycatch_asm (p : asm 1 (1 + (1 + 1) ) ) (c : asm 1 3) : asm 1 3 :=
+  seq_asm (relabel_asm (id_ _) (bimap (id_ _) merge ) p)
+   (relabel_asm (id_ _ ) merge (app_asm pure_ret_asm c)).
+
+
+Definition raise_asm (s : sensitivity) : asm 1 1:=
+  {| internal := 0; code := fun _ => bbb (BRaise s) |}.
+
+(** Equipped with our combinators, the compiler writes itself
+    by induction on the structure of the statement.
+*)
+Fixpoint compile_stmt (s : stmt sensitivity_lat) {struct s} : asm 1 (1 + 2) :=
+  match s with
+  | Skip       => pure_ret_asm
+  | Assign x e => raw_asm_block (after (compile_assign x e) (Bjmp f0))
+  | Output s e => raw_asm_block (after (compile_output s e) (Bjmp f0) )
+  | Seq l r    => seq_asm_exc (compile_stmt l) (compile_stmt r)
+  | If e l r   => if_asm (compile_expr 0 e) (compile_stmt l) (compile_stmt r)
+  | Raise s => pure_exc_asm s
+  | While e s => while_asm_exc (compile_expr 0 e) (compile_stmt s)
+  | TryCatch t c => trycatch_asm (compile_stmt t) (compile_stmt c)
+  end.
+
+Definition compile (s : stmt sensitivity_lat) : asm 1 1 :=
+  seq_asm (compile_stmt s )
+          (relabel_asm (id_ _) (fun _ => f0) (app_asm id_asm (app_asm (raise_asm Public) (raise_asm Private) ) )).
+
+(** We now consider its proof of correctness in [Imp2AsmCorrectness.v]. *)

--- a/secure_example/LabelledImp2AsmCorrectness.v
+++ b/secure_example/LabelledImp2AsmCorrectness.v
@@ -1,0 +1,1356 @@
+(** * Functional correctness of the compiler *)
+
+(** We finally turn to proving our compiler correct.
+
+SAZ: This needs to be updated.
+
+    We express the result as a (weak) bisimulation between
+    the [itree] resulting from the denotation of the source
+    _Imp_ statement and the denotation of the compiled _Asm_
+    program. This weak bisimulation is a _up-to-tau_ bisimulation.
+    More specifically, we relate the itrees after having
+    interpreted the events contained in the trees, and run
+    the resulting computation from the state monad:
+    [ImpState] on the _Imp_ side, [Reg] and [Memory] on the
+    _Asm_ side.
+
+    The proof is essentially structured as followed:
+    - a simulation relation is defined to relate the _Imp_
+    state to the _Asm_ memory during the simulation. This
+    relation is strengthened into a second one additionally
+    relating the result of the denotation of an expression to
+    the _Asm_ set of registers, and used during the simulation
+    of expressions.
+    - the desired bisimulation is defined to carry out the
+    the simulation invariant into a up-to-tau equivalence after
+    interpretation of events. Once again a slightly different
+    bisimulation is defined when handling expressions.
+    - Linking is proved in isolation: the "high level" control
+    flow combinators for _Asm_ defined in [Imp2Asm.v] are
+    proved correct in the same style as the elementary ones
+    from [AsmCombinators.v].
+    - Finally, all the pieces are tied together to prove the
+    correctness.
+
+    We emphasize the following aspects of the proof:
+    - Despite establishing a termination-sensitive correctness
+    result over Turing-complete languages, we have not written
+    a single [cofix]. All coinductive reasoning is internalized
+    into the [itree] library.
+    - We have separated the control-flow-related reasoning from
+    the functional correctness one. In particular, the low-level
+    [asm] combinators are entirely reusable, and the high-level
+    ones are only very loosely tied to _Imp_.
+    - All reasoning is equational. In particular, reasoning at the
+    level of [ktree]s rather than introducing the entry label and
+    trying to reason at the level of [itree]s ease sensibly the pain
+    by reducing the amount of binders under which we need to work.
+    - We transparently make use of the heterogeneous bisimulation provided
+    by the [itree] library to relate computations of _Asm_ expressions that
+    return a pair of environments (registers and memory) and a [unit] value to
+    ones of _Imp_ that return a single environment and an [Imp.value].
+ *)
+
+(* begin hide *)
+
+From Coq Require Import
+     Lia
+     Arith
+     String
+     List
+     Morphisms.
+
+From ITree Require Import
+     ITree
+     ITreeFacts
+     Basics.CategorySub
+     Basics.HeterogeneousRelations
+     Events.StateFacts
+     Events.MapDefault
+     Events.Exception
+     Events.ExceptionFacts
+.
+
+From SecureExample Require Import
+     LabelledImp
+     LabelledAsm
+     LabelledAsmCombinators
+     Utils_tutorial
+     LabelledImp2Asm
+     Fin
+     KTreeFin
+     LabelledImpHandler
+.
+
+Import ITreeNotations.
+
+From ExtLib Require Import
+     Structures.Monad
+     Structures.Maps
+     Data.Map.FMapAList.
+
+Import ListNotations.
+
+Import CatNotations.
+Local Open Scope cat.
+
+Import Monads.
+Open Scope monad_scope.
+Open Scope itree_scope.
+
+(* end hide *)
+
+(* ================================================================= *)
+(** ** Simulation relations and invariants *)
+
+(** The compiler is proved correct by constructing a (itree) bisimulation
+    between the source program and its compilation.  The compiler does two
+    things that affect the state:
+
+      - it translates source Imp variables to Asm global variables, which should
+        match at each step of computation
+
+      - it introduces temporary local variables that name intermediate values
+
+    As is traditional, we define, to this end, a simulation relation [Renv] and
+    invariants that relate the source Imp environment to the target Asm
+    environment, following the description above.
+
+    [Renv] relates two [alist var value] environments if they act as
+    equivalent maps.  This is used to relate Imp's [ImpState] environment to
+    Asm's [Memory].
+
+*)
+
+Section Simulation_Relation.
+
+  (** ** Definition of the simulation relations *)
+
+  (** The simulation relation for evaluation of statements.
+      The relation relates two environments of type [alist var value].
+      The source and target environments exactly agree on user variables.
+   *)
+  Definition Renv (g_imp : map) (g_asm : memory) : Prop :=
+    forall x, g_imp x = g_asm x.
+
+  Global Instance Renv_refl : Reflexive Renv.
+  Proof.
+    red. intros. unfold Renv. auto.
+  Qed.
+
+ (** The simulation relation for evaluation of expressions.
+
+     The relation connects
+
+       - the global state at the Imp level
+
+       - the memory and register states at the Asm level
+
+     and, additionally the returned value at the _Imp_ level. The _Asm_ side
+     does not carry a [value], but a [unit], since its denotation does not
+     return any [value].
+
+     The [sim_rel] relation is parameterized by the state of the local [asm]
+     environment before the step, and the name of the variable used to store the
+     result.
+
+
+     It enforces three conditions:
+     - [Renv] on the global environments, ensuring that evaluation of expressions does
+     not change user variables;
+
+     - Agreement on the computed value, i.e. the returned value [v] is stored at
+     the assembly level in the expected temporary;
+
+     - The "stack" of temporaries used to compute intermediate results is left
+       untouched.
+  *)
+  Definition sim_rel l_asm n: (map * value) -> (registers * memory * unit) -> Prop :=
+    fun '(g_imp', v) '(l_asm',g_asm', _)  =>
+      Renv g_imp' g_asm' /\            (* we don't corrupt any of the imp variables *)
+      l_asm' n = v /\          (* we get the right value *)
+      (forall m, m < n -> forall v,              (* we don't mess with anything on the "stack" *)
+            l_asm m = v <-> l_asm' m = v).
+
+  Lemma sim_rel_find : forall g_asm g_imp l_asm l_asm' n  v,
+    sim_rel l_asm n (g_imp, v) (l_asm', g_asm, tt) ->
+    l_asm' n = v.
+  Proof.
+    intros. red in H. tauto.
+  Qed.
+
+  (** ** Facts on the simulation relations *)
+
+  (** [Renv] entails agreement of lookup of user variables. *)
+  Lemma Renv_find:
+    forall g_asm g_imp x,
+      Renv g_imp g_asm ->
+      g_imp x = g_asm x.
+  Proof.
+    intros. auto.
+  Qed.
+
+  (** [sim_rel] can be initialized from [Renv]. *)
+  Lemma sim_rel_add: forall g_asm l_asm g_imp n v,
+      Renv g_imp g_asm ->
+      sim_rel l_asm n  (g_imp, v) ((update_reg n v l_asm, g_asm, tt)).
+  Proof.
+    intros. red. split; auto. split; auto.
+    - unfold update_reg. rewrite Nat.eqb_refl. auto.
+    - intros. assert (n <> m). lia.
+      unfold update_reg. apply Nat.eqb_neq in H1. rewrite H1. split; auto.
+  Qed.
+
+  (** [Renv] can be recovered from [sim_rel]. *)
+  Lemma sim_rel_Renv: forall l_asm n s1 l v1 s2 v2,
+      sim_rel l_asm n (s2,v2) (l,s1,v1) -> Renv s2 s1 .
+  Proof.
+    intros ? ? ? ? ? ? ? H; apply H.
+  Qed.
+
+  Lemma sim_rel_find_tmp_n:
+    forall l_asm g_asm' n l_asm' g_imp' v,
+      sim_rel l_asm n  (g_imp',v) (l_asm', g_asm', tt) ->
+      l_asm' n = v.
+  Proof.
+    intros ? ? ? ? ? ? [_ [H _]]; exact H.
+  Qed.
+
+  (** [sim_rel] entails agreement of lookups in the "stack" between its argument
+      and the current Asm environement *)
+  Lemma sim_rel_find_tmp_lt_n:
+    forall l_asm g_asm' n m l_asm' g_imp' v,
+      m < n ->
+      sim_rel l_asm n (g_imp',v) (l_asm', g_asm', tt) ->
+      l_asm m = l_asm' m.
+  Proof.
+    intros ? ? ? ? ? ? ? ineq [_ [_ H]].
+    match goal with
+    | |- _ = ?x => destruct x eqn:EQ
+    end.
+    setoid_rewrite (H _ ineq); auto.
+    apply H; auto.
+  Qed.
+
+  Lemma sim_rel_find_tmp_n_trans:
+    forall l_asm n l_asm' l_asm'' g_asm' g_asm'' g_imp' g_imp'' v v',
+      sim_rel l_asm n (g_imp',v) (l_asm', g_asm', tt)  ->
+      sim_rel l_asm' (S n) (g_imp'',v') (l_asm'', g_asm'', tt)  ->
+      l_asm'' n = v.
+  Proof.
+    intros.
+    generalize H; intros LU; apply sim_rel_find_tmp_n in LU.
+    unfold alist_In in LU; erewrite sim_rel_find_tmp_lt_n in LU; eauto.
+  Qed.
+
+  (** [Renv] is preserved by assignment.
+   *)
+  Lemma Renv_write_local:
+    forall (k : var) (g_asm g_imp : map) v,
+      Renv g_imp g_asm ->
+      Renv (update k v g_imp) (update k v g_asm).
+  Proof.
+    unfold Renv. intros. unfold update.
+    destruct (k =? x)%string; auto.
+  Qed.
+
+  (** [sim_rel] can be composed when proving binary arithmetic operators. *)
+  Lemma sim_rel_binary_op:
+    forall (l_asm l_asm' l_asm'' : registers) (g_asm' g_asm'' : memory) (g_imp' g_imp'' : map)
+      (n v v' : nat)
+      (Hsim : sim_rel l_asm n (g_imp', v) (l_asm', g_asm', tt))
+      (Hsim': sim_rel l_asm' (S n) (g_imp'', v') (l_asm'', g_asm'', tt))
+      (op: nat -> nat -> nat),
+      sim_rel l_asm n (g_imp'', op v v') (update_reg n (op v v') l_asm'', g_asm'', tt).
+  Proof.
+    intros.
+    split; [| split].
+    - eapply sim_rel_Renv; eassumption.
+    - unfold update_reg. rewrite Nat.eqb_refl; auto.
+    - intros m LT v''. assert (n <> m). lia.
+      destruct Hsim as [_ [_ Hsim]].
+      destruct Hsim' as [_ [_ Hsim']].
+      rewrite Hsim; [| auto with arith].
+      rewrite Hsim'; [| auto with arith].
+      unfold update_reg. apply Nat.eqb_neq in H. rewrite H. reflexivity.
+  Qed.
+
+End Simulation_Relation.
+
+(* ================================================================= *)
+(** ** Bisimulation *)
+
+(** We now make precise the bisimulation established to show the correctness of
+    the compiler.  Naturally, we cannot establish a _strong bisimulation_
+    between the source program and the target program: the [asm] counterpart
+    performs "more steps" when evaluating expressions.  The appropriate notion
+    is of course the _equivalence up to tau_. However, the [itree] structures
+    are also quite different.  [asm] programs manipulate two state
+    components. The simulation will establish that the [imp] global state
+    corresponds to the [asm] memory, but to be able to  establish this
+    correspondence, we also need to interpret the [asm] register effects.  *)
+
+Section Bisimulation.
+
+
+  (** Definition of our bisimulation relation.
+
+      As previously explained, the bisimulation relates (up-to-tau)
+      two [itree]s after having interpreted their events.
+
+      We additionally bake into it a simulation invariant:
+      - Events are interpreted from states related by [Renv]
+      - Returned values must contain related states, as well as computed datas
+        related by another relation [RAB] taken in parameter.
+      In our case, we will specialize [RAB] to the total relation since the trees return
+      respectively [unit] and the unique top-level label [F0: fin 1].
+   *)
+
+  Section RAB.
+
+    Context {A B : Type}.
+    Context (RAB : A -> B -> Prop).  (* relation on Imp / Asm values *)
+
+    Definition state_invariant (a : map * A) (b : registers * memory * B)  :=
+      Renv (fst a) (snd (fst b)) /\ (RAB (snd a) (snd  b)).
+
+    Definition bisimilar  (t1 : itree ((impExcE sensitivity_lat) +' stateE +' (IOE sensitivity_lat)) A) (t2 : itree ((impExcE sensitivity_lat) +' Reg +' Memory +' (IOE sensitivity_lat)) B)  :=
+    forall g_asm g_imp l,
+      Renv g_imp g_asm ->
+      eutt state_invariant
+           (interp_imp _ t1 g_imp)
+           (interp_asm t2 (l, g_asm) ).
+  End RAB.
+
+
+  (** [bisimilar] is compatible with [eutt]. *)
+
+  Global Instance eutt_bisimilar  {A B}  (RAB : A -> B -> Prop):
+    Proper (eutt eq ==> eutt eq ==> iff) (@bisimilar A B RAB).
+  Proof.
+    repeat intro.
+    unfold bisimilar. split.
+    - intros. unfold interp_imp, interp_asm. rewrite <- H, <-H0.
+      apply H1; auto.
+    - intros. unfold interp_imp, interp_asm.
+      rewrite H, H0. apply H1; auto.
+  Qed.
+
+  Lemma bisimilar_bind' {A A' B C} (RAA' : A -> A' -> Prop) (RBC: B -> C -> Prop):
+    forall (t1 : itree _ A) (t2 : itree _ A') ,
+      bisimilar RAA' t1 t2 ->
+      forall (k1 : A -> itree _ B) (k2 : A' -> itree _ C)
+        (H: forall (a:A) (a':A'), RAA' a a' -> bisimilar RBC (k1 a) (k2 a')),
+        bisimilar RBC (t1 >>= k1) (t2 >>= k2).
+  Proof.
+    repeat intro. unfold interp_asm, interp_imp.
+    repeat rewrite interp_state_bind.
+    eapply eutt_clo_bind.
+    { eapply H; auto. }
+    intros [s1 a] [ [regs mem] a'].
+    intros Hs. destruct Hs.
+    cbn in *. eapply H0; eauto.
+  Qed.
+
+  Lemma bisimilar_iter {A A' B B'}
+        (R : A -> A' -> Prop)
+        (S : B -> B' -> Prop)
+        (t1 : A -> itree (_) (A + B))
+        (t2 : A' -> itree (_) (A' + B')) :
+    (forall l l', R l l' -> bisimilar (sum_rel R S) (t1 l) (t2 l')) ->
+    forall x x', R x x' ->
+    bisimilar S (iter (C := ktree _) t1 x) (iter (C := ktree _) t2 x').
+  Proof.
+
+    unfold bisimilar, interp_asm, interp_imp.
+    intros.
+    pose proof @interp_state_iter'. unfold state_eq in H2.
+    repeat setoid_rewrite H2.
+    eapply (eutt_iter' (state_invariant R)); intros.
+    2 : { split; auto. }
+    destruct H3. destruct j1 as [s1 a].
+    destruct j2 as [ [regs1 mem1] a']. cbn in *.
+    eapply eutt_clo_bind; eauto. intros [s2 r1] [ [regs2 mem2 ] r2 ] Hs.
+    red in Hs. cbn in *. destruct Hs as [Hs Hr].
+    inv Hr;
+    apply eqit_Ret; constructor; split; auto.
+  Qed.
+
+  (** [sim_rel] at [n] entails that [GetVar (gen_tmp n)] gets interpreted
+      as returning the same value as the _Imp_ related one.
+   *)
+  Lemma sim_rel_get_tmp0:
+    forall n l l' g_asm g_imp v,
+      sim_rel l' n (g_imp,v) (l, g_asm,tt) ->
+      (interp_asm ((trigger (GetReg n)) : itree ((impExcE sensitivity_lat) +' Reg +' Memory +' (IOE sensitivity_lat)) value)
+                                       (l, g_asm))
+      ≈     (Ret (l, g_asm, v)).
+  Proof.
+    intros.
+    unfold interp_asm.
+    rewrite interp_state_trigger.
+    cbn. apply eqit_Ret.
+    destruct H. destruct H0. cbv. rewrite H0. auto.
+  Qed.
+
+
+End Bisimulation.
+
+(* ================================================================= *)
+(** ** Linking *)
+
+(** We first show that our "high level" [asm] combinators are correct.  These
+    proofs are mostly independent from the compiler, and therefore fairly
+    reusable.  Once again, these notion of correctness are expressed as
+    equations commuting the denotation with the combinator.  *)
+
+Section Linking.
+
+  Import KTreeFin.
+
+  (** [seq_asm] is denoted as the (horizontal) composition of denotations. *)
+  Lemma seq_asm_correct {A B C} (ab : asm A B) (bc : asm B C) :
+      denote_asm (seq_asm ab bc)
+    ⩯ denote_asm ab >>> denote_asm bc.
+  Proof.
+    unfold seq_asm.
+    rewrite loop_asm_correct, relabel_asm_correct, app_asm_correct.
+
+    rewrite fmap_id0, cat_id_r, fmap_swap.
+    apply cat_from_loop.
+  Qed.
+(*
+  Check fun (E : Type -> Type) Case (ktree_fin ) *)
+
+  Definition reassoc_seq_asm_exc {B C D : nat} : fin ((B + C) + (D + C) ) -> fin (B + (D + C) ) :=
+    ((assoc_r >>> bimap (id_ B) (bimap (id_ C) swap >>> assoc_l >>>
+                                                          bimap merge (id_ D) >>> swap))).
+(* we can compute this functions behavior on each of all parts of its element space with like 4 equations *)
+
+  Lemma reassoc_seq_asm_exc_B (B C D : nat) (b : fin B) (bc : fin (B + C) ) :
+     split_fin_sum B C  bc = inl b -> reassoc_seq_asm_exc (L (D + C) bc) = L (D + C) b.
+  Proof.
+    intros. unfold reassoc_seq_asm_exc. cbn.
+    unfold cat, Cat_sub, cat, Cat_Fun.
+    unfold assoc_r, AssocR_Coproduct, case_, Case_sub, case_, Case_Kleisli, case_sum.
+    cbn. unfold to_bif, ToBifunctor_Fun_fin. unfold swap, Swap_Coproduct, case_.
+    unfold bimap, Bimap_Coproduct, case_, cat. cbn. rewrite split_fin_sum_L. rewrite H.
+    repeat rewrite split_fin_sum_L. auto.
+  Qed.
+
+  Lemma reassoc_seq_asm_exc_C_ab (B C D : nat ) (c : fin C) (bc : fin (B + C) ) :
+    split_fin_sum B C bc = inr c -> @reassoc_seq_asm_exc B C D (L _ bc ) = R _ (R _ c).
+  Proof.
+    intros. unfold reassoc_seq_asm_exc. cbn.
+    unfold cat, Cat_sub, cat, Cat_Fun.
+    unfold assoc_r, AssocR_Coproduct, case_, Case_sub, case_, Case_Kleisli, case_sum.
+    cbn. unfold to_bif, ToBifunctor_Fun_fin. unfold swap, Swap_Coproduct, case_.
+    unfold bimap, Bimap_Coproduct, case_, cat. cbn.
+    repeat rewrite split_fin_sum_L. repeat rewrite split_fin_sum_R. rewrite H. cbn.
+    repeat rewrite split_fin_sum_L. repeat rewrite split_fin_sum_R. cbn.
+    repeat rewrite split_fin_sum_L. repeat rewrite split_fin_sum_R. cbn.
+    unfold assoc_l, AssocL_Coproduct. cbn. unfold case_.
+    repeat rewrite split_fin_sum_L. repeat rewrite split_fin_sum_R. cbn.
+    repeat rewrite split_fin_sum_L. repeat rewrite split_fin_sum_R. cbn.
+    unfold merge, case_. repeat rewrite split_fin_sum_L. repeat rewrite split_fin_sum_R. cbn.
+    auto.
+  Qed.
+
+  Lemma reassoc_seq_asm_exc_D (B C D : nat ) (d : fin D) (dc : fin (D + C) ) :
+    split_fin_sum D C dc = inl d -> @reassoc_seq_asm_exc B C D (R _ dc ) = R _ (L _ d).
+  Proof.
+    intros. unfold reassoc_seq_asm_exc. cbn.
+    unfold cat, Cat_sub, cat, Cat_Fun.
+    unfold assoc_r, AssocR_Coproduct, case_, Case_sub, case_, Case_Kleisli, case_sum.
+    cbn. unfold to_bif, ToBifunctor_Fun_fin. unfold swap, Swap_Coproduct, case_.
+    unfold bimap, Bimap_Coproduct, case_, cat. cbn.
+    repeat rewrite split_fin_sum_L. repeat rewrite split_fin_sum_R. cbn.
+    repeat rewrite split_fin_sum_L. repeat rewrite split_fin_sum_R. cbn. rewrite H.
+    unfold assoc_l, AssocL_Coproduct. cbn. unfold case_. cbn.
+    repeat rewrite split_fin_sum_L. repeat rewrite split_fin_sum_R. cbn. auto.
+  Qed.
+
+  Lemma reassoc_seq_asm_exc_C_bd (B C D : nat ) (c : fin C) (dc : fin (D + C) ) :
+    split_fin_sum D C dc = inr c -> @reassoc_seq_asm_exc B C D (R _ dc ) = R _ (R _ c).
+  Proof.
+    intros. unfold reassoc_seq_asm_exc. cbn.
+    unfold cat, Cat_sub, cat, Cat_Fun.
+    unfold assoc_r, AssocR_Coproduct, case_, Case_sub, case_, Case_Kleisli, case_sum.
+    cbn. unfold to_bif, ToBifunctor_Fun_fin. unfold swap, Swap_Coproduct, case_.
+    unfold bimap, Bimap_Coproduct, case_, cat. cbn.
+    repeat rewrite split_fin_sum_L. repeat rewrite split_fin_sum_R. cbn. rewrite H.
+    repeat rewrite split_fin_sum_L. repeat rewrite split_fin_sum_R. cbn.
+    unfold assoc_l, AssocL_Coproduct. cbn. unfold case_. cbn.
+    repeat rewrite split_fin_sum_L. repeat rewrite split_fin_sum_R.
+    repeat rewrite split_fin_sum_L. repeat rewrite split_fin_sum_R.
+    unfold merge. unfold case_. rewrite split_fin_sum_R. auto.
+  Qed.
+
+  Lemma seq_asm_exc_correct {A B C D} (ab : asm A (B + C)) (bd : asm B (D + C)) :
+     denote_asm (seq_asm_exc ab bd)
+   ⩯ denote_asm ab  >>> case_ (denote_asm bd) inr_.
+  Proof.
+    unfold seq_asm_exc, expose_linking_labels, swap_and_merge, comb.
+    rewrite loop_asm_correct, relabel_asm_correct, app_asm_correct. rewrite cat_id_r.
+    repeat rewrite fmap_swap.
+    match goal with |- loop ?b ⩯ _ =>  set b as body end.
+    assert (forall a : fin A, body (merge_fin_sum _ _ (inr a)) ≈
+                              r <- denote_asm ab a;;
+                         Ret
+                           (reassoc_seq_asm_exc (L _ r) )).
+
+    {
+      intros. match goal with |- _ ≈ ?t => remember t as t' end.
+      unfold body. cbn. repeat setoid_rewrite bind_ret_l.
+      rewrite bind_bind. rewrite split_fin_sum_R. cbn.
+      repeat rewrite bind_ret_l. Local Opaque denote_asm. unfold from_bif, FromBifunctor_ktree_fin.
+      rewrite bind_ret_l. rewrite split_merge. cbn.
+      setoid_rewrite bind_ret_l. rewrite bind_bind.
+      unfold from_bif, FromBifunctor_ktree_fin. setoid_rewrite bind_ret_l.
+      cbn. unfold unsubm. subst. unfold reassoc_seq_asm_exc. reflexivity.
+    } (* this unfolding basically shows that you only need to unfold the top level loop twice*)
+    assert (forall b : fin B, body (merge_fin_sum _ _ (inl b) ) ≈
+                              r <- denote_asm bd b;;
+                         Ret (reassoc_seq_asm_exc (R _ r) )).
+    {
+      intros. unfold body. cbn. repeat setoid_rewrite bind_ret_l.
+      rewrite split_fin_sum_L. cbn. repeat setoid_rewrite bind_ret_l.
+      rewrite split_merge. cbn. rewrite bind_bind. setoid_rewrite bind_ret_l.
+      unfold from_bif, FromBifunctor_ktree_fin. setoid_rewrite bind_ret_l.
+      cbn. unfold unsubm. unfold reassoc_seq_asm_exc. reflexivity.
+    }
+    assert (body ⩯ case_
+                 (denote_asm bd >>> (fun r => Ret (reassoc_seq_asm_exc (R _ r) ) ))
+                 (denote_asm ab >>> (fun r => Ret (reassoc_seq_asm_exc (L _ r)) ))).
+    { do 5 red. unfold case_, Case_sub. unfold to_bif, ToBifunctor_ktree_fin.
+      cbn.
+      intros. destruct (split_fin_sum B A a) eqn : Heq.
+      - rewrite bind_ret_l. cbn. rewrite <- H0. rewrite <- Heq. rewrite merge_split. reflexivity.
+      - rewrite bind_ret_l. cbn. rewrite <- H. rewrite <- Heq. rewrite merge_split. reflexivity.
+    }
+    rewrite H1.
+    do 5 red. intros. Local Opaque denote_asm. unfold loop. cbn.
+    rewrite bind_bind. rewrite bind_ret_l. unfold from_bif, FromBifunctor_ktree_fin.
+    rewrite bind_ret_l. cbn.
+    setoid_rewrite unfold_iter_ktree. cbn. unfold to_bif, ToBifunctor_ktree_fin.
+    repeat rewrite split_fin_sum_R. repeat rewrite bind_bind. rewrite bind_ret_l.
+    cbn. rewrite bind_bind. eapply eqit_bind'; try reflexivity. intros; subst.
+    repeat setoid_rewrite bind_ret_l.
+    destruct (split_fin_sum _ _ r2) as [b | c] eqn : Heq.
+    - erewrite reassoc_seq_asm_exc_B; eauto. rewrite split_fin_sum_L. cbn.
+      repeat setoid_rewrite bind_ret_l. rewrite split_merge. rewrite tau_eutt.
+      setoid_rewrite unfold_iter_ktree. cbn. repeat rewrite bind_bind.
+      repeat setoid_rewrite bind_ret_l. cbn. rewrite split_fin_sum_L. cbn.
+      rewrite bind_bind. setoid_rewrite bind_ret_l. cbn.
+      match goal with |- eqit eq true true (ITree.bind _ ?k ) _ => remember k as k_id  end.
+      assert (forall r, k_id r ≈ Ret r ).
+      {
+        subst. intros. destruct (split_fin_sum _ _ r) as [d | c] eqn : Heqr .
+        - erewrite  reassoc_seq_asm_exc_D; eauto. rewrite split_fin_sum_R. cbn.
+          repeat rewrite bind_ret_l. unfold from_bif, FromBifunctor_ktree_fin.
+          cbn. rewrite bind_ret_l. rewrite split_fin_sum_R. cbn.
+          unfold id. apply eqit_Ret.
+          apply unique_fin.
+          unfold split_fin_sum in Heqr.
+          destruct (lt_dec (proj1_sig r) D ); try discriminate.
+          injection Heqr as Heqr. rewrite <- Heqr. cbn. auto.
+        - erewrite reassoc_seq_asm_exc_C_bd; eauto. rewrite split_fin_sum_R.
+          cbn. repeat setoid_rewrite bind_ret_l. rewrite split_merge.
+          unfold split_fin_sum in Heqr. destruct r. cbn in Heqr.
+          destruct (lt_dec x D); try discriminate. injection Heqr as Heqr.
+          subst. cbn. apply eqit_Ret. apply unique_fin. cbn.
+          lia.
+      }
+      setoid_rewrite <- bind_ret_r at 3.
+      eapply eqit_bind'; try reflexivity. clear Heqk_id. intros; subst.
+      rewrite H2. reflexivity.
+    - erewrite reassoc_seq_asm_exc_C_ab; eauto. rewrite split_fin_sum_R.
+      cbn. repeat setoid_rewrite bind_ret_l. rewrite split_merge.
+      cbn. unfold from_bif, FromBifunctor_ktree_fin. cbn. reflexivity.
+  Qed.
+
+    (* remaining goals in this lemma could all be solved with proof irrelavance *)
+
+  (** [if_asm] is denoted as the ktree first denoting the branching condition,
+      then looking-up the appropriate variable and following with either denotation. *)
+  Lemma if_asm_correct {A} (e : list instr) (tp fp : asm 1 A) :
+      denote_asm (if_asm e tp fp)
+    ⩯ ((fun _ =>
+         denote_list e ;;
+         v <- trigger (GetReg tmp_if) ;;
+         if v : value then denote_asm fp f0 else denote_asm tp f0)).
+  Proof.
+    unfold if_asm.
+    rewrite seq_asm_correct.
+    unfold cond_asm.
+    rewrite raw_asm_block_correct_lifted.
+    rewrite relabel_asm_correct.
+
+    intros ?.
+    Local Opaque denote_asm.
+
+    unfold CategoryOps.cat, Cat_sub, CategoryOps.cat, Cat_Kleisli; simpl.
+    rewrite denote_after.
+    cbn.
+    repeat setoid_rewrite bind_bind.
+    apply eqit_bind; try reflexivity. intros _.
+    apply eqit_bind; try reflexivity. intros [].
+
+    - rewrite !bind_ret_l.
+      setoid_rewrite (app_asm_correct tp fp _).
+      setoid_rewrite bind_bind.
+      match goal with
+      | [ |- _ (?t >>= _) _ ] => let y := eval compute in t in change t with y
+      end.
+      rewrite bind_ret_l. cbn.
+      setoid_rewrite bind_ret_l.
+      rewrite bind_bind.
+      setoid_rewrite bind_ret_l.
+      unfold from_bif, FromBifunctor_ktree_fin; cbn.
+      rewrite bind_ret_r'.
+      { rewrite (unique_f0 (fi' 0)). reflexivity. }
+      { intros.
+        Local Opaque split_fin_sum R. cbv. Local Transparent split_fin_sum R.
+        rewrite split_fin_sum_R. reflexivity. }
+
+    - rewrite !bind_ret_l.
+      setoid_rewrite (app_asm_correct tp fp _).
+      repeat setoid_rewrite bind_bind.
+      match goal with
+      | [ |- _ (?t >>= _) _ ] => let y := eval compute in t in change t with y
+      end.
+      rewrite bind_ret_l. cbn. rewrite bind_bind.
+      setoid_rewrite bind_ret_l.
+      unfold from_bif, FromBifunctor_ktree_fin.
+      setoid_rewrite bind_ret_l.
+      rewrite bind_ret_r'.
+      { rewrite (unique_f0 (fi' 0)). reflexivity. }
+      { intros. Local Opaque split_fin_sum L. cbv. Local Transparent split_fin_sum R.
+        rewrite split_fin_sum_L. reflexivity. }
+  Qed.
+
+  (** [while_asm] is denoted as the loop of the body with two entry point, the exit
+      of the loop, and the body in which we have the same structure as for the conditional *)
+  Notation label_case := (split_fin_sum _ _).
+
+  Lemma while_asm_correct (e : list instr) (p : asm 1 1) :
+      denote_asm (while_asm e p)
+    ⩯ (loop (C := sub (ktree _) fin) (fun l : fin (1 + 1) =>
+         match label_case l with
+         | inl _ =>
+           denote_list e ;;
+           v <- trigger (GetReg tmp_if) ;;
+           if (v:value) then Ret (fS f0) else (denote_asm p f0;; Ret f0)
+         | inr _ => Ret f0
+         end)).
+  Proof.
+    unfold while_asm.
+    rewrite loop_asm_correct.
+    apply Proper_loop.
+    rewrite relabel_asm_correct.
+    rewrite fmap_id0, cat_id_l.
+    rewrite app_asm_correct.
+    rewrite if_asm_correct.
+    intros x.
+    cbn.
+    unfold to_bif, ToBifunctor_ktree_fin.
+    rewrite bind_ret_l.
+    destruct (label_case x); cbn.
+    - rewrite !bind_bind. setoid_rewrite bind_ret_l. setoid_rewrite bind_bind.
+      eapply eutt_clo_bind; try reflexivity. intros; subst.
+      repeat rewrite bind_bind.
+      eapply eutt_clo_bind; try reflexivity. intros; subst.
+      unfold from_bif, FromBifunctor_ktree_fin; cbn.
+      repeat rewrite bind_bind.
+      repeat setoid_rewrite bind_ret_l.
+      destruct u0.
+      + rewrite (pure_asm_correct _ _); cbn.
+        rewrite !bind_ret_l.
+        apply eqit_Ret.
+        apply unique_fin; reflexivity.
+
+      + rewrite (relabel_asm_correct _ _ _ _). cbn.
+        rewrite bind_ret_l.
+        setoid_rewrite bind_bind.
+        eapply eutt_clo_bind; try reflexivity.
+        intros ? ? [].
+        repeat rewrite bind_ret_l.
+        apply eqit_Ret.
+        rewrite (unique_f0 u1).
+        apply unique_fin; reflexivity.
+
+    - cbn.
+      rewrite (pure_asm_correct _ _).
+      rewrite bind_bind. cbn.
+      unfold from_bif, FromBifunctor_ktree_fin.
+      rewrite !bind_ret_l.
+      apply eqit_Ret.
+      rewrite (unique_f0 f).
+      apply unique_fin; reflexivity.
+Qed.
+
+Definition relabel_output  : fin (1 + 2) -> fin (1 + (1 + 2)) :=
+  bimap (id_ _) inr_.
+
+Lemma while_asm_exc_correct (e : list instr) (p : asm 1 (1 + 2 )) :
+   denote_asm (while_asm_exc e p)
+ ⩯ (loop (C := sub (ktree _) fin) (fun l : fin (1 + 1) =>
+         match label_case l with
+         | inl _ =>
+           denote_list e;;
+           v <- trigger (GetReg tmp_if) ;;
+           if (v:value)
+           then Ret (fS f0)
+           else (l' <- denote_asm p f0;; Ret (relabel_output l')  )
+         | inr _ => Ret (f0)
+         end)) .
+Proof.
+  unfold while_asm_exc. rewrite loop_asm_correct. apply Proper_loop.
+  rewrite relabel_asm_correct. rewrite app_asm_correct. rewrite pure_asm_correct.
+  rewrite if_asm_correct. cbn.  rewrite fmap_id0. rewrite cat_id_l.
+  unfold relabel_output.
+  do 5 red. intros. unfold cat, Cat_sub, cat, Cat_Kleisli.
+  cbn. rewrite bind_bind. setoid_rewrite bind_ret_l. cbn.
+  destruct (label_case (a : fin (1 + 1) )); cbn.
+  - repeat setoid_rewrite bind_bind. eapply eqit_bind'; try reflexivity. intros [] [] _ ; subst.
+    eapply eqit_bind'; try reflexivity. intros; subst.
+    destruct r2.
+    + specialize @pure_asm_correct as Hpac. do 5 red in Hpac. setoid_rewrite Hpac.
+      clear Hpac. cbn. repeat setoid_rewrite bind_ret_l.
+      apply eqit_Ret. cbn. unfold unsubm. Local Transparent L. apply unique_fin.
+      auto.
+    + unfold direct_output_while_exc. specialize @relabel_asm_correct as Hrac.
+      do 5 red in Hrac. rewrite Hrac. cbn. repeat rewrite bind_bind.
+      repeat setoid_rewrite bind_ret_l. cbn. unfold unsubm, id_, Id_sub, id_, Id_Fun.
+      eapply eqit_bind'; try reflexivity. intros; subst. apply eqit_Ret. apply unique_fin.
+      Local Transparent L. destruct r0 as [n Hn]. Opaque L.
+      do 3 (destruct n; auto). lia.
+  - unfold cat, Cat_sub, cat, Cat_Kleisli. cbn. rewrite bind_bind.
+    rewrite bind_ret_l. unfold inr_, Inr_sub, inr_, Inr_Kleisli, lift_ktree_. cbn.
+    unfold cat. rewrite bind_bind. rewrite bind_ret_l. unfold from_bif, FromBifunctor_ktree_fin.
+    rewrite bind_ret_l.
+    setoid_rewrite unique_f0. cbn.
+    unfold unsubm.  unfold merge, case_, Case_sub, to_bif, ToBifunctor_Fun_fin.
+    cbn. unfold cat, Cat_Fun.  rewrite split_fin_sum_R. apply eqit_Ret.
+    cbn. unfold id_, Id_sub, id_, Id_Fun. cbn. apply unique_fin. cbn. Local Transparent L.
+    auto.
+Qed.
+
+Lemma trycatch_asm_correct (p : asm 1 (1 + (1 + 1) )) (c : asm 1 3) :
+  denote_asm (trycatch_asm p c)
+⩯ denote_asm p >>> case_ inl_ (merge >>> denote_asm c ).
+Proof.
+ unfold trycatch_asm. rewrite seq_asm_correct. repeat rewrite relabel_asm_correct.
+ rewrite app_asm_correct.  do 5 red. intros. cbn.
+ repeat rewrite bind_bind. repeat setoid_rewrite bind_ret_l.
+ unfold unsubm, id_, Id_sub, id_, Id_Fun. eapply eqit_bind'; try reflexivity.
+ intros; subst. cbn. destruct r2 as [l Hl].
+ do 3 (try destruct l as [ | l]; auto); try lia; cbn; repeat rewrite bind_bind.
+ - repeat setoid_rewrite bind_ret_l. cbn. unfold pure_ret_asm.
+   specialize (@pure_asm_correct) as Hpac. do 5 red in Hpac. rewrite Hpac.
+   setoid_rewrite bind_ret_l. apply eqit_Ret. cbn. apply unique_fin. auto.
+ - repeat setoid_rewrite bind_ret_l. cbn. unfold id.
+   unfold merge, case_, Case_sub, case_, Case_Kleisli, case_sum, to_bif, ToBifunctor_Fun_fin.
+   cbn. setoid_rewrite <- bind_ret_r at 4. eapply eqit_bind' with (RR := eq).
+   + match goal with |- eqit eq true true (denote_asm c ?f1) (denote_asm c (?f2) ) => assert (f1 = f2) end.
+   { apply unique_fin. auto. }
+   timeout 5 rewrite H. reflexivity.
+   + intros; subst. destruct r2. cbn. apply eqit_Ret. apply unique_fin. cbn. lia.
+ - repeat setoid_rewrite bind_ret_l. cbn. setoid_rewrite <- bind_ret_r at 4.
+   eapply eqit_bind' with (RR := eq).
+   + match goal with |- eqit eq true true (denote_asm c ?f1) (denote_asm c (?f2) ) => assert (f1 = f2) end.
+     { apply unique_fin. auto. }
+     rewrite H. reflexivity.
+   + intros; subst. apply eqit_Ret. apply unique_fin. destruct r2. cbn. lia.
+Qed.
+
+
+  Definition link_with_exc : ktree_fin ((impExcE sensitivity_lat) +' Reg +' Memory +' (IOE sensitivity_lat)) (1 + 2) 1  :=
+    case_ (id_ _)
+    (case_ (C := ktree_fin _ )
+            (fun _ : fin 1 => v <- trigger (Throw Public);; match v : void with end )
+            (fun _ : fin 1 => v <- trigger (Throw Private);; match v : void with end )).
+
+  Lemma compile_compile_stmt_correct (s : stmt sensitivity_lat) :
+    denote_asm (compile s)
+  ⩯ denote_asm (compile_stmt s) >>> link_with_exc .
+  Proof.
+    unfold compile, link_with_exc.
+    cbn in *. rewrite seq_asm_correct. rewrite relabel_asm_correct. remember (app_asm (raise_asm Public) (raise_asm Private) ) as app.
+    assert (denote_asm (app_asm (@id_asm 1) app) ⩯ bimap (denote_asm id_asm) (denote_asm app) ).
+    { rewrite app_asm_correct. reflexivity. }
+    rewrite H. unfold id_asm. rewrite pure_asm_correct. rewrite Heqapp.
+    rewrite app_asm_correct.
+    do 5 red. intros. Opaque denote_asm. cbn. eapply eqit_bind'; try reflexivity. intros; subst.
+    repeat setoid_rewrite bind_bind. repeat setoid_rewrite bind_ret_l. cbn.
+    destruct r2 as [l Hl].
+    do 3 (try destruct l as [ | l]; cbn ); try lia; repeat setoid_rewrite bind_ret_l.
+    - apply eqit_Ret. apply unique_fin. auto.
+    - cbn. rewrite bind_bind. setoid_rewrite bind_ret_l. cbn.
+      rewrite bind_bind. Transparent denote_asm. tau_steps.  apply eqit_Vis. intros [].
+    - cbn. rewrite bind_bind. setoid_rewrite bind_ret_l. cbn.
+      rewrite bind_bind. Transparent denote_asm. tau_steps.  apply eqit_Vis. intros [].
+      Opaque denote_asm.
+  Qed.
+
+  Lemma early_link_with_exc (p1 p2: ktree_fin ((impExcE sensitivity_lat) +' Reg +' Memory +' (IOE sensitivity_lat)) 1 (1 + 2) ) :
+    p1 >>> case_ p2 inr_ >>> link_with_exc ⩯ p1 >>> link_with_exc >>> p2 >>> link_with_exc.
+  Proof.
+    unfold cat, Cat_sub, cat, Cat_Kleisli. cbn. repeat setoid_rewrite bind_bind.
+    do 5 red. intros. eapply eqit_bind'; try reflexivity. intros; subst.
+    destruct r2 as [l Hl]. do 3 (try destruct l as [ | l]; cbn ); try lia;
+                             repeat setoid_rewrite bind_ret_l.
+    - cbn. reflexivity.
+    - cbn. repeat rewrite bind_bind. eapply eqit_bind'; try reflexivity. intros [].
+    - cbn. repeat rewrite bind_bind. eapply eqit_bind'; try reflexivity. intros [].
+  Qed.
+
+
+
+(* where *)
+End Linking.
+
+(* ================================================================= *)
+(** ** Correctness *)
+
+Section Correctness.
+
+  Arguments interp_imp {Labels} {R}.
+  Arguments denote_expr {Labels}.
+  Arguments denote_stmt {Labels}.
+
+  (** Correctness of expressions.
+      We strengthen [bisimilar]: initial environments are still related by [Renv],
+      but intermediate ones must now satisfy [sim_rel].
+      Note that by doing so, we use a _heterogeneous bisimulation_: the trees
+      return values of different types ([alist var value * unit] for _Asm_,
+      [alist var value * value] for _Imp_). The difference is nonetheless mostly
+      transparent for the user, except for the use of the more general lemma [eqit_bind'].
+   *)
+  Lemma compile_expr_correct : forall e g_imp g_asm l n,
+      Renv g_imp g_asm ->
+      eutt (sim_rel l n)
+            (interp_imp (denote_expr e) g_imp)
+            (interp_asm (denote_list (compile_expr n e)) (l, g_asm) ).
+  Proof.
+    induction e; simpl; intros.
+    - (* Var case *)
+      (* We first compute and eliminate taus on both sides. *)
+      force_left.
+      rewrite tau_eutt.
+
+      tau_steps.
+
+      (* We are left with [Ret] constructs on both sides, that remains to be related *)
+      red; rewrite <-eqit_Ret.
+      unfold lookup_default, lookup, Map_alist.
+
+      (* On the _Asm_ side, we bind to [gen_tmp n] a lookup to [varOf v] *)
+      (* On the _Imp_ side, we return the value of a lookup to [varOf v] *)
+      erewrite Renv_find; [| eassumption].
+      apply sim_rel_add; assumption.
+
+    - (* Literal case *)
+      (* We reduce both sides to Ret constructs *)
+      tau_steps.
+
+      red; rewrite <-eqit_Ret.
+      (* _Asm_ bind the litteral to [gen_tmp n] while _Imp_ returns it *)
+      apply sim_rel_add; assumption.
+
+    (* The three binary operator cases are identical *)
+    - (* Plus case *)
+      (* We push [interp_locals] into the denotations *)
+
+      do 2 setoid_rewrite denote_list_app.
+      repeat setoid_rewrite interp_state_bind.
+
+      (* The Induction hypothesis on [e1] relates the first itrees *)
+      eapply eutt_clo_bind.
+      { eapply IHe1; assumption. }
+      (* We obtain new related environments *)
+      intros [g_imp' v] [ [g_asm' l'] [] ]    HSIM.
+      (* The Induction hypothesis on [e2] relates the second itrees *)
+      eapply eutt_clo_bind.
+      { eapply IHe2.
+        eapply sim_rel_Renv; eassumption. }
+      (* And we once again get new related environments *)
+      intros [g_imp'' v'] [ [g_asm'' l''] []] HSIM'.
+      (* We can now reduce down to Ret constructs that remains to be related *)
+      tau_steps.
+      red. rewrite <- eqit_Ret. clear -HSIM HSIM'.
+      red. unfold get_reg. split; try split; try tauto.
+      eapply sim_rel_Renv; eauto.
+      eapply sim_rel_find_tmp_n_trans in HSIM' as Hn; eauto. apply sim_rel_find in HSIM' as Hsn.
+      rewrite Hn. rewrite Hsn. unfold update_reg. rewrite Nat.eqb_refl. auto.
+      intros. assert (n <> m). lia. unfold update_reg.
+      apply Nat.eqb_neq in H0. rewrite H0.
+      red in HSIM'. destruct HSIM' as [_ [? ?] ]. rewrite<-  H2; eauto.
+      red in HSIM. destruct HSIM as [ ? [?  ?] ].
+      apply H5; eauto.
+    - (* Sub case *)
+      (* We push [interp_locals] into the denotations *)
+
+      do 2 setoid_rewrite denote_list_app.
+      repeat setoid_rewrite interp_state_bind.
+
+      (* The Induction hypothesis on [e1] relates the first itrees *)
+      eapply eutt_clo_bind.
+      { eapply IHe1; assumption. }
+      (* We obtain new related environments *)
+      intros [g_imp' v] [ [g_asm' l'] [] ]    HSIM.
+      (* The Induction hypothesis on [e2] relates the second itrees *)
+      eapply eutt_clo_bind.
+      { eapply IHe2.
+        eapply sim_rel_Renv; eassumption. }
+      (* And we once again get new related environments *)
+      intros [g_imp'' v'] [ [g_asm'' l''] []] HSIM'.
+      (* We can now reduce down to Ret constructs that remains to be related *)
+      tau_steps.
+      red. rewrite <- eqit_Ret. clear -HSIM HSIM'.
+      red. unfold get_reg. split; try split; try tauto.
+      eapply sim_rel_Renv; eauto.
+      eapply sim_rel_find_tmp_n_trans in HSIM' as Hn; eauto. apply sim_rel_find in HSIM' as Hsn.
+      rewrite Hn. rewrite Hsn. unfold update_reg. rewrite Nat.eqb_refl. auto.
+      intros. assert (n <> m). lia. unfold update_reg.
+      apply Nat.eqb_neq in H0. rewrite H0.
+      red in HSIM'. destruct HSIM' as [_ [? ?] ]. rewrite<-  H2; eauto.
+      red in HSIM. destruct HSIM as [ ? [?  ?] ].
+      apply H5; eauto.
+    - (* Mul case *)
+      (* We push [interp_locals] into the denotations *)
+
+      do 2 setoid_rewrite denote_list_app.
+      repeat setoid_rewrite interp_state_bind.
+
+      (* The Induction hypothesis on [e1] relates the first itrees *)
+      eapply eutt_clo_bind.
+      { eapply IHe1; assumption. }
+      (* We obtain new related environments *)
+      intros [g_imp' v] [ [g_asm' l'] [] ]    HSIM.
+      (* The Induction hypothesis on [e2] relates the second itrees *)
+      eapply eutt_clo_bind.
+      { eapply IHe2.
+        eapply sim_rel_Renv; eassumption. }
+      (* And we once again get new related environments *)
+      intros [g_imp'' v'] [ [g_asm'' l''] []] HSIM'.
+      (* We can now reduce down to Ret constructs that remains to be related *)
+      tau_steps.
+      red. rewrite <- eqit_Ret. clear -HSIM HSIM'.
+      red. unfold get_reg. split; try split; try tauto.
+      eapply sim_rel_Renv; eauto.
+      eapply sim_rel_find_tmp_n_trans in HSIM' as Hn; eauto. apply sim_rel_find in HSIM' as Hsn.
+      rewrite Hn. rewrite Hsn. unfold update_reg. rewrite Nat.eqb_refl. auto.
+      intros. assert (n <> m). lia. unfold update_reg.
+      apply Nat.eqb_neq in H0. rewrite H0.
+      red in HSIM'. destruct HSIM' as [_ [? ?] ]. rewrite<-  H2; eauto.
+      red in HSIM. destruct HSIM as [ ? [?  ?] ].
+      apply H5; eauto.
+  Qed.
+
+  (** Correctness of the assign statement.
+      The resulting list of instructions is denoted as
+      denoting the expression followed by setting the variable.
+   *)
+  Lemma compile_assign_correct : forall e x,
+      bisimilar eq
+        ((v <- denote_expr e ;; trigger (Put x v)) : itree ((impExcE sensitivity_lat) +' stateE +' (IOE sensitivity_lat)) unit)
+        ((denote_list (compile_assign x e)) : itree ((impExcE sensitivity_lat) +' Reg +' Memory +' (IOE sensitivity_lat)) unit).
+  Proof.
+    red; intros.
+    unfold compile_assign.
+    (* We push interpreters inside of the denotations *)
+    unfold interp_imp, interp_asm.
+    rewrite denote_list_app.
+    do 2 rewrite interp_state_bind.
+    (* By correctness of the compilation of expressions,
+       we can match the head trees.
+     *)
+    eapply eutt_clo_bind.
+    { eapply compile_expr_correct; eauto. }
+
+    (* Once again, we get related environments *)
+    intros [g_imp' v]  [ [g_asm' l'] y] HSIM.
+    simpl in HSIM.
+
+    (* We can now reduce to Ret constructs *)
+    tau_steps.
+    red. rewrite <- eqit_Ret.
+
+    (* And remains to relate the results *)
+    unfold state_invariant. cbn. split; auto.
+    unfold get_reg. destruct HSIM as [ ? [? ?] ].
+    rewrite H1. apply Renv_write_local; auto.
+  Qed.
+
+  Lemma compile_output_correct : forall s e,
+      bisimilar eq
+        ((v <- denote_expr e ;; trigger (LabelledPrint _ s v)) : itree ((impExcE sensitivity_lat) +' stateE +' (IOE sensitivity_lat)) unit)
+        ((@denote_list  ((impExcE sensitivity_lat) +' Reg +' Memory +' (IOE sensitivity_lat)) _ _ _ (compile_output s e))).
+  Proof.
+    red. intros. unfold compile_output. unfold interp_imp, interp_asm.
+    rewrite denote_list_app.
+    do 2 rewrite interp_state_bind.
+    eapply eutt_clo_bind.
+    { eapply compile_expr_correct; eauto. }
+    intros [g_imp' v]  [ [g_asm' l'] y] HSIM.
+    simpl in HSIM. cbn.
+    do 2 setoid_rewrite interp_state_bind. setoid_rewrite bind_bind. repeat setoid_rewrite interp_state_trigger.
+    setoid_rewrite interp_state_ret. cbn. tau_steps.
+    unfold get_reg. destruct HSIM as [? [? ?] ]. rewrite H1.
+    apply eqit_Vis. intros []. repeat setoid_rewrite bind_ret_l.
+    apply eqit_Ret. cbn. split; auto.
+  Qed.
+
+  (* The first parameter of [bisimilar] is unnecessary for this development.
+     The return type is heterogeneous, the singleton type [F 1] on one side
+     and [unit] on the other, hence we instantiate the parameter with the trivial
+     relation.
+   *)
+  Definition TT {A B}: A -> B -> Prop  := fun _ _ => True.
+  Hint Unfold TT: core.
+
+  Definition equivalent (s:stmt sensitivity_lat ) (t:asm 1 1) : Prop :=
+    bisimilar TT (denote_stmt s) (denote_asm t f0).
+
+  Inductive RI : (unit + unit) -> (unit + unit + unit) -> Prop :=
+  | RI_inl : RI (inl tt) (inl (inl tt))
+  | RI_inr : RI (inr tt) (inr tt).
+
+  (* Utility: slight rephrasing of [while] to facilitate rewriting
+     in the main theorem.*)
+  Lemma while_is_loop {E} (body : itree E (unit+unit)) :
+    while body
+          ≈ iter (C := ktree _) (fun l : unit + unit =>
+                    match l with
+                    | inl _ => x <- body;; match x with inl _ => Ret (inl (inl tt)) | inr _ => Ret (inr tt) end
+                    | inr _ => Ret (inl (inl tt))   (* Enter loop *)
+                    end) (inr tt).
+  Proof.
+    unfold while.
+    rewrite! unfold_iter_ktree.
+    rewrite bind_ret_l, tau_eutt.
+    rewrite unfold_iter_ktree.
+    rewrite unfold_iter.
+    rewrite !bind_bind.
+    eapply eutt_clo_bind. reflexivity.
+    intros. subst.
+    destruct u2 as [[]|[]].
+    2 : { force_right. reflexivity. }
+    rewrite bind_ret_l, !tau_eutt.
+    unfold iter, Iter_Kleisli.
+    apply eutt_iter' with (RI := fun _ r => inl tt = r).
+    - intros _ _ [].
+      rewrite <- bind_ret_r at 1.
+      eapply eutt_clo_bind; try reflexivity.
+      intros [|[]] _ []; apply eqit_Ret; auto; constructor; auto.
+    - constructor.
+  Qed.
+
+  Definition to_itree' {E A} (f : ktree_fin E 1 A) : itree E (fin A) := f f0.
+  Lemma fold_to_itree' {E A} (f : ktree_fin E 1 A) : f f0 = to_itree' f.
+  Proof. reflexivity. Qed.
+
+  Global Instance Proper_to_itree' {E A} :
+    Proper (eq2 ==> eutt eq) (@to_itree' E A).
+  Proof.
+    repeat intro.
+    apply H.
+  Qed.
+
+  Notation Inr_Kleisli := Inr_Kleisli.
+
+
+  Definition label_rel (r : unit + sensitivity) (l : fin 3) :=
+             match r with
+             | inl tt => proj1_sig l = 0
+             | inr Public => proj1_sig l = 1
+             | inr Private => proj1_sig l = 2 end.
+
+  Lemma throw_prefix_denote_expr (e : expr) :
+    throw_prefix (denote_expr e) ≈ r <- denote_expr e;; Ret (inl r).
+  Proof.
+    induction e.
+    - cbn. setoid_rewrite throw_prefix_ev. rewrite bind_trigger.
+      apply eqit_Vis. intros. rewrite tau_eutt. rewrite throw_prefix_ret.
+      reflexivity.
+    - cbn. rewrite throw_prefix_ret. rewrite bind_ret_l.
+      reflexivity.
+    - simpl. rewrite bind_bind. setoid_rewrite bind_bind. rewrite throw_prefix_bind.
+      rewrite IHe1. rewrite bind_bind. setoid_rewrite bind_ret_l.
+      eapply eutt_clo_bind; try reflexivity. intros; subst.
+      rewrite throw_prefix_bind. rewrite IHe2. rewrite bind_bind.
+      setoid_rewrite bind_ret_l. setoid_rewrite throw_prefix_ret.
+      reflexivity.
+    - simpl. rewrite bind_bind. setoid_rewrite bind_bind. rewrite throw_prefix_bind.
+      rewrite IHe1. rewrite bind_bind. setoid_rewrite bind_ret_l.
+      eapply eutt_clo_bind; try reflexivity. intros; subst.
+      rewrite throw_prefix_bind. rewrite IHe2. rewrite bind_bind.
+      setoid_rewrite bind_ret_l. setoid_rewrite throw_prefix_ret.
+      reflexivity.
+    -  simpl. rewrite bind_bind. setoid_rewrite bind_bind. rewrite throw_prefix_bind.
+      rewrite IHe1. rewrite bind_bind. setoid_rewrite bind_ret_l.
+      eapply eutt_clo_bind; try reflexivity. intros; subst.
+      rewrite throw_prefix_bind. rewrite IHe2. rewrite bind_bind.
+      setoid_rewrite bind_ret_l. setoid_rewrite throw_prefix_ret.
+      reflexivity.
+  Qed.
+
+
+  Lemma compile_stmt_correct (s : stmt sensitivity_lat) :
+        bisimilar label_rel (throw_prefix (denote_stmt s)) (denote_asm (compile_stmt s) f0).
+  Proof.
+    induction s.
+    - (* Assign *)
+     simpl. rewrite raw_asm_block_correct. rewrite denote_after.
+     rewrite throw_prefix_bind. rewrite throw_prefix_denote_expr.
+     rewrite bind_bind. setoid_rewrite bind_ret_l.
+     assert (forall r, throw_prefix (Err := sensitivity) (E := (stateE +' (IOE _))) (trigger (Put x r) ) ≈ trigger (Put x r);; Ret (inl tt)  ).
+     {
+       intros. rewrite bind_trigger. setoid_rewrite throw_prefix_ev.
+       apply eqit_Vis. setoid_rewrite tau_eutt. intros []. rewrite throw_prefix_ret. reflexivity.
+     }
+     setoid_rewrite H.
+     setoid_rewrite <- bind_ret_r at 6.
+     rewrite <- bind_bind.
+     setoid_rewrite bind_bind at 2.
+     eapply bisimilar_bind'.
+     { eapply compile_assign_correct; eauto. }
+     intros [] [] _. cbn. rewrite bind_ret_l.
+     red. intros. unfold interp_imp, interp_asm. repeat rewrite interp_state_ret.
+     apply eqit_Ret; split; cbn; auto.
+    - (* Seq *)
+      simpl. Opaque denote_asm. cbn.
+      assert (denote_asm (seq_asm_exc (compile_stmt s1) (compile_stmt s2)) f0 ≈
+              (denote_asm (compile_stmt s1) >>> case_ (denote_asm (compile_stmt s2)) inr_) f0).
+      { specialize (@seq_asm_exc_correct) as Hsaec.
+      do 5 red in Hsaec. rewrite Hsaec.  reflexivity. }
+      rewrite H. rewrite throw_prefix_bind.
+      cbn. eapply bisimilar_bind'; eauto.
+      intros. destruct a; cbn in H0; try destruct s.
+      + destruct u. assert (a' = f0). { apply unique_fin; auto. }
+        subst. setoid_rewrite bind_ret_l. cbn. setoid_rewrite unique_f0.
+        auto.
+      + assert (a' = fS f0). { apply unique_fin; auto. }
+        subst. setoid_rewrite bind_ret_l. cbn. rewrite bind_ret_l.
+        unfold from_bif, FromBifunctor_ktree_fin . cbn.
+        red. intros. unfold interp_imp, interp_asm.
+        repeat rewrite interp_state_ret. apply eqit_Ret.
+        split; auto.
+      + assert (a' = fS (fS f0)). { apply unique_fin; auto. }
+        subst. setoid_rewrite bind_ret_l. cbn. rewrite bind_ret_l.
+        unfold from_bif, FromBifunctor_ktree_fin . cbn.
+        red. intros. unfold interp_imp, interp_asm.
+        repeat rewrite interp_state_ret. apply eqit_Ret.
+        split; auto.
+    - (* If *)
+      simpl.  rewrite fold_to_itree'. rewrite if_asm_correct.
+      cbn. rewrite throw_prefix_bind. rewrite <- fold_to_itree'.
+      rewrite throw_prefix_denote_expr. rewrite bind_bind. setoid_rewrite bind_ret_l.
+      red. intros. unfold interp_imp, interp_asm. do 2 rewrite interp_state_bind.
+      eapply eutt_clo_bind.
+      { eapply compile_expr_correct; eauto. }
+      intros. destruct u1 as [s v]. destruct u2 as [ [reg mem] ?  ]. destruct u.
+      cbn. assert (Htmp : reg 0 = v).
+      { cbn in H0. tauto. }
+      apply sim_rel_Renv in H0.
+      rewrite interp_state_bind. rewrite interp_state_trigger. cbn.
+      rewrite bind_ret_l. cbn. setoid_rewrite Htmp.
+      destruct v.
+      + apply IHs2. auto.
+      + apply IHs1. auto.
+    - (* While *) (* throw_prefix_bind proof should be the main thing I need *)
+                  (* maybe a throw_prefix_iter as well *)
+      simpl. rewrite while_is_loop. rewrite fold_to_itree'. rewrite while_asm_exc_correct. rewrite <- fold_to_itree'.
+      setoid_rewrite throw_prefix_iter.
+      unfold loop.
+      (* might have written while_asm_exc wrong *)
+      unfold loop. cbn. setoid_rewrite bind_bind. rewrite bind_ret_l.
+      setoid_rewrite bind_ret_l.
+      eapply bisimilar_iter with (R := fun a l => match a with inl _ => proj1_sig l = 0 | inr _ => proj1_sig l = 1 end);
+      auto.
+      intros [ | ] l Hl.
+      + cbn. assert (l = f0). { apply unique_fin; auto. } rewrite H. cbn.
+        setoid_rewrite bind_bind.
+        setoid_rewrite throw_prefix_bind. rewrite throw_prefix_denote_expr.
+        repeat rewrite bind_bind. setoid_rewrite bind_bind. setoid_rewrite bind_ret_l.
+        red. intros.
+        unfold interp_asm, interp_imp.
+        do 2 rewrite interp_state_bind. eapply eutt_clo_bind.
+        {  eapply compile_expr_correct; auto. }
+        intros [m v] [ [reg mem] [] ]. cbn.
+        intros [HRenv [ Hreg0  ? ] ].
+        destruct v.
+        * setoid_rewrite bind_ret_l. setoid_rewrite throw_prefix_ret. setoid_rewrite bind_ret_l.
+          rewrite bind_trigger. rewrite interp_state_vis. cbn.
+          setoid_rewrite bind_ret_l. rewrite tau_eutt. cbn. unfold get_reg, tmp_if.
+          rewrite Hreg0. repeat setoid_rewrite bind_ret_l. cbn.
+          unfold to_bif, ToBifunctor_ktree_fin. cbn. repeat rewrite interp_state_ret.
+          apply eqit_Ret. split; auto. cbn. constructor. red. auto.
+        * repeat setoid_rewrite bind_bind. setoid_rewrite throw_prefix_bind.
+          setoid_rewrite bind_bind. rewrite bind_trigger. rewrite interp_state_vis.
+          cbn. setoid_rewrite bind_ret_l. rewrite tau_eutt. cbn. unfold get_reg, tmp_if. rewrite Hreg0.
+          setoid_rewrite bind_bind. do 2 rewrite interp_state_bind. eapply eutt_clo_bind.
+          { apply IHs. auto. }
+          intros [ st [ [] | [ | ] ] ] [ [reg' mem' ] l' ] Hst.
+          -- cbn. setoid_rewrite bind_ret_l. setoid_rewrite throw_prefix_ret.
+             setoid_rewrite bind_ret_l. cbn. red in Hst. cbn in Hst. assert (l' = f0).
+             apply unique_fin. cbn; tauto. subst. cbn. repeat setoid_rewrite bind_ret_l.
+             cbn. unfold to_bif, ToBifunctor_ktree_fin. cbn. repeat rewrite interp_state_ret.
+             apply eqit_Ret.  split; try tauto. cbn. constructor. auto.
+          -- destruct Hst. red in H3. cbn in H3. cbn. setoid_rewrite bind_ret_l.
+             assert (l' = fS f0). apply unique_fin. cbn; tauto. subst.
+             cbn. repeat setoid_rewrite bind_ret_l. cbn. unfold to_bif, ToBifunctor_ktree_fin. cbn.
+             repeat rewrite interp_state_ret. apply eqit_Ret. split; auto. constructor. red. auto.
+          -- destruct Hst. red in H3. cbn in H3. cbn. setoid_rewrite bind_ret_l.
+             assert (l' = fS (fS f0)). apply unique_fin. cbn; tauto. subst.
+             cbn. repeat setoid_rewrite bind_ret_l. cbn. unfold to_bif, ToBifunctor_ktree_fin. cbn.
+             repeat rewrite interp_state_ret. apply eqit_Ret. split; auto. constructor. red. auto.
+      + cbn. assert (l = fS f0). { apply unique_fin; auto. } subst. cbn.
+        setoid_rewrite throw_prefix_ret. setoid_rewrite bind_bind. setoid_rewrite bind_ret_l.
+        cbn. setoid_rewrite bind_bind. setoid_rewrite bind_ret_l. cbn. repeat rewrite bind_bind.
+        rewrite bind_ret_l. repeat setoid_rewrite bind_ret_l. cbn.
+        unfold to_bif, ToBifunctor_ktree_fin. cbn. red. intros.
+        unfold interp_imp, interp_asm. repeat rewrite interp_state_ret. apply eqit_Ret.
+        split; auto. cbn. constructor. auto.
+    - simpl. unfold pure_ret_asm. rewrite fold_to_itree'.
+      rewrite pure_asm_correct. rewrite throw_prefix_ret. cbn.
+      red. intros. unfold interp_imp, interp_asm. repeat rewrite interp_state_ret. apply eqit_Ret.
+      split; cbn; auto.
+    - (* Output *)
+      simpl. rewrite raw_asm_block_correct. rewrite denote_after.
+      rewrite throw_prefix_bind. rewrite throw_prefix_denote_expr.
+      rewrite bind_bind. setoid_rewrite bind_ret_l.
+      assert (forall r, throw_prefix (Err := sensitivity) (E := (stateE +' (IOE _))) (trigger (LabelledPrint _ s r) ) ≈
+                                trigger (LabelledPrint _ s r);; Ret (inl tt)  ).
+     {
+       intros. rewrite bind_trigger. setoid_rewrite throw_prefix_ev.
+       apply eqit_Vis. setoid_rewrite tau_eutt. intros []. rewrite throw_prefix_ret. reflexivity.
+     }
+     setoid_rewrite H.
+     setoid_rewrite <- bind_ret_r at 6.
+     rewrite <- bind_bind.
+     setoid_rewrite bind_bind at 2.
+     eapply bisimilar_bind'.
+     { eapply compile_output_correct; eauto. }
+     intros [] [] _. cbn. rewrite bind_ret_l.
+     red. intros. unfold interp_imp, interp_asm. repeat rewrite interp_state_ret.
+     apply eqit_Ret; split; cbn; auto.
+    - (* Raise *)
+      simpl. unfold pure_exc_asm. rewrite fold_to_itree'. rewrite pure_asm_correct.
+      cbn. unfold trigger.
+      setoid_rewrite unfold_iter_ktree. cbn. rewrite bind_ret_l.
+      red. intros. unfold interp_imp, interp_asm. repeat rewrite interp_state_ret.
+      apply eqit_Ret. split; cbn; destruct s; auto.
+    - (* TryCatch *)
+      simpl. rewrite fold_to_itree'. rewrite trycatch_asm_correct.
+      cbn. rewrite throw_prefix_of_try_catch. rewrite try_catch_to_throw_prefix.
+      set (fun (r : unit + sensitivity + sensitivity) (l :fin 3) =>
+             match r with
+             | inl (inl _ ) => label_rel (inl tt) l
+             | inl (inr s) => False
+             | inr s => label_rel (inr s) l end
+          ) as R .
+      eapply bisimilar_bind' with (RAA' := R).
+      + cbn. rewrite throw_prefix_bind. setoid_rewrite <- bind_ret_r at 5.
+        eapply bisimilar_bind'; eauto. intros.
+        destruct a.
+        * rewrite throw_prefix_ret. red. intros.
+          unfold interp_imp, interp_asm. repeat rewrite interp_state_ret.
+          apply eqit_Ret. split; auto. cbn. destruct u. cbn in H. auto.
+        * red. intros.
+          unfold interp_imp, interp_asm. repeat rewrite interp_state_ret.
+          apply eqit_Ret. split; auto.
+      + intros.  destruct a as [ [ | ] | ]; try destruct s; cbn in H; try contradiction.
+        * cbn in H. assert (a' = f0).
+          { apply unique_fin. auto. }
+          subst. repeat setoid_rewrite bind_ret_l. cbn.
+          unfold from_bif, FromBifunctor_ktree_fin.
+          red; intros.
+          unfold interp_imp, interp_asm. repeat rewrite interp_state_ret.
+          apply eqit_Ret. split; auto. cbn. destruct u. auto.
+        *  assert (a' = fS f0).
+          { apply unique_fin. auto. }
+          subst. repeat setoid_rewrite bind_ret_l. cbn.
+          repeat setoid_rewrite bind_ret_l. cbn. unfold id.
+          setoid_rewrite unique_f0. auto.
+        * assert (a' = fS (fS f0)).
+          { apply unique_fin. auto. }
+          subst. repeat setoid_rewrite bind_ret_l. cbn.
+          repeat setoid_rewrite bind_ret_l. cbn. unfold id.
+          setoid_rewrite unique_f0. auto.
+Qed.
+
+(** Correctness of the compiler.
+      After interpretation of the [Locals], the source _Imp_ statement
+      denoted as an [itree] and the compiled _Asm_ program denoted
+      as an [itree] are equivalent up-to-taus.
+      The correctness is termination sensitive, but nonetheless a simple
+      induction on statements.
+      We are only left with reasoning about the functional correctness of
+      the compiler, all control-flow related reasoning having been handled
+      in isolation.
+   *)
+  Theorem compile_correct (s : stmt sensitivity_lat) :
+    equivalent s (compile s).
+  Proof.
+    unfold equivalent.  unfold compile. rewrite throw_prefix_bind_decomp.
+    rewrite fold_to_itree'. rewrite seq_asm_correct. rewrite relabel_asm_correct.
+    do 2 rewrite app_asm_correct.  rewrite <- fold_to_itree'. cbn.
+    eapply bisimilar_bind'. eapply compile_stmt_correct.
+    specialize (@pure_asm_correct ) as Hpac. do 5 red in Hpac.
+    intros [ [] | [ | ] ] l Hl; repeat setoid_rewrite bind_ret_l; cbn.
+    - assert (l = f0). { red in Hl. apply unique_fin. auto. } subst.
+      cbn. setoid_rewrite Hpac. repeat setoid_rewrite bind_ret_l.
+      red. intros. unfold interp_imp, interp_asm. repeat rewrite interp_state_ret.  apply eqit_Ret.
+      split; auto.
+    - assert (l = fS f0). { red in Hl. apply unique_fin. auto. } subst.
+      cbn. repeat setoid_rewrite bind_ret_l.
+      red. intros. unfold interp_imp, interp_asm. rewrite bind_bind. rewrite bind_trigger.
+      rewrite interp_state_vis. cbn. setoid_rewrite bind_bind. unfold raise_asm. cbn.
+      Transparent denote_asm. cbn. repeat setoid_rewrite bind_ret_l.
+      setoid_rewrite unfold_iter_ktree at 3. cbn. repeat setoid_rewrite bind_bind.
+      rewrite bind_trigger. rewrite interp_state_bind. rewrite interp_state_trigger.
+      cbn. rewrite bind_bind. rewrite bind_trigger. apply eqit_Vis. intros [].
+    - assert (l = fS (fS f0)). { red in Hl. apply unique_fin. auto. } subst.
+      cbn. repeat setoid_rewrite bind_ret_l.
+      red. intros. unfold interp_imp, interp_asm. rewrite bind_bind. rewrite bind_trigger.
+      rewrite interp_state_vis. cbn. setoid_rewrite bind_bind. unfold raise_asm. cbn.
+      Transparent denote_asm. cbn. repeat setoid_rewrite bind_ret_l.
+      setoid_rewrite unfold_iter_ktree at 3. cbn. repeat setoid_rewrite bind_bind.
+      rewrite bind_trigger. rewrite interp_state_bind. rewrite interp_state_trigger.
+      cbn. rewrite bind_bind. rewrite bind_trigger. apply eqit_Vis. intros [].
+Qed.
+
+End Correctness.
+
+(* ================================================================= *)
+(** ** Closing word. *)
+
+(** Through this medium-sized example, we have seen how to use [itree]s to
+    denote two languages, how to run them and how to prove correct a compiler
+    between them.
+    We have emphasized that the theory of [ktree]s allowed us to decouple
+    all reasoning about the control-flow from the proof of the compiler itself.
+    The resulting proof is entirely structurally inductive and equational. In
+    particular, we obtain a final theorem relating potentially infinite
+    computations without having to write any cofixed-point.
+
+    If this result is encouraging, one might always wonder how things scale.
+
+    A first good sanity check is to extend the languages with a _Print_
+    instruction.
+    It requires to add a new event to the language and therefore makes the
+    correctness theorem relate trees actually still containing events.
+    This change, which a good exercise to try, turns out to be as
+    straightforward as one would hope. The only new lemma needed is to show
+    that [interp_locals] leaves the new [Print] event untouched.
+    This extension can be found in the _tutorial-print_ branch.
+
+    More importantly, our compiler is fairly stupid and inefficient: it creates
+    blocks for each compiled statement! One would hope to easily write and
+    prove an optimization coalescing elementary blocks together.
+
+    A first example of optimization at the [asm] level proved correct is
+    demonstrated in the _AsmOptimization.v_ file.
+ *)

--- a/secure_example/LabelledImp2AsmNoninterferencePres.v
+++ b/secure_example/LabelledImp2AsmNoninterferencePres.v
@@ -1,0 +1,217 @@
+From Coq Require Import Program.Basics Morphisms.
+
+From ITree Require Import
+     ITree
+     ITreeFacts
+     Secure.SecureEqHalt
+     Secure.SecureEqEuttTrans
+     Secure.SecureEqProgInsens
+.
+
+From SecureExample Require Import
+     Utils_tutorial
+     Fin
+     KTreeFin
+     LabelledImp
+     LabelledAsm
+     LabelledImp2Asm
+     LabelledImp2AsmCorrectness
+     LabelledImpHandler
+     LabelledImpTypes
+     LabelledImpTypesProgInsens
+.
+
+Import ITreeNotations.
+
+Import Monads.
+Open Scope monad_scope.
+
+Section SecurityPreservation.
+
+Context (Γ : var -> sensitivity).
+Context (l : sensitivity).
+
+Instance labell_equiv_equiv {Γ' l'} : Equivalence (labelled_equiv sensitivity_lat Γ' l').
+Proof.
+  constructor; red; intros; red; red; intros; auto.
+  - rewrite H; auto.
+  - rewrite H; auto.
+Qed.
+
+Definition labelled_sim : map -> (registers * memory) -> Prop :=
+  fun g_imp g_asm => labelled_equiv sensitivity_lat Γ l g_imp (snd g_asm).
+
+Definition asm_eq : registers * memory -> registers * memory -> Prop :=
+  fun '(regs1, mem1) '(regs2, mem2) => labelled_equiv sensitivity_lat Γ l mem1 mem2.
+
+Lemma state_rel_aux:
+  forall (p1 : map * unit) (p2 : registers * memory * fin 1),
+    rcompose (product_rel (labelled_equiv sensitivity_lat Γ l) eq) (state_invariant TT) p1 p2 ->
+    product_rel labelled_sim TT p1 p2.
+Proof.
+  intros [σ [] ] [ [regs mem] ?] Hcomp. inv Hcomp.
+  destruct r2 as [σ' [] ]. destruct REL1. split; red; auto.
+  cbn. red in REL2. destruct REL2 as [Hst _ ]. cbn in *.
+  assert (labelled_equiv _ Γ l σ' mem).
+  { red in Hst. do 2 red. intros. auto. }
+  etransitivity; eauto.
+Qed.
+
+Lemma state_rel_aux':
+  forall x0 x1 : registers * memory * fin 1,
+    flip
+      (rcompose
+         (flip
+            (rcompose (product_rel (LabelledImpTypes.labelled_equiv sensitivity_lat Γ l) (@eq unit) )
+                      (state_invariant TT))) (state_invariant TT)) x0 x1 ->
+    product_rel asm_eq eq x0 x1.
+Proof.
+  intros [ [regs1  mem1] ? ] [ [reg2 mem2] ? ].
+  intros H. inv H. inv REL1. split; cbn.
+  2 :  setoid_rewrite unique_f0; auto.
+   inv REL0. inv REL3. inv REL2. destruct r0. destruct r2. cbn in *.
+   subst. transitivity m0.
+   cbv; intros; auto. transitivity m; auto. cbv; intros; auto.
+Qed.
+
+Section ProgressSensitive.
+
+Definition labelled_bisimilar {A B : Type} (RAB : A -> B -> Prop)
+           (t1 : itree ((impExcE _) +' stateE +' (IOE _)) A ) (t2 : itree ((impExcE _) +'
+ Reg +' Memory +' (IOE _)) B) :=
+  forall (g_imp : map) (g_asm : memory) (regs : registers),
+    labelled_equiv _ Γ l g_imp g_asm ->
+    eqit_secure _ (priv_exc_io sensitivity_lat) (product_rel labelled_sim RAB) true true l (interp_imp _ t1 g_imp ) (interp_asm t2 (regs, g_asm)).
+
+Lemma compile_preserves_ps_security : forall (c : stmt _),
+    label_state_sec_eutt _ Γ l eq  (interp_imp _ (denote_stmt _ c)) (interp_imp _ (denote_stmt _ c)) ->
+    labelled_bisimilar TT (denote_stmt _ c) (denote_asm (compile c) f0 ) .
+Proof.
+  intros s Hsecs. red in Hsecs. red. intros g_imp g_asm regs Hs.
+  assert (labelled_equiv _ Γ l g_imp g_imp). reflexivity.
+  specialize (compile_correct s) as Heutt. do 2 red in Heutt.
+  assert (Renv g_asm g_asm). reflexivity.
+  specialize (Hsecs g_imp g_asm Hs).
+  specialize (Heutt g_asm g_asm regs H0) .
+  specialize (eutt_secure_eqit_secure) as Htrans.
+  eapply Htrans in Heutt; eauto.
+  eapply SecureEqEuttHalt.eqit_secure_RR_imp; try apply Heutt.
+  apply state_rel_aux; auto.
+Qed.
+
+Lemma compile_preserves_ps_ni : forall (c : stmt _),
+    label_state_sec_eutt _ Γ l eq  (interp_imp _ (denote_stmt _ c)) (interp_imp _ (denote_stmt _ c)) ->
+    forall σ1 σ2, asm_eq σ1 σ2 ->
+             eqit_secure _ (priv_exc_io _) (product_rel asm_eq eq) true true l
+             (interp_asm (denote_asm (compile c) f0) σ1) ((interp_asm (denote_asm (compile c) f0)) σ2).
+Proof.
+  intros c Hsecc [regs1 mem1] [regs2 mem2]. intros Hasmeq.
+  assert (labelled_equiv _ Γ l mem1 mem1). reflexivity.
+  assert (labelled_equiv _ Γ l mem2 mem2). reflexivity.
+  specialize (compile_correct c) as Heutt. do 2 red in Heutt.
+  assert (Renv mem1 mem1). reflexivity.
+  assert (Renv mem2 mem2). reflexivity.
+  do 2 red in Hsecc.
+  assert (Hmem12 : labelled_equiv _ Γ l mem1 mem2). auto.
+  specialize (Hsecc mem1 mem2 Hmem12) as Hsecc'.
+  specialize (Heutt mem1 mem1 regs1 H1) as Heutt1.
+  specialize (Heutt mem2 mem2 regs2 H2) as Heutt2.
+  specialize (eutt_secure_eqit_secure) as Htrans.
+  eapply Htrans in Heutt1 as Heutt1'; eauto.
+  eapply Htrans in Heutt2 as Heutt2'; eauto.
+  eapply Htrans in Hsecc'; eauto.
+  apply eqit_secure_sym in Hsecc'.
+  eapply Htrans in Hsecc'; eauto.
+  apply eqit_secure_sym in Hsecc'.
+  eapply SecureEqEuttHalt.eqit_secure_RR_imp; try apply Hsecc'; eauto.
+  intros.
+  apply state_rel_aux'; auto.
+Qed.
+
+
+End ProgressSensitive.
+
+Section ProgressInsensitive.
+
+Definition labelled_pi_bisimilar {A B : Type} (RAB : A -> B -> Prop)
+           (t1 : itree ((impExcE _) +' stateE +' (IOE _)) A ) (t2 : itree ((impExcE _) +'
+ Reg +' Memory +' (IOE _)) B) :=
+  forall (g_imp : map) (g_asm : memory) (regs : registers),
+    labelled_equiv _ Γ l g_imp g_asm ->
+    pi_eqit_secure _ (priv_exc_io _) (product_rel labelled_sim RAB) true true l (interp_imp _ t1 g_imp ) (interp_asm t2 (regs, g_asm)).
+
+Lemma compile_preserves_pi_security : forall (c : stmt _),
+    label_state_pi_sec_eutt _ Γ l eq  (interp_imp _ (denote_stmt _ c)) (interp_imp _ (denote_stmt _ c)) ->
+    labelled_pi_bisimilar TT (denote_stmt _ c) (denote_asm (compile c) f0 ) .
+Proof.
+  intros s Hsecs. red in Hsecs. red. intros g_imp g_asm regs Hs.
+  assert (labelled_equiv _ Γ l g_imp g_imp). reflexivity.
+  specialize (compile_correct s) as Heutt. do 2 red in Heutt.
+  assert (Renv g_asm g_asm). reflexivity.
+  specialize (Hsecs g_imp g_asm Hs).
+  specialize (Heutt g_asm g_asm regs H0) .
+  specialize (pi_eqit_secure_mixed_trans) as Htrans.
+  eapply Htrans in Heutt; eauto.
+  eapply pi_eqit_secure_RR_imp; try apply Heutt.
+  apply state_rel_aux; auto.
+Qed.
+
+Lemma compile_preserves_pi_ni : forall (c : stmt _),
+    label_state_pi_sec_eutt _ Γ l eq  (interp_imp _ (denote_stmt _ c)) (interp_imp _ (denote_stmt _ c)) ->
+    forall σ1 σ2, asm_eq σ1 σ2 ->
+             pi_eqit_secure _ (priv_exc_io _) (product_rel asm_eq eq) true true l
+             (interp_asm (denote_asm (compile c) f0) σ1) ((interp_asm (denote_asm (compile c) f0)) σ2).
+Proof.
+  intros c Hsecc [regs1 mem1] [regs2 mem2]. intros Hasmeq.
+  assert (labelled_equiv _ Γ l mem1 mem1). reflexivity.
+  assert (labelled_equiv _ Γ l mem2 mem2). reflexivity.
+  specialize (compile_correct c) as Heutt. do 2 red in Heutt.
+  assert (Renv mem1 mem1). reflexivity.
+  assert (Renv mem2 mem2). reflexivity.
+  do 2 red in Hsecc.
+  assert (Hmem12 : labelled_equiv _ Γ l mem1 mem2). auto.
+  specialize (Hsecc mem1 mem2 Hmem12) as Hsecc'.
+  specialize (Heutt mem1 mem1 regs1 H1) as Heutt1.
+  specialize (Heutt mem2 mem2 regs2 H2) as Heutt2.
+  specialize (pi_eqit_secure_mixed_trans) as Htrans.
+  eapply Htrans in Heutt1 as Heutt1'; eauto.
+  eapply Htrans in Heutt2 as Heutt2'; eauto.
+  eapply Htrans in Hsecc'; eauto.
+  apply pi_eqit_secure_sym in Hsecc'.
+  eapply Htrans in Hsecc'; eauto.
+  apply pi_eqit_secure_sym in Hsecc'.
+  eapply pi_eqit_secure_RR_imp; try apply Hsecc'; eauto.
+  intros.
+  apply state_rel_aux'; auto.
+Qed.
+
+
+End ProgressInsensitive.
+
+
+End SecurityPreservation.
+(*
+stmt :=
+     | throw
+     | try c1 catch c2
+
+itree (state +' IOE +' Exc) tt
+
+
+denote_throw := trigger Throw
+
+
+denote_catch
+
+
+
+block := ...
+         | throw
+
+
+compile p : asm 1 1
+
+
+compile p : asm 1 2
+
+*)

--- a/secure_example/LabelledImpHandler.v
+++ b/secure_example/LabelledImpHandler.v
@@ -1,0 +1,117 @@
+From ITree Require Import
+     ITree
+     ITreeFacts
+     Events.State
+     Events.StateFacts
+     Events.Exception
+.
+
+From SecureExample Require Import
+     LabelledImp
+     Lattice
+.
+
+Import Monads.
+Import MonadNotation.
+Local Open Scope monad_scope.
+
+Section LabelledImpHandler.
+
+Context (Labels : Lattice).
+
+Definition priv_io (A : Type) (e : IOE Labels A) :=
+  match e with
+  | LabelledPrint _ s _ => s end.
+
+
+Definition priv_exc (A : Type) (e : impExcE Labels A ) :=
+  match e with
+  | Throw s => s end.
+
+Definition priv_exc_io := case_ priv_exc priv_io.
+
+Definition product_rel {R1 R2 S1 S2} (RR1: R1 -> S1 -> Prop) (RR2 : R2 -> S2 -> Prop)
+           (p1 : R1 * R2) (p2 : S1 * S2) : Prop :=
+  RR1 (fst p1) (fst p2) /\ RR2 (snd p1) (snd p2).
+
+Definition handle_case {E1 E2 : Type -> Type} {M : Type -> Type} (hl : E1 ~> M) (hr : E2 ~> M) : (E1 +' E2) ~> M :=
+  fun _ e => match e with
+          | inl1 el => hl _ el
+          | inr1 er => hr _ er end.
+
+Definition handle_state_io : forall A, (stateE +' (IOE Labels)) A ->
+                                  stateT map (itree ((impExcE Labels) +' (IOE Labels))) A :=
+  fun _ e => match e with
+          | inl1 el => handleState _ el
+          | inr1 er => fun s => r <- ITree.trigger (inr1 er);; Ret (s, r) end.
+
+Definition handle_imp : forall A, ((impExcE Labels) +' stateE +' (IOE Labels)) A ->
+                             stateT map (itree ((impExcE Labels) +' (IOE Labels)) ) A :=
+  fun _ e => match e with
+          | inl1 el => fun s => r <- ITree.trigger (inl1 el);; Ret (s, r)
+          | inr1 er => handle_state_io _ er end.
+
+Definition interp_imp {R} (t : itree ((impExcE Labels) +' stateE +' (IOE Labels)) R ) : stateT map (itree ((impExcE Labels) +' (IOE Labels))) R :=
+  interp_state handle_imp t.
+
+Hint Unfold interp_imp : core.
+Hint Unfold handle_state_io : core.
+Hint Unfold handle_imp : core.
+Hint Unfold product_rel : core.
+(*
+Ltac use_simpobs :=
+  repeat match goal with
+         | H : TauF _ = observe ?t |- _ => apply simpobs in H
+         | H : RetF _ = observe ?t |- _ => apply simpobs in H
+         | H : VisF _ _ = observe ?t |- _ => apply simpobs in H
+  end.
+
+Ltac destruct_imp_ev := repeat match goal with
+                        | e : (?E1 +' ?E2) ?A |- _ => destruct e
+                        | exc : impExcE ?A |- _ => destruct exc
+                        | st : stateE ?A |- _ => destruct st
+                        | io : IOE ?A |- _ => destruct io
+                        end.
+
+ (* TODO : replace with labelled equiv *)
+Lemma interp_eqit_secure_imp : forall (R1 R2 : Type) (RR : R1 -> R2 -> Prop) (priv_map : privacy_map)
+                                 (t1 : itree (impExcE +' stateE +' IOE) R1 )
+                                 (t2 : itree (impExcE +' stateE +' IOE) R2),
+    eqit_secure sense_preorder (priv_imp priv_map) RR true true Public t1 t2 ->
+    low_eqit_secure_impstate true true priv_map RR (interp_imp t1 )  (interp_imp t2).
+Proof.
+  red. intros.
+  eapply interp_eqit_secure_state; eauto.
+  - constructor; red; intros; cbv; intros; auto. red in H1. rewrite H1; auto.
+    rewrite H1; auto.
+  - intros. destruct_imp_ev.
+    + destruct s.
+      * eapply respect_public'. cbv. auto. red. intros. cbn.
+        setoid_rewrite bind_trigger. apply eqit_secure_public_Vis. cbv. auto.
+        intros [].
+      * eapply respect_private_e. cbv. auto. constructor. intros [].
+        intros. setoid_rewrite bind_trigger. pfold. constructor. intros [].
+        cbv. auto.
+    + destruct (priv_map x) eqn : Hl.
+      * apply respect_public'. cbv. rewrite Hl. auto.
+        red. intros. cbn. apply secure_eqit_ret.  split; auto. cbv. rewrite H1; auto.
+      * apply respect_private_ne. cbv. rewrite Hl. auto.
+        constructor. exact 0. intros. cbn. apply terminates_ret. red. intros. auto.
+    + destruct (priv_map x) eqn : Hl.
+      * apply respect_public'. cbv. rewrite Hl. auto.
+        red. intros. cbn. apply secure_eqit_ret. split; auto.
+        cbn. apply low_equiv_update_public; auto.
+      * apply respect_private_ne. cbv. rewrite Hl. auto.
+        constructor. exact tt. intros. cbn. apply terminates_ret.
+        apply low_equiv_update_private_r; auto. red; intros; auto.
+    + destruct s.
+      * eapply respect_public'. cbv. auto. red. intros. cbn.
+        setoid_rewrite bind_trigger. apply eqit_secure_public_Vis. cbv. auto.
+        intros []. apply secure_eqit_ret. split; auto.
+      * eapply respect_private_ne. cbv. auto. constructor. exact tt.
+        intros. cbn. setoid_rewrite bind_trigger. apply terminates_vis.
+        intros []. apply terminates_ret. red; intros; auto.
+         cbn. split; auto. constructor. exact tt.
+Qed.
+*)
+End LabelledImpHandler.

--- a/secure_example/LabelledImpInline.v
+++ b/secure_example/LabelledImpInline.v
@@ -1,0 +1,124 @@
+From Coq Require Import String.
+
+From ITree Require Import
+     ITree
+     ITreeFacts
+     Events.StateFacts
+     Events.Exception
+.
+
+From SecureExample Require Import
+     Lattice
+     LabelledAsm
+.
+
+Import Monads.
+Import MonadNotation.
+Local Open Scope monad_scope.
+Local Open Scope string_scope.
+
+Section LabelledImp.
+
+Definition var : Set := string.
+
+Definition value : Type := nat.
+
+(** Expressions are made of variables, constant literals, and arithmetic operations. *)
+Inductive expr : Type :=
+| Var (_ : var)
+| Lit (_ : value)
+| Plus  (_ _ : expr)
+| Minus (_ _ : expr)
+| Mult  (_ _ : expr).
+
+(** The statements are straightforward. The [While] statement is the only
+ potentially diverging one. *)
+
+Inductive stmt : Type :=
+| Assign (x : var) (e : expr)    (* x = e *)
+| Seq    (a b : stmt)            (* a ; b *)
+| If     (i : expr) (t e : stmt) (* if (i) then { t } else { e } *)
+| While  (t : expr) (b : stmt)   (* while (t) { b } *)
+| Skip                           (* ; *)
+| Output (s : sensitivity) (e : expr)
+(* exceptions *)
+| Raise (s : sensitivity)
+| TryCatch (t c : stmt)
+(* Inline *)
+| AsmInline (p : asm 1 1)
+.
+
+Variant ClearRegs : Type -> Type :=
+  | Clear : ClearRegs unit.
+
+Section LabelledImpInlineSemantics.
+  Context {E : Type -> Type}.
+  Context {HasReg : Reg -< E}.
+  (* thought I might need this, but without it things get simpler *)
+  (* Context {HasClearRegs : ClearRegs -< E}. *)
+  Context {HasMemory : Memory -< E}.
+  Context {HasIOE : LabelledImp.IOE sensitivity_lat -< E}.
+
+  Notation impExcE := (LabelledImp.impExcE sensitivity_lat ).
+
+  Notation privacy_map := LabelledImp.privacy_map.
+
+
+
+
+  Fixpoint denote_expr (e : expr) : itree (impExcE +' E) value :=
+    match e with
+    | Var x => trigger (Load x)
+    | Lit v => Ret v
+    | Plus e1 e2 => x <- denote_expr e1;;
+                   y <- denote_expr e2;;
+                   Ret (x + y)
+    | Minus e1 e2 => x <- denote_expr e1;;
+                    y <- denote_expr e2;;
+                    Ret (x - y)
+    | Mult e1 e2 => x <- denote_expr e1;;
+                   y <- denote_expr e2;;
+                   Ret (x * y) end.
+
+
+  Definition is_true (v : value) : bool :=
+    Nat.ltb 0 v.
+
+  Definition while {E} (t : itree E (unit + unit) ) : itree E unit :=
+    ITree.iter (fun _ => t) tt.
+
+  (* so I need to make sure *)
+  Program Definition denote_asm_inline {A B} (p : asm A B) : Fin.fin A -> itree (impExcE +' E) (Fin.fin B) :=
+    @denote_asm (impExcE +' E) _ _ _ _ A B p.
+
+  Fixpoint denote_stmt (s : stmt) : itree (impExcE +' E) unit :=
+    match s with
+    | Assign x e => y <- denote_expr e;; trigger (HasMemory _ (Store x y))
+    | Seq s1 s2 => denote_stmt s1 ;; denote_stmt s2
+    | If e c1 c2 => b <- denote_expr e;;
+                   if (is_true b)
+                   then denote_stmt c1
+                   else denote_stmt c2
+    | Skip => Ret tt
+    | Output s e => v <- denote_expr e;; trigger (inr1 (HasIOE _ (LabelledImp.LabelledPrint sensitivity_lat s v)) )
+    | While b c => while (
+                      b <- denote_expr b;;
+                      if (is_true b)
+                      then denote_stmt c;; Ret (inl tt)
+                      else Ret (inr tt) )
+    | Raise s => trigger (Throw s);; Ret tt
+    | TryCatch t c => try_catch (denote_stmt t) (fun _ => denote_stmt c)
+    | AsmInline p => denote_asm_inline p Fin.f0;; Ret tt
+    end.
+
+(* very inefficient, but not sure I really care about extraction so whatever *)
+Definition map : Type := var -> value.
+
+
+End LabelledImpInlineSemantics.
+
+End LabelledImp.
+
+Definition interp_imp_inline {E1 E2 : Type -> Type} {A : Type} :
+  itree (E1 +' Reg +' Memory +' E2) A ->
+  stateT (registers * memory) (itree (E1 +' E2)) A := @interp_asm E1 E2 A.

--- a/secure_example/LabelledImpInline2Asm.v
+++ b/secure_example/LabelledImpInline2Asm.v
@@ -1,0 +1,288 @@
+From Coq Require Import Arith Lia List.
+
+From ITree Require Import ITree.
+
+From SecureExample Require Import
+     LabelledImpInline
+     LabelledAsm
+     LabelledAsmCombinators
+     Fin
+     Utils_tutorial
+.
+
+Import ListNotations.
+Import CatNotations.
+Local Open Scope cat_scope.
+
+Import LabelledAsmCombinators.
+
+(* ================================================================= *)
+(** ** Compilation of expressions *)
+
+Section compile_assign.
+
+  (** Expressions are compiled straightforwardly.
+      The argument [l] is the number of registers already introduced to compile
+      the expression, and is used for the name of the next one.
+      The result of the computation [compile_expr l e] always ends up stored in [l].
+   *)
+  Fixpoint compile_expr (l:reg) (e: expr): list instr :=
+    match e with
+    | Var x => [Iload l x]
+    | Lit n => [Imov l (Oimm n)]
+    | Plus e1 e2 =>
+      let instrs1 := compile_expr l e1 in
+      let instrs2 := compile_expr (1 + l) e2 in
+      instrs1 ++ instrs2 ++ [Iadd l l (Oreg (1 + l))]
+    | Minus e1 e2 =>
+      let instrs1 := compile_expr l e1 in
+      let instrs2 := compile_expr (1 + l) e2 in
+      instrs1 ++ instrs2 ++ [Isub l l (Oreg (1 + l))]
+    | Mult e1 e2 =>
+      let instrs1 := compile_expr l e1 in
+      let instrs2 := compile_expr (1 + l) e2 in
+      instrs1 ++ instrs2 ++ [Imul l l (Oreg (1 + l))]
+      end.
+
+  (** Compiles the expression and then moves the result (in register [0]) to address
+      [x].  Note: here we assume a one-to-one mapping of _Imp_ global variable names
+      and _Asm_ addresses.
+  *)
+  Definition compile_assign (x: var) (e: expr): list instr :=
+    let instrs := compile_expr 0 e in
+    instrs ++ [Istore x (Oreg 0)].
+
+  Definition compile_output (s : sensitivity) (e : expr) : list instr :=
+    let instrs := compile_expr 0 e in
+    instrs ++  [IOutput s 0].
+
+End compile_assign.
+
+(* ================================================================= *)
+(** ** Control flow combinators *)
+
+
+(** Sequencing of blocks: the program [seq_asm ab bc] links the
+    exit points of [ab] with the entry points of [bc].
+
+[[
+           B
+   A---ab-----bc---C
+]]
+
+   ... can be implemented using just [app_asm], [relabel_asm] and [loop_asm].
+
+  Indeed, [app_asm ab bc] can be visualized as:
+[[
+  A---ab---B
+  B---bc---C
+]]
+ i.e. a [asm (A + B) (B + C)]. To link them, we need first to swap the entry points.
+
+We obtain the following diagram:
+[seq_asm ab bc]
+[[
+       +------+
+       |      |
+   A------ab--+B
+       |
+      B+--bc------C
+]]
+
+Which translates to:
+ *)
+Definition seq_asm {A B C} (ab : asm A B) (bc : asm B C)
+  : asm A C :=
+  loop_asm (relabel_asm swap (id_ _) (app_asm ab bc)).
+
+Section seq_asm_exc.
+Context {A B C D : nat}.
+Context (ab : asm A (B + C)).
+Context (bd : asm B (D + C)).
+(* so what I need to do is get this to the form some swapping should get this the rest of the
+   way to the other *)
+Definition comb : asm (A + B) ((B + C) + (D + C)) := app_asm ab bd.
+
+
+
+Definition swap_and_merge : CategorySub.sub Fun fin (C + (D + C) ) (D + C) :=
+  cat (cat ( cat (bimap (id_ _) (swap) ) assoc_l) (bimap merge (id_ _) )) swap.
+
+Definition expose_linking_labels : asm (B + A) (B + (D + C) )  := relabel_asm swap (cat (cat assoc_r (id_ _)) (bimap (id_ _ ) swap_and_merge) ) comb.
+
+Definition seq_asm_exc : asm A (D + C) := loop_asm expose_linking_labels.
+
+End seq_asm_exc.
+
+(** Location of temporary for [if]. *)
+Definition tmp_if := 0.
+
+(** Turns the list of instructions resulting from the conditional
+    expression of a _if_ to a block with two exit points.
+ *)
+Definition cond_asm (e : list instr) : asm 1 2 :=
+  raw_asm_block (after e (Bbrz tmp_if (fS f0) f0)).
+
+
+(** Conditional branch of blocks.
+    The program [if_asm e tp fp] creates a block out of [e] jumping
+    either left or right.
+    Using [seq_asm], this block is sequenced with the vertical
+    composition [app_asm] of [tp] and [fp].
+    Remains one mismatch: [app_asm] duplicates the domain of outputs,
+    although they share the same. We hence use [relabel_asm] to collapse
+    them together.
+
+ [if_asm e tp fp]
+[[
+           true
+       /ee-------tp---A\
+    1--                 --A
+       \ee-------fp---A/
+           false
+]]
+ *)
+Definition if_asm {A}
+           (e : list instr) (tp : asm 1 A) (fp : asm 1 A) :
+  asm 1 A :=
+  seq_asm (cond_asm e)
+          (relabel_asm (id_ _) merge (app_asm tp fp)).
+
+
+
+(* Conditional looping of blocks.
+   The program [while_asm e p] composes vertically two programs:
+   an [if_asm] construct with [p] followed by a jump on the true branch,
+   and a unique jump on the false branch.
+   The loop is then closed with [loop_asm] by matching the jump from the
+   true branch to the entry point.
+
+[while_asm e p]
+[[
+      +-------------+
+      |             |
+      |    true     |
+      |  e-------p--+
+  1---+--e--------------1
+           false
+]]
+*)
+Definition while_asm (e : list instr) (p : asm 1 1) :
+  asm 1 1 :=
+  loop_asm (relabel_asm (id_ _) merge
+    (app_asm (if_asm e
+                (relabel_asm (id_ _) inl_ p)
+                (pure_asm inr_))
+            (pure_asm inl_))).
+
+
+
+
+Definition pure_ret_asm : asm 1 3 :=
+  pure_asm (fun _ => f0).
+
+Definition pure_exc_asm (s : sensitivity) : asm 1 3 :=
+  pure_asm (fun _ => match s with Public => fS (f0) | Private => (fS (fS f0)) end).
+
+
+Section while_asm_exc.
+  Context (e : list instr).
+  Context (p : asm 1 (1 + 2) ).
+  (* part of the problem is I am thinking about it wrong, because only a success signal in the body loop  gets fed back into the loop, either *)
+  (*Definition direct_output_while_exc : asm (1 + 2) (1 + (1 + 2) ) := app_asm (pure_asm (id_ _)) (pure_asm inr_). *)
+  Definition direct_output_while_exc : asm 1 (1 + (1 + 2)) :=
+    relabel_asm (id_ _) (bimap inl_ inr_) p.
+
+  Definition while_asm_exc : asm 1 3 :=
+    loop_asm (relabel_asm (id_ _) merge (app_asm
+                                           (if_asm e direct_output_while_exc (pure_asm (fun _ => fS (f0)) ))
+                                           (pure_asm inl_))).
+
+(*
+  I should refactor these to just use local let definitions
+*)
+
+End while_asm_exc.
+(* probably can refact seq_asm_exc to be simpler *)
+
+
+Definition trycatch_asm (p : asm 1 (1 + (1 + 1) ) ) (c : asm 1 3) : asm 1 3 :=
+  seq_asm (relabel_asm (id_ _) (bimap (id_ _) merge ) p)
+   (relabel_asm (id_ _ ) merge (app_asm pure_ret_asm c)).
+
+
+Definition raise_asm (s : sensitivity) : asm 1 1:=
+  {| internal := 0; code := fun _ => bbb (BRaise s) |}.
+
+(** Equipped with our combinators, the compiler writes itself
+    by induction on the structure of the statement.
+*)
+
+
+(*analyzing this function seems key to verifying this approach*)
+Definition exception_to_sum_branch_reassoc {B C : nat} : fin (C + B) -> fin (C + (B + 2)) :=
+  fun l => match split_fin_sum C B l with
+             | inl lc => (L (B + 2) lc)
+             | inr lb => (R C (L 2 lb))
+             end.
+
+Lemma exception_to_sum_branch_reassoc_nop : forall (B C : nat ) (f : fin (C + B) ),
+    proj1_sig f = (proj1_sig (exception_to_sum_branch_reassoc f) ).
+Proof.
+  intros. unfold exception_to_sum_branch_reassoc.
+  destruct f.
+  assert (x < C \/ x - C < B). lia.
+  destruct H.
+  - unfold split_fin_sum. cbn. destruct (lt_dec x C); auto.
+    contradiction.
+  - unfold split_fin_sum. cbn. destruct (lt_dec x C); auto. unfold L. cbn. lia.
+Qed.
+
+
+Definition exception_to_sum_branch {B C : nat} (br : branch (fin (C + B) )) : branch (fin (C + (B + 2))) :=
+  match br with
+  | Bjmp l => Bjmp (exception_to_sum_branch_reassoc l)
+  | Bbrz r l1 l2 =>
+     Bbrz r (exception_to_sum_branch_reassoc l1) (exception_to_sum_branch_reassoc l2)
+  | BRaise s => match s with
+               | Public => Bjmp (R C (R B f0))
+               | Private => Bjmp (R C (R B (fS f0) ))
+               end
+  end.
+
+Fixpoint exception_to_sum_block {B C : nat} (bl : block (fin (C + B))) : block (fin (C + (B + 2)) ) :=
+  match bl with
+  | bbi instr bl' => bbi instr (exception_to_sum_block bl')
+  | bbb br => bbb (exception_to_sum_branch br)
+  end.
+
+Definition exception_to_sum_bks {A B C: nat} : bks (C + A) (C + B) -> bks (C + A) (C + (B + 2)) :=
+  fun f a => exception_to_sum_block (f a).
+
+(* small associativity problem, should be fixable
+   going to see if I can rewrite previous parts to avoid equality proofs
+
+*)
+Definition exception_to_sum {A B : nat} (p : asm A B) : asm A (B + 2) :=
+  {|
+    internal := internal p;
+    code := exception_to_sum_bks (code p)
+  |}.
+
+
+Fixpoint compile_stmt (s : stmt) {struct s} : asm 1 (1 + 2) :=
+  match s with
+  | Skip       => pure_ret_asm
+  | Assign x e => raw_asm_block (after (compile_assign x e) (Bjmp f0))
+  | Output s e => raw_asm_block (after (compile_output s e) (Bjmp f0) )
+  | Seq l r    => seq_asm_exc (compile_stmt l) (compile_stmt r)
+  | If e l r   => if_asm (compile_expr 0 e) (compile_stmt l) (compile_stmt r)
+  | Raise s => pure_exc_asm s
+  | While e s => while_asm_exc (compile_expr 0 e) (compile_stmt s)
+  | TryCatch t c => trycatch_asm (compile_stmt t) (compile_stmt c)
+  | AsmInline p => exception_to_sum p
+  end.
+
+Definition compile (s : stmt) : asm 1 1 :=
+  seq_asm (compile_stmt s )
+          (relabel_asm (id_ _) (fun _ => f0) (app_asm id_asm (app_asm (raise_asm Public) (raise_asm Private) ) )).

--- a/secure_example/LabelledImpInline2AsmCorrectness.v
+++ b/secure_example/LabelledImpInline2AsmCorrectness.v
@@ -1,0 +1,1578 @@
+(** * Functional correctness of the compiler *)
+
+(** We finally turn to proving our compiler correct.
+
+SAZ: This needs to be updated.
+
+    We express the result as a (weak) bisimulation between
+    the [itree] resulting from the denotation of the source
+    _Imp_ statement and the denotation of the compiled _Asm_
+    program. This weak bisimulation is a _up-to-tau_ bisimulation.
+    More specifically, we relate the itrees after having
+    interpreted the events contained in the trees, and run
+    the resulting computation from the state monad:
+    [ImpState] on the _Imp_ side, [Reg] and [Memory] on the
+    _Asm_ side.
+
+    The proof is essentially structured as followed:
+    - a simulation relation is defined to relate the _Imp_
+    state to the _Asm_ memory during the simulation. This
+    relation is strengthened into a second one additionally
+    relating the result of the denotation of an expression to
+    the _Asm_ set of registers, and used during the simulation
+    of expressions.
+    - the desired bisimulation is defined to carry out the
+    the simulation invariant into a up-to-tau equivalence after
+    interpretation of events. Once again a slightly different
+    bisimulation is defined when handling expressions.
+    - Linking is proved in isolation: the "high level" control
+    flow combinators for _Asm_ defined in [Imp2Asm.v] are
+    proved correct in the same style as the elementary ones
+    from [AsmCombinators.v].
+    - Finally, all the pieces are tied together to prove the
+    correctness.
+
+    We emphasize the following aspects of the proof:
+    - Despite establishing a termination-sensitive correctness
+    result over Turing-complete languages, we have not written
+    a single [cofix]. All coinductive reasoning is internalized
+    into the [itree] library.
+    - We have separated the control-flow-related reasoning from
+    the functional correctness one. In particular, the low-level
+    [asm] combinators are entirely reusable, and the high-level
+    ones are only very loosely tied to _Imp_.
+    - All reasoning is equational. In particular, reasoning at the
+    level of [ktree]s rather than introducing the entry label and
+    trying to reason at the level of [itree]s ease sensibly the pain
+    by reducing the amount of binders under which we need to work.
+    - We transparently make use of the heterogeneous bisimulation provided
+    by the [itree] library to relate computations of _Asm_ expressions that
+    return a pair of environments (registers and memory) and a [unit] value to
+    ones of _Imp_ that return a single environment and an [Imp.value].
+ *)
+
+(* begin hide *)
+
+From Coq Require Import
+     Arith
+     String
+     Morphisms
+     Lia.
+
+From ITree Require Import
+     ITree
+     ITreeFacts
+     Basics.CategorySub
+     Basics.HeterogeneousRelations
+     Events.StateFacts
+     Events.MapDefault
+     Events.Exception
+     Events.ExceptionFacts
+.
+
+From SecureExample Require Import
+     LabelledImpInline
+     LabelledAsm
+     LabelledAsmCombinators
+     Utils_tutorial
+     LabelledImpInline2Asm
+     Fin
+     KTreeFin
+     LabelledImpHandler
+.
+
+Import ITreeNotations.
+
+From ExtLib Require Import
+     Structures.Monad
+     Structures.Maps
+     Data.Map.FMapAList.
+
+Import CatNotations.
+Local Open Scope cat.
+
+Import Monads.
+Open Scope monad_scope.
+Open Scope itree_scope.
+
+(* end hide *)
+
+(* ================================================================= *)
+(** ** Simulation relations and invariants *)
+
+(** The compiler is proved correct by constructing a (itree) bisimulation
+    between the source program and its compilation.  The compiler does two
+    things that affect the state:
+
+      - it translates source Imp variables to Asm global variables, which should
+        match at each step of computation
+
+      - it introduces temporary local variables that name intermediate values
+
+    As is traditional, we define, to this end, a simulation relation [Renv] and
+    invariants that relate the source Imp environment to the target Asm
+    environment, following the description above.
+
+    [Renv] relates two [alist var value] environments if they act as
+    equivalent maps.  This is used to relate Imp's [ImpState] environment to
+    Asm's [Memory].
+
+*)
+Notation update := LabelledImp.update.
+Notation impExcE := LabelledImp.impExcE.
+Notation IOE := LabelledImp.IOE.
+Section Simulation_Relation.
+
+  (*here is where differences start, because now imp programs have the same denotation,
+    I think sim_rel just becomes Renv? mapped to the second argument? *)
+
+  (** ** Definition of the simulation relations *)
+
+  (** The simulation relation for evaluation of statements.
+      The relation relates two environments of type [alist var value].
+      The source and target environments exactly agree on user variables.
+   *)
+  Definition Renv (g_imp : map) (g_asm : memory) : Prop :=
+    forall x, g_imp x = g_asm x.
+
+  Global Instance Renv_refl : Reflexive Renv.
+  Proof.
+    red. intros. unfold Renv. auto.
+  Qed.
+
+ (** The simulation relation for evaluation of expressions.
+
+     The relation connects
+
+       - the global state at the Imp level
+
+       - the memory and register states at the Asm level
+
+     and, additionally the returned value at the _Imp_ level. The _Asm_ side
+     does not carry a [value], but a [unit], since its denotation does not
+     return any [value].
+
+     The [sim_rel] relation is parameterized by the state of the local [asm]
+     environment before the step, and the name of the variable used to store the
+     result.
+
+
+     It enforces three conditions:
+     - [Renv] on the global environments, ensuring that evaluation of expressions does
+     not change user variables;
+
+     - Agreement on the computed value, i.e. the returned value [v] is stored at
+     the assembly level in the expected temporary;
+
+     - The "stack" of temporaries used to compute intermediate results is left
+       untouched.
+  *)
+  (*need to edit this *)
+  Definition sim_rel l_asm n: (registers * map * value) -> (registers * memory * unit) -> Prop :=
+    fun '(_, g_imp', v) '(l_asm',g_asm', _)  =>
+      Renv g_imp' g_asm' /\            (* we don't corrupt any of the imp variables *)
+      l_asm' n = v /\          (* we get the right value *)
+      (forall m, m < n -> forall v,              (* we don't mess with anything on the "stack" *)
+            l_asm m = v <-> l_asm' m = v).
+
+  Lemma sim_rel_find : forall g_asm g_imp l_imp l_asm l_asm' n  v,
+    sim_rel l_asm n (l_imp, g_imp, v) (l_asm', g_asm, tt) ->
+    l_asm' n = v.
+  Proof.
+    intros. red in H. tauto.
+  Qed.
+
+  (** ** Facts on the simulation relations *)
+
+  (** [Renv] entails agreement of lookup of user variables. *)
+  Lemma Renv_find:
+    forall g_asm g_imp x,
+      Renv g_imp g_asm ->
+      g_imp x = g_asm x.
+  Proof.
+    intros. auto.
+  Qed.
+
+  (** [sim_rel] can be initialized from [Renv]. *)
+  Lemma sim_rel_add: forall g_asm l_asm g_imp l_imp n v,
+      Renv g_imp g_asm ->
+      sim_rel l_asm n  (l_imp, g_imp, v) ((update_reg n v l_asm, g_asm, tt)).
+  Proof.
+    intros. red. split; auto. split; auto.
+    - unfold update_reg. rewrite Nat.eqb_refl. auto.
+    - intros. assert (n <> m). lia.
+      unfold update_reg. apply Nat.eqb_neq in H1. rewrite H1. split; auto.
+  Qed.
+
+  (** [Renv] can be recovered from [sim_rel]. *)
+  Lemma sim_rel_Renv: forall l_asm n s1 l1 l2 v1 s2 v2,
+      sim_rel l_asm n (l2, s2,v2) (l1,s1,v1) -> Renv s2 s1 .
+  Proof.
+    intros ? ? ? ? ? ? ? ? H; apply H.
+  Qed.
+
+  Lemma sim_rel_find_tmp_n:
+    forall l_asm g_asm' n l_imp l_asm' g_imp' v,
+      sim_rel l_asm n  (l_imp, g_imp',v) (l_asm', g_asm', tt) ->
+      l_asm' n = v.
+  Proof.
+    intros ? ? ? ? ? ? ? [_ [H _]]; exact H.
+  Qed.
+
+  (** [sim_rel] entails agreement of lookups in the "stack" between its argument
+      and the current Asm environement *)
+  Lemma sim_rel_find_tmp_lt_n:
+    forall l_asm g_asm' n m l_asm' l_imp' g_imp' v,
+      m < n ->
+      sim_rel l_asm n (l_imp', g_imp',v) (l_asm', g_asm', tt) ->
+      l_asm m = l_asm' m.
+  Proof.
+    intros ? ? ? ? ? ? ? ? ineq [_ [_ H]].
+    match goal with
+    | |- _ = ?x => destruct x eqn:EQ
+    end.
+    setoid_rewrite (H _ ineq); auto.
+    apply H; auto.
+  Qed.
+
+  Lemma sim_rel_find_tmp_n_trans:
+    forall l_asm n l_asm' l_asm'' g_asm' g_asm'' l_imp' g_imp' l_imp'' g_imp'' v v',
+      sim_rel l_asm n (l_imp', g_imp',v) (l_asm', g_asm', tt)  ->
+      sim_rel l_asm' (S n) (l_imp'', g_imp'',v') (l_asm'', g_asm'', tt)  ->
+      l_asm'' n = v.
+  Proof.
+    intros.
+    generalize H; intros LU; apply sim_rel_find_tmp_n in LU.
+    unfold alist_In in LU; erewrite sim_rel_find_tmp_lt_n in LU; eauto.
+  Qed.
+
+  (** [Renv] is preserved by assignment.
+   *)
+
+  Lemma Renv_write_local:
+    forall (k : var) (g_asm g_imp : map) v,
+      Renv g_imp g_asm ->
+      Renv (update k v g_imp) (update k v g_asm).
+  Proof.
+    unfold Renv. intros. unfold update.
+    destruct (k =? x)%string; auto.
+  Qed.
+
+  (** [sim_rel] can be composed when proving binary arithmetic operators. *)
+  Lemma sim_rel_binary_op:
+    forall (l_asm l_asm' l_asm'' l_imp' l_imp'': registers) (g_asm' g_asm'' : memory) (g_imp' g_imp'' : map)
+      (n v v' : nat)
+      (Hsim : sim_rel l_asm n (l_imp', g_imp', v) (l_asm', g_asm', tt))
+      (Hsim': sim_rel l_asm' (S n) (l_imp'', g_imp'', v') (l_asm'', g_asm'', tt))
+      (op: nat -> nat -> nat),
+      sim_rel l_asm n (l_imp'', g_imp'', op v v') (update_reg n (op v v') l_asm'', g_asm'', tt).
+  Proof.
+    intros.
+    split; [| split].
+    - eapply sim_rel_Renv; eassumption.
+    - unfold update_reg. rewrite Nat.eqb_refl; auto.
+    - intros m LT v''. assert (n <> m). lia.
+      destruct Hsim as [_ [_ Hsim]].
+      destruct Hsim' as [_ [_ Hsim']].
+      rewrite Hsim; [| auto with arith].
+      rewrite Hsim'; [| auto with arith].
+      unfold update_reg. apply Nat.eqb_neq in H. rewrite H. reflexivity.
+  Qed.
+
+End Simulation_Relation.
+
+(* ================================================================= *)
+(** ** Bisimulation *)
+
+(** We now make precise the bisimulation established to show the correctness of
+    the compiler.  Naturally, we cannot establish a _strong bisimulation_
+    between the source program and the target program: the [asm] counterpart
+    performs "more steps" when evaluating expressions.  The appropriate notion
+    is of course the _equivalence up to tau_. However, the [itree] structures
+    are also quite different.  [asm] programs manipulate two state
+    components. The simulation will establish that the [imp] global state
+    corresponds to the [asm] memory, but to be able to  establish this
+    correspondence, we also need to interpret the [asm] register effects.  *)
+
+(*
+Goal forall E1 E2 R, @interp_imp_inline E1 E2 R = interp_asm.
+  auto.
+Qed.
+*)
+Section Bisimulation.
+
+
+  (** Definition of our bisimulation relation.
+
+      As previously explained, the bisimulation relates (up-to-tau)
+      two [itree]s after having interpreted their events.
+
+      We additionally bake into it a simulation invariant:
+      - Events are interpreted from states related by [Renv]
+      - Returned values must contain related states, as well as computed datas
+        related by another relation [RAB] taken in parameter.
+      In our case, we will specialize [RAB] to the total relation since the trees return
+      respectively [unit] and the unique top-level label [F0: fin 1].
+   *)
+
+  Section RAB.
+
+    Context {A B : Type}.
+    Context (RAB : A -> B -> Prop).  (* relation on Imp / Asm values *)
+
+    Definition state_invariant (a : registers * memory * A) (b : registers * memory * B)  :=
+      Renv (snd (fst a)) (snd (fst b)) /\ (RAB (snd a) (snd  b)).
+
+    Definition bisimilar  (t1 : itree ((impExcE sensitivity_lat) +' Reg +' Memory +' (IOE sensitivity_lat)) A) (t2 : itree ((impExcE sensitivity_lat) +' Reg +' Memory +' (IOE sensitivity_lat)) B)  :=
+    forall g_asm g_imp l1 l2,
+      Renv g_imp g_asm ->
+      eutt state_invariant
+           (interp_imp_inline t1 (l1, g_imp))
+           (interp_asm t2 (l2, g_asm) ).
+  End RAB.
+
+
+  (** [bisimilar] is compatible with [eutt]. *)
+
+  Global Instance eutt_bisimilar  {A B}  (RAB : A -> B -> Prop):
+    Proper (eutt eq ==> eutt eq ==> iff) (@bisimilar A B RAB).
+  Proof.
+    repeat intro.
+    unfold bisimilar. split.
+    - intros. unfold interp_imp_inline, interp_asm. rewrite <- H, <-H0.
+      apply H1; auto.
+    - intros. unfold interp_imp_inline, interp_asm.
+      rewrite H, H0. apply H1; auto.
+  Qed.
+
+  Lemma bisimilar_bind' {A A' B C} (RAA' : A -> A' -> Prop) (RBC: B -> C -> Prop):
+    forall (t1 : itree _ A) (t2 : itree _ A') ,
+      bisimilar RAA' t1 t2 ->
+      forall (k1 : A -> itree _ B) (k2 : A' -> itree _ C)
+        (H: forall (a:A) (a':A'), RAA' a a' -> bisimilar RBC (k1 a) (k2 a')),
+        bisimilar RBC (t1 >>= k1) (t2 >>= k2).
+  Proof.
+    repeat intro. unfold interp_imp_inline, interp_asm.
+    repeat rewrite interp_state_bind.
+    eapply eutt_clo_bind.
+    { eapply H; auto. }
+    intros [[regs1 mem1] a] [ [regs2 mem2] a'].
+    intros Hs. destruct Hs.
+    cbn in *. eapply H0; eauto.
+  Qed.
+
+  Lemma bisimilar_iter {A A' B B'}
+        (R : A -> A' -> Prop)
+        (S : B -> B' -> Prop)
+        (t1 : A -> itree (_) (A + B))
+        (t2 : A' -> itree (_) (A' + B')) :
+    (forall l l', R l l' -> bisimilar (sum_rel R S) (t1 l) (t2 l')) ->
+    forall x x', R x x' ->
+    bisimilar S (iter (C := ktree _) t1 x) (iter (C := ktree _) t2 x').
+  Proof.
+
+    unfold bisimilar, interp_imp_inline, interp_asm, interp_imp.
+    intros.
+    pose proof @interp_state_iter'. unfold state_eq in H2.
+    repeat setoid_rewrite H2.
+    eapply (eutt_iter' (state_invariant R)); intros.
+    2 : { split; auto. }
+    destruct H3. destruct j1 as [ [regs1 mem1] a].
+    destruct j2 as [ [regs2 mem2] a']. cbn in *.
+    eapply eutt_clo_bind; eauto. intros [ [regs3 mem3] r1] [ [regs4 mem4 ] r2 ] Hs.
+    red in Hs. cbn in *. destruct Hs as [Hs Hr].
+    inv Hr;
+    apply eqit_Ret; constructor; split; auto.
+  Qed.
+
+  (** [sim_rel] at [n] entails that [GetVar (gen_tmp n)] gets interpreted
+      as returning the same value as the _Imp_ related one.
+   *)
+  Lemma sim_rel_get_tmp0:
+    forall n l l' g_asm l_imp g_imp v,
+      sim_rel l' n (l_imp, g_imp,v) (l, g_asm,tt) ->
+      (interp_asm ((trigger (GetReg n)) : itree ((impExcE sensitivity_lat) +' Reg +' Memory +' (IOE sensitivity_lat)) value)
+                                       (l, g_asm))
+      ≈     (Ret (l, g_asm, v)).
+  Proof.
+    intros.
+    unfold interp_asm.
+    rewrite interp_state_trigger.
+    cbn. apply eqit_Ret.
+    destruct H. destruct H0. cbv. rewrite H0. auto.
+  Qed.
+
+
+End Bisimulation.
+
+(* ================================================================= *)
+(** ** Linking *)
+
+(** We first show that our "high level" [asm] combinators are correct.  These
+    proofs are mostly independent from the compiler, and therefore fairly
+    reusable.  Once again, these notion of correctness are expressed as
+    equations commuting the denotation with the combinator.  *)
+
+Section Linking.
+
+  Import KTreeFin.
+
+  (** [seq_asm] is denoted as the (horizontal) composition of denotations. *)
+  Lemma seq_asm_correct {A B C} (ab : asm A B) (bc : asm B C) :
+      denote_asm (seq_asm ab bc)
+    ⩯ denote_asm ab >>> denote_asm bc.
+  Proof.
+    unfold seq_asm.
+    rewrite loop_asm_correct, relabel_asm_correct, app_asm_correct.
+
+    rewrite fmap_id0, cat_id_r, fmap_swap.
+    apply cat_from_loop.
+  Qed.
+(*
+  Check fun (E : Type -> Type) Case (ktree_fin ) *)
+
+  Definition reassoc_seq_asm_exc {B C D : nat} : fin ((B + C) + (D + C) ) -> fin (B + (D + C) ) :=
+    ((assoc_r >>> bimap (id_ B) (bimap (id_ C) swap >>> assoc_l >>>
+                                                          bimap merge (id_ D) >>> swap))).
+(* we can compute this functions behavior on each of all parts of its element space with like 4 equations *)
+
+  Lemma reassoc_seq_asm_exc_B (B C D : nat) (b : fin B) (bc : fin (B + C) ) :
+     split_fin_sum B C  bc = inl b -> reassoc_seq_asm_exc (L (D + C) bc) = L (D + C) b.
+  Proof.
+    intros. unfold reassoc_seq_asm_exc. cbn.
+    unfold cat, Cat_sub, cat, Cat_Fun.
+    unfold assoc_r, AssocR_Coproduct, case_, Case_sub, case_, Case_Kleisli, case_sum.
+    cbn. unfold to_bif, ToBifunctor_Fun_fin. unfold swap, Swap_Coproduct, case_.
+    unfold bimap, Bimap_Coproduct, case_, cat. cbn. rewrite split_fin_sum_L. rewrite H.
+    repeat rewrite split_fin_sum_L. auto.
+  Qed.
+
+  Lemma reassoc_seq_asm_exc_C_ab (B C D : nat ) (c : fin C) (bc : fin (B + C) ) :
+    split_fin_sum B C bc = inr c -> @reassoc_seq_asm_exc B C D (L _ bc ) = R _ (R _ c).
+  Proof.
+    intros. unfold reassoc_seq_asm_exc. cbn.
+    unfold cat, Cat_sub, cat, Cat_Fun.
+    unfold assoc_r, AssocR_Coproduct, case_, Case_sub, case_, Case_Kleisli, case_sum.
+    cbn. unfold to_bif, ToBifunctor_Fun_fin. unfold swap, Swap_Coproduct, case_.
+    unfold bimap, Bimap_Coproduct, case_, cat. cbn.
+    repeat rewrite split_fin_sum_L. repeat rewrite split_fin_sum_R. rewrite H. cbn.
+    repeat rewrite split_fin_sum_L. repeat rewrite split_fin_sum_R. cbn.
+    repeat rewrite split_fin_sum_L. repeat rewrite split_fin_sum_R. cbn.
+    unfold assoc_l, AssocL_Coproduct. cbn. unfold case_.
+    repeat rewrite split_fin_sum_L. repeat rewrite split_fin_sum_R. cbn.
+    repeat rewrite split_fin_sum_L. repeat rewrite split_fin_sum_R. cbn.
+    unfold merge, case_. repeat rewrite split_fin_sum_L. repeat rewrite split_fin_sum_R. cbn.
+    auto.
+  Qed.
+
+  Lemma reassoc_seq_asm_exc_D (B C D : nat ) (d : fin D) (dc : fin (D + C) ) :
+    split_fin_sum D C dc = inl d -> @reassoc_seq_asm_exc B C D (R _ dc ) = R _ (L _ d).
+  Proof.
+    intros. unfold reassoc_seq_asm_exc. cbn.
+    unfold cat, Cat_sub, cat, Cat_Fun.
+    unfold assoc_r, AssocR_Coproduct, case_, Case_sub, case_, Case_Kleisli, case_sum.
+    cbn. unfold to_bif, ToBifunctor_Fun_fin. unfold swap, Swap_Coproduct, case_.
+    unfold bimap, Bimap_Coproduct, case_, cat. cbn.
+    repeat rewrite split_fin_sum_L. repeat rewrite split_fin_sum_R. cbn.
+    repeat rewrite split_fin_sum_L. repeat rewrite split_fin_sum_R. cbn. rewrite H.
+    unfold assoc_l, AssocL_Coproduct. cbn. unfold case_. cbn.
+    repeat rewrite split_fin_sum_L. repeat rewrite split_fin_sum_R. cbn. auto.
+  Qed.
+
+  Lemma reassoc_seq_asm_exc_C_bd (B C D : nat ) (c : fin C) (dc : fin (D + C) ) :
+    split_fin_sum D C dc = inr c -> @reassoc_seq_asm_exc B C D (R _ dc ) = R _ (R _ c).
+  Proof.
+    intros. unfold reassoc_seq_asm_exc. cbn.
+    unfold cat, Cat_sub, cat, Cat_Fun.
+    unfold assoc_r, AssocR_Coproduct, case_, Case_sub, case_, Case_Kleisli, case_sum.
+    cbn. unfold to_bif, ToBifunctor_Fun_fin. unfold swap, Swap_Coproduct, case_.
+    unfold bimap, Bimap_Coproduct, case_, cat. cbn.
+    repeat rewrite split_fin_sum_L. repeat rewrite split_fin_sum_R. cbn. rewrite H.
+    repeat rewrite split_fin_sum_L. repeat rewrite split_fin_sum_R. cbn.
+    unfold assoc_l, AssocL_Coproduct. cbn. unfold case_. cbn.
+    repeat rewrite split_fin_sum_L. repeat rewrite split_fin_sum_R.
+    repeat rewrite split_fin_sum_L. repeat rewrite split_fin_sum_R.
+    unfold merge. unfold case_. rewrite split_fin_sum_R. auto.
+  Qed.
+
+  Lemma seq_asm_exc_correct {A B C D} (ab : asm A (B + C)) (bd : asm B (D + C)) :
+     denote_asm (seq_asm_exc ab bd)
+   ⩯ denote_asm ab  >>> case_ (denote_asm bd) inr_.
+  Proof.
+    unfold seq_asm_exc, expose_linking_labels, swap_and_merge, comb.
+    rewrite loop_asm_correct, relabel_asm_correct, app_asm_correct. rewrite cat_id_r.
+    repeat rewrite fmap_swap.
+    match goal with |- loop ?b ⩯ _ =>  set b as body end.
+    assert (forall a : fin A, body (merge_fin_sum _ _ (inr a)) ≈
+                              r <- denote_asm ab a;;
+                         Ret
+                           (reassoc_seq_asm_exc (L _ r) )).
+
+    {
+      intros. match goal with |- _ ≈ ?t => remember t as t' end.
+      unfold body. cbn. repeat setoid_rewrite bind_ret_l.
+      rewrite bind_bind. rewrite split_fin_sum_R. cbn.
+      repeat rewrite bind_ret_l. Local Opaque denote_asm. unfold from_bif, FromBifunctor_ktree_fin.
+      rewrite bind_ret_l. rewrite split_merge. cbn.
+      setoid_rewrite bind_ret_l. rewrite bind_bind.
+      unfold from_bif, FromBifunctor_ktree_fin. setoid_rewrite bind_ret_l.
+      cbn. unfold unsubm. subst. unfold reassoc_seq_asm_exc. reflexivity.
+    } (* this unfolding basically shows that you only need to unfold the top level loop twice*)
+    assert (forall b : fin B, body (merge_fin_sum _ _ (inl b) ) ≈
+                              r <- denote_asm bd b;;
+                         Ret (reassoc_seq_asm_exc (R _ r) )).
+    {
+      intros. unfold body. cbn. repeat setoid_rewrite bind_ret_l.
+      rewrite split_fin_sum_L. cbn. repeat setoid_rewrite bind_ret_l.
+      rewrite split_merge. cbn. rewrite bind_bind. setoid_rewrite bind_ret_l.
+      unfold from_bif, FromBifunctor_ktree_fin. setoid_rewrite bind_ret_l.
+      cbn. unfold unsubm. unfold reassoc_seq_asm_exc. reflexivity.
+    }
+    assert (body ⩯ case_
+                 (denote_asm bd >>> (fun r => Ret (reassoc_seq_asm_exc (R _ r) ) ))
+                 (denote_asm ab >>> (fun r => Ret (reassoc_seq_asm_exc (L _ r)) ))).
+    { do 5 red. unfold case_, Case_sub. unfold to_bif, ToBifunctor_ktree_fin.
+      cbn.
+      intros. destruct (split_fin_sum B A a) eqn : Heq.
+      - rewrite bind_ret_l. cbn. rewrite <- H0. rewrite <- Heq. rewrite merge_split. reflexivity.
+      - rewrite bind_ret_l. cbn. rewrite <- H. rewrite <- Heq. rewrite merge_split. reflexivity.
+    }
+    rewrite H1.
+    do 5 red. intros. Local Opaque denote_asm. unfold loop. cbn.
+    rewrite bind_bind. rewrite bind_ret_l. unfold from_bif, FromBifunctor_ktree_fin.
+    rewrite bind_ret_l. cbn.
+    setoid_rewrite unfold_iter_ktree. cbn. unfold to_bif, ToBifunctor_ktree_fin.
+    repeat rewrite split_fin_sum_R. repeat rewrite bind_bind. rewrite bind_ret_l.
+    cbn. rewrite bind_bind. eapply eqit_bind'; try reflexivity. intros; subst.
+    repeat setoid_rewrite bind_ret_l.
+    destruct (split_fin_sum _ _ r2) as [b | c] eqn : Heq.
+    - erewrite reassoc_seq_asm_exc_B; eauto. rewrite split_fin_sum_L. cbn.
+      repeat setoid_rewrite bind_ret_l. rewrite split_merge. rewrite tau_eutt.
+      setoid_rewrite unfold_iter_ktree. cbn. repeat rewrite bind_bind.
+      repeat setoid_rewrite bind_ret_l. cbn. rewrite split_fin_sum_L. cbn.
+      rewrite bind_bind. setoid_rewrite bind_ret_l. cbn.
+      match goal with |- eqit eq true true (ITree.bind _ ?k ) _ => remember k as k_id  end.
+      assert (forall r, k_id r ≈ Ret r ).
+      {
+        subst. intros. destruct (split_fin_sum _ _ r) as [d | c] eqn : Heqr .
+        - erewrite  reassoc_seq_asm_exc_D; eauto. rewrite split_fin_sum_R. cbn.
+          repeat rewrite bind_ret_l. unfold from_bif, FromBifunctor_ktree_fin.
+          cbn. rewrite bind_ret_l. rewrite split_fin_sum_R. cbn.
+          unfold id. apply eqit_Ret.
+          apply unique_fin.
+          unfold split_fin_sum in Heqr.
+          destruct (lt_dec (proj1_sig r) D ); try discriminate.
+          injection Heqr as Heqr. rewrite <- Heqr. cbn. auto.
+        - erewrite reassoc_seq_asm_exc_C_bd; eauto. rewrite split_fin_sum_R.
+          cbn. repeat setoid_rewrite bind_ret_l. rewrite split_merge.
+          unfold split_fin_sum in Heqr. destruct r. cbn in Heqr.
+          destruct (lt_dec x D); try discriminate. injection Heqr as Heqr.
+          subst. cbn. apply eqit_Ret. apply unique_fin. cbn.
+          lia.
+      }
+      setoid_rewrite <- bind_ret_r at 3.
+      eapply eqit_bind'; try reflexivity. clear Heqk_id. intros; subst.
+      rewrite H2. reflexivity.
+    - erewrite reassoc_seq_asm_exc_C_ab; eauto. rewrite split_fin_sum_R.
+      cbn. repeat setoid_rewrite bind_ret_l. rewrite split_merge.
+      cbn. unfold from_bif, FromBifunctor_ktree_fin. cbn. reflexivity.
+  Qed.
+
+    (* remaining goals in this lemma could all be solved with proof irrelavance *)
+
+  (** [if_asm] is denoted as the ktree first denoting the branching condition,
+      then looking-up the appropriate variable and following with either denotation. *)
+  Lemma if_asm_correct {A} (e : list instr) (tp fp : asm 1 A) :
+      denote_asm (if_asm e tp fp)
+    ⩯ ((fun _ =>
+         denote_list e ;;
+         v <- trigger (GetReg tmp_if) ;;
+         if v : value then denote_asm fp f0 else denote_asm tp f0)).
+  Proof.
+    unfold if_asm.
+    rewrite seq_asm_correct.
+    unfold cond_asm.
+    rewrite raw_asm_block_correct_lifted.
+    rewrite relabel_asm_correct.
+
+    intros ?.
+    Local Opaque denote_asm.
+
+    unfold CategoryOps.cat, Cat_sub, CategoryOps.cat, Cat_Kleisli; simpl.
+    rewrite denote_after.
+    cbn.
+    repeat setoid_rewrite bind_bind.
+    apply eqit_bind; try reflexivity. intros _.
+    apply eqit_bind; try reflexivity. intros [].
+
+    - rewrite !bind_ret_l.
+      setoid_rewrite (app_asm_correct tp fp _).
+      setoid_rewrite bind_bind.
+      match goal with
+      | [ |- _ (?t >>= _) _ ] => let y := eval compute in t in change t with y
+      end.
+      rewrite bind_ret_l. cbn.
+      setoid_rewrite bind_ret_l.
+      rewrite bind_bind.
+      setoid_rewrite bind_ret_l.
+      unfold from_bif, FromBifunctor_ktree_fin; cbn.
+      rewrite bind_ret_r'.
+      { rewrite (unique_f0 (fi' 0)). reflexivity. }
+      { intros. cbv - [split_fin_sum R]. rewrite split_fin_sum_R. reflexivity. }
+
+    - rewrite !bind_ret_l.
+      setoid_rewrite (app_asm_correct tp fp _).
+      repeat setoid_rewrite bind_bind.
+      match goal with
+      | [ |- _ (?t >>= _) _ ] => let y := eval compute in t in change t with y
+      end.
+      rewrite bind_ret_l. cbn. rewrite bind_bind.
+      setoid_rewrite bind_ret_l.
+      unfold from_bif, FromBifunctor_ktree_fin.
+      setoid_rewrite bind_ret_l.
+      rewrite bind_ret_r'.
+      { rewrite (unique_f0 (fi' 0)). reflexivity. }
+      { intros. cbv - [split_fin_sum L]. rewrite split_fin_sum_L. reflexivity. }
+  Qed.
+
+  (** [while_asm] is denoted as the loop of the body with two entry point, the exit
+      of the loop, and the body in which we have the same structure as for the conditional *)
+  Notation label_case := (split_fin_sum _ _).
+
+  Lemma while_asm_correct (e : list instr) (p : asm 1 1) :
+      denote_asm (while_asm e p)
+    ⩯ (loop (C := sub (ktree _) fin) (fun l : fin (1 + 1) =>
+         match label_case l with
+         | inl _ =>
+           denote_list e ;;
+           v <- trigger (GetReg tmp_if) ;;
+           if (v:value) then Ret (fS f0) else (denote_asm p f0;; Ret f0)
+         | inr _ => Ret f0
+         end)).
+  Proof.
+    unfold while_asm.
+    rewrite loop_asm_correct.
+    apply Proper_loop.
+    rewrite relabel_asm_correct.
+    rewrite fmap_id0, cat_id_l.
+    rewrite app_asm_correct.
+    rewrite if_asm_correct.
+    intros x.
+    cbn.
+    unfold to_bif, ToBifunctor_ktree_fin.
+    rewrite bind_ret_l.
+    destruct (label_case x); cbn.
+    - rewrite !bind_bind. setoid_rewrite bind_ret_l. setoid_rewrite bind_bind.
+      eapply eutt_clo_bind; try reflexivity. intros; subst.
+      repeat rewrite bind_bind.
+      eapply eutt_clo_bind; try reflexivity. intros; subst.
+      unfold from_bif, FromBifunctor_ktree_fin; cbn.
+      repeat rewrite bind_bind.
+      repeat setoid_rewrite bind_ret_l.
+      destruct u0.
+      + rewrite (pure_asm_correct _ _); cbn.
+        rewrite !bind_ret_l.
+        apply eqit_Ret.
+        apply unique_fin; reflexivity.
+
+      + rewrite (relabel_asm_correct _ _ _ _). cbn.
+        rewrite bind_ret_l.
+        setoid_rewrite bind_bind.
+        eapply eutt_clo_bind; try reflexivity.
+        intros ? ? [].
+        repeat rewrite bind_ret_l.
+        apply eqit_Ret.
+        rewrite (unique_f0 u1).
+        apply unique_fin; reflexivity.
+
+    - cbn.
+      rewrite (pure_asm_correct _ _).
+      rewrite bind_bind. cbn.
+      unfold from_bif, FromBifunctor_ktree_fin.
+      rewrite !bind_ret_l.
+      apply eqit_Ret.
+      rewrite (unique_f0 f).
+      apply unique_fin; reflexivity.
+Qed.
+
+Definition relabel_output  : fin (1 + 2) -> fin (1 + (1 + 2)) :=
+  bimap (id_ _) inr_.
+
+Opaque L.
+
+Lemma while_asm_exc_correct (e : list instr) (p : asm 1 (1 + 2 )) :
+   denote_asm (while_asm_exc e p)
+ ⩯ (loop (C := sub (ktree _) fin) (fun l : fin (1 + 1) =>
+         match label_case l with
+         | inl _ =>
+           denote_list e;;
+           v <- trigger (GetReg tmp_if) ;;
+           if (v:value)
+           then Ret (fS f0)
+           else (l' <- denote_asm p f0;; Ret (relabel_output l')  )
+         | inr _ => Ret (f0)
+         end)) .
+Proof.
+  unfold while_asm_exc. rewrite loop_asm_correct. apply Proper_loop.
+  rewrite relabel_asm_correct. rewrite app_asm_correct. rewrite pure_asm_correct.
+  rewrite if_asm_correct. cbn.  rewrite fmap_id0. rewrite cat_id_l.
+  unfold relabel_output.
+  do 5 red. intros. unfold cat, Cat_sub, cat, Cat_Kleisli.
+  cbn. rewrite bind_bind. setoid_rewrite bind_ret_l. cbn.
+  destruct (label_case (a : fin (1 + 1) )); cbn.
+  - repeat setoid_rewrite bind_bind. eapply eqit_bind'; try reflexivity. intros [] [] _ ; subst.
+    eapply eqit_bind'; try reflexivity. intros; subst.
+    destruct r2.
+    + specialize @pure_asm_correct as Hpac. do 5 red in Hpac. setoid_rewrite Hpac.
+      clear Hpac. cbn. repeat setoid_rewrite bind_ret_l.
+      apply eqit_Ret. cbn. unfold unsubm. apply unique_fin. auto.
+    + unfold direct_output_while_exc. specialize @relabel_asm_correct as Hrac.
+      do 5 red in Hrac. rewrite Hrac. cbn. repeat rewrite bind_bind.
+      repeat setoid_rewrite bind_ret_l. cbn. unfold unsubm, id_, Id_sub, id_, Id_Fun.
+      eapply eqit_bind'; try reflexivity. intros; subst. apply eqit_Ret. apply unique_fin.
+      destruct r0 as [n Hn].
+      do 3 (destruct n; auto). lia.
+  - unfold cat, Cat_sub, cat, Cat_Kleisli. cbn. rewrite bind_bind.
+    rewrite bind_ret_l. unfold inr_, Inr_sub, inr_, Inr_Kleisli, lift_ktree_. cbn.
+    unfold cat. rewrite bind_bind. rewrite bind_ret_l. unfold from_bif, FromBifunctor_ktree_fin.
+    rewrite bind_ret_l.
+    setoid_rewrite unique_f0. cbn.
+    unfold unsubm.  unfold merge, case_, Case_sub, to_bif, ToBifunctor_Fun_fin.
+    cbn. unfold cat, Cat_Fun. rewrite split_fin_sum_R. apply eqit_Ret.
+    cbn. unfold id_, Id_sub, id_, Id_Fun. cbn. apply unique_fin. cbn. Local Transparent L.
+    auto.
+Qed.
+
+Lemma trycatch_asm_correct (p : asm 1 (1 + (1 + 1) )) (c : asm 1 3) :
+  denote_asm (trycatch_asm p c)
+⩯ denote_asm p >>> case_ inl_ (merge >>> denote_asm c ).
+Proof.
+ unfold trycatch_asm. rewrite seq_asm_correct. repeat rewrite relabel_asm_correct.
+ rewrite app_asm_correct.  do 5 red. intros. cbn.
+ repeat rewrite bind_bind. repeat setoid_rewrite bind_ret_l.
+ unfold unsubm, id_, Id_sub, id_, Id_Fun. eapply eqit_bind'; try reflexivity.
+ intros; subst. cbn. destruct r2 as [l Hl].
+ do 3 (try destruct l as [ | l]; auto); try lia; cbn; repeat rewrite bind_bind.
+ - repeat setoid_rewrite bind_ret_l. cbn. unfold pure_ret_asm.
+   specialize (@pure_asm_correct) as Hpac. do 5 red in Hpac. rewrite Hpac.
+   setoid_rewrite bind_ret_l. apply eqit_Ret. cbn. apply unique_fin. auto.
+ - repeat setoid_rewrite bind_ret_l. cbn. unfold id.
+   unfold merge, case_, Case_sub, case_, Case_Kleisli, case_sum, to_bif, ToBifunctor_Fun_fin.
+   cbn. setoid_rewrite <- bind_ret_r at 4. eapply eqit_bind' with (RR := eq).
+   + match goal with |- eqit eq true true (denote_asm c ?f1) (denote_asm c (?f2) ) => assert (f1 = f2) end.
+   { apply unique_fin. auto. }
+   timeout 5 rewrite H. reflexivity.
+   + intros; subst. destruct r2. cbn. apply eqit_Ret. apply unique_fin. cbn. lia.
+ - repeat setoid_rewrite bind_ret_l. cbn. setoid_rewrite <- bind_ret_r at 4.
+   eapply eqit_bind' with (RR := eq).
+   + match goal with |- eqit eq true true (denote_asm c ?f1) (denote_asm c (?f2) ) => assert (f1 = f2) end.
+     { apply unique_fin. auto. }
+     rewrite H. reflexivity.
+   + intros; subst. apply eqit_Ret. apply unique_fin. destruct r2. cbn. lia.
+Qed.
+
+
+  Definition link_with_exc : ktree_fin ((impExcE sensitivity_lat) +' Reg +' Memory +' (IOE sensitivity_lat)) (1 + 2) 1  :=
+    case_ (id_ _)
+    (case_ (C := ktree_fin _ )
+            (fun _ : fin 1 => v <- trigger (Throw Public);; match v : void with end )
+            (fun _ : fin 1 => v <- trigger (Throw Private);; match v : void with end )).
+
+  Lemma compile_compile_stmt_correct (s : stmt) :
+    denote_asm (compile s)
+  ⩯ denote_asm (compile_stmt s) >>> link_with_exc .
+  Proof.
+    unfold compile, link_with_exc.
+    cbn in *. rewrite seq_asm_correct. rewrite relabel_asm_correct. remember (app_asm (raise_asm Public) (raise_asm Private) ) as app.
+    assert (denote_asm (app_asm (@id_asm 1) app) ⩯ bimap (denote_asm id_asm) (denote_asm app) ).
+    { rewrite app_asm_correct. reflexivity. }
+    rewrite H. unfold id_asm. rewrite pure_asm_correct. rewrite Heqapp.
+    rewrite app_asm_correct.
+    do 5 red. intros. cbn. eapply eqit_bind'; try reflexivity. intros; subst.
+    repeat setoid_rewrite bind_bind. repeat setoid_rewrite bind_ret_l. cbn.
+    destruct r2 as [l Hl].
+Transparent denote_asm.
+    do 3 (try destruct l as [ | l]; cbn ); try lia; repeat setoid_rewrite bind_ret_l.
+    - apply eqit_Ret. apply unique_fin. auto.
+    - cbn. rewrite bind_bind. setoid_rewrite bind_ret_l. cbn.
+      rewrite bind_bind. tau_steps.  apply eqit_Vis. intros [].
+    - cbn. rewrite bind_bind. setoid_rewrite bind_ret_l. cbn.
+      rewrite bind_bind. tau_steps.  apply eqit_Vis. intros [].
+  Qed.
+
+  Lemma early_link_with_exc (p1 p2: ktree_fin ((impExcE sensitivity_lat) +' Reg +' Memory +' (IOE sensitivity_lat)) 1 (1 + 2) ) :
+    p1 >>> case_ p2 inr_ >>> link_with_exc ⩯ p1 >>> link_with_exc >>> p2 >>> link_with_exc.
+  Proof.
+    unfold cat, Cat_sub, cat, Cat_Kleisli. cbn. repeat setoid_rewrite bind_bind.
+    do 5 red. intros. eapply eqit_bind'; try reflexivity. intros; subst.
+    destruct r2 as [l Hl]. do 3 (try destruct l as [ | l]; cbn ); try lia;
+                             repeat setoid_rewrite bind_ret_l.
+    - cbn. reflexivity.
+    - cbn. repeat rewrite bind_bind. eapply eqit_bind'; try reflexivity. intros [].
+    - cbn. repeat rewrite bind_bind. eapply eqit_bind'; try reflexivity. intros [].
+  Qed.
+
+
+
+(* where *)
+End Linking.
+
+(* ================================================================= *)
+(** ** Correctness *)
+
+Section Correctness.
+
+(*
+  Arguments interp_imp {Labels} {R}.
+  Arguments denote_expr {Labels}.
+  Arguments denote_stmt {Labels}.
+*)
+  (** Correctness of expressions.
+      We strengthen [bisimilar]: initial environments are still related by [Renv],
+      but intermediate ones must now satisfy [sim_rel].
+      Note that by doing so, we use a _heterogeneous bisimulation_: the trees
+      return values of different types ([alist var value * unit] for _Asm_,
+      [alist var value * value] for _Imp_). The difference is nonetheless mostly
+      transparent for the user, except for the use of the more general lemma [eqit_bind'].
+   *)
+  (* here we need to codify in some way that denote_expr cannot call any asm inlined code,
+     which is to say that that interp (denote_expr e) (regs, heap) ≈ Ret (regs, ...) leaving the regs unchanged
+     this brings up an interesting point which is that this compiler is correct if you don't care about final register states
+     and does this cause other problems down the line?
+
+     ultimately we need to take the program compile it and relate the two programs with the same starting heap and
+     possibly different registers,
+
+     suppose we inline the following asm code
+
+
+     a :=
+     START
+     BRZ 0 l1 l2
+
+     l1
+     Istore (Oimm 0) X
+     JMP Exit
+
+     l2
+     Istore (Oimm 1) X
+     JMP Exit
+
+
+
+     c := (if X + X + X = 0 then skip else skip); a
+
+     interp (denote c) = fun (regs, heap) => Ret (regs, if regs 0 = 0 then update heap X 0 else update heap X 1 )
+
+     interp (denote (compile c)) = fun (regs, heap) => let regs' := ... in Ret (if regs' 0 = 0 then update heap X 0 else update heap X 1)
+
+     these denotations are not the same even if we ignore the effects on the registers because a is "bad",
+     it makes changes to the heap based on the registers
+
+     for the compiler to be correct, we need to know that no inlined asm code ever does that
+
+     It is not enough to just nuke the registers on the imp side before running inlined code, because I could still write code that
+     looks for differences in the registers, and those differences might be there based on expression computations
+
+     If I added a nuke registers instruction to asm that could work, but I think the restriction of imp programs is a better/easier solution
+
+   *)
+
+
+  (*maybe should be strengthened to requiring too state equivalent memories *)
+  Definition valid_asm {T} m : Prop := forall (l1 l2 : registers) (g_asm1 g_asm2 : memory),
+    Renv g_asm1 g_asm2 ->
+    @eutt ((impExcE sensitivity_lat) +' (IOE sensitivity_lat)) _ _ (state_invariant (@eq T ))
+          (m (l1, g_asm1)) (m (l2, g_asm2)).
+
+  Inductive valid_stmt : stmt -> Prop :=
+    | validSkip : valid_stmt Skip
+    | validAssign x e : valid_stmt (Assign x e)
+    | validOuptut l e : valid_stmt (Output l e)
+    | validRaise l : valid_stmt (Raise l)
+    | validSeq c1 c2 : valid_stmt c1 -> valid_stmt c2 -> valid_stmt (Seq c1 c2)
+    | validIf b c1 c2 : valid_stmt c1 -> valid_stmt c2 -> valid_stmt (If b c1 c2)
+    | validWhile b c : valid_stmt c -> valid_stmt (While b c)
+    | validTryCatch c1 c2 : valid_stmt c1 -> valid_stmt c2 -> valid_stmt (TryCatch c1 c2)
+    | validAsmInline (a : asm 1 1) : valid_asm (interp_asm (throw_prefix (denote_asm a f0)))  -> valid_stmt (AsmInline a)
+  .
+
+  Lemma compile_expr_correct : forall e g_imp g_asm l1 l2 n,
+      Renv g_imp g_asm ->
+      eutt (sim_rel l2 n)
+            (interp_imp_inline (denote_expr e) (l1,g_imp))
+            (interp_asm (denote_list (compile_expr n e)) (l2, g_asm) ).
+  Proof.
+    induction e; simpl; intros.
+    - (* Var case *)
+      (* We first compute and eliminate taus on both sides. *)
+      force_left.
+      rewrite tau_eutt.
+
+      tau_steps.
+
+      (* We are left with [Ret] constructs on both sides, that remains to be related *)
+      red; rewrite <-eqit_Ret.
+      unfold lookup_default, lookup, Map_alist, LabelledImp.get.
+
+      (* On the _Asm_ side, we bind to [gen_tmp n] a lookup to [varOf v] *)
+      (* On the _Imp_ side, we return the value of a lookup to [varOf v] *)
+      erewrite Renv_find; [| eassumption].
+      apply sim_rel_add; assumption.
+
+    - (* Literal case *)
+      (* We reduce both sides to Ret constructs *)
+      tau_steps.
+
+      red; rewrite <-eqit_Ret.
+      (* _Asm_ bind the litteral to [gen_tmp n] while _Imp_ returns it *)
+      apply sim_rel_add; assumption.
+
+    (* The three binary operator cases are identical *)
+    - (* Plus case *)
+      (* We push [interp_locals] into the denotations *)
+
+      do 2 setoid_rewrite denote_list_app.
+      repeat setoid_rewrite interp_state_bind.
+
+      (* The Induction hypothesis on [e1] relates the first itrees *)
+      eapply eutt_clo_bind.
+      { eapply IHe1; assumption. }
+      (* We obtain new related environments *)
+      intros [ [l_imp' g_imp'] v] [ [g_asm' l'] [] ]    HSIM.
+      (* The Induction hypothesis on [e2] relates the second itrees *)
+      eapply eutt_clo_bind.
+      { eapply IHe2.
+        eapply sim_rel_Renv; eassumption. }
+      (* And we once again get new related environments *)
+      intros [ [l_imp'' g_imp''] v'] [ [g_asm'' l''] []] HSIM'.
+      (* We can now reduce down to Ret constructs that remains to be related *)
+      tau_steps.
+      red. rewrite <- eqit_Ret. clear -HSIM HSIM'.
+      red. unfold get_reg, update_reg. cbn. split; try split; try tauto.
+      eapply sim_rel_Renv; eauto.
+      eapply sim_rel_find_tmp_n_trans in HSIM' as Hn; eauto. apply sim_rel_find in HSIM' as Hsn.
+      rewrite Hn. rewrite Hsn. unfold update_reg. rewrite Nat.eqb_refl. auto.
+      intros. assert (n <> m). lia. unfold update_reg.
+      apply Nat.eqb_neq in H0. rewrite H0.
+      red in HSIM'. destruct HSIM' as [_ [? ?] ]. rewrite<-  H2; eauto.
+      red in HSIM. destruct HSIM as [ ? [?  ?] ].
+      apply H5; eauto.
+    - (* Sub case *)
+      (* We push [interp_locals] into the denotations *)
+
+      do 2 setoid_rewrite denote_list_app.
+      repeat setoid_rewrite interp_state_bind.
+
+      (* The Induction hypothesis on [e1] relates the first itrees *)
+      eapply eutt_clo_bind.
+      { eapply IHe1; assumption. }
+      (* We obtain new related environments *)
+      intros [ [l_imp' g_imp'] v] [ [g_asm' l'] [] ]    HSIM.
+      (* The Induction hypothesis on [e2] relates the second itrees *)
+      eapply eutt_clo_bind.
+      { eapply IHe2.
+        eapply sim_rel_Renv; eassumption. }
+      (* And we once again get new related environments *)
+      intros [ [l_imp'' g_imp''] v'] [ [g_asm'' l''] []] HSIM'.
+      (* We can now reduce down to Ret constructs that remains to be related *)
+      tau_steps.
+      red. rewrite <- eqit_Ret. clear -HSIM HSIM'.
+      red. unfold get_reg. split; try split; try tauto.
+      eapply sim_rel_Renv; eauto.
+      eapply sim_rel_find_tmp_n_trans in HSIM' as Hn; eauto. apply sim_rel_find in HSIM' as Hsn.
+      rewrite Hn. rewrite Hsn. unfold update_reg. rewrite Nat.eqb_refl. auto.
+      intros. assert (n <> m). lia. unfold update_reg.
+      apply Nat.eqb_neq in H0. rewrite H0.
+      red in HSIM'. destruct HSIM' as [_ [? ?] ]. rewrite<-  H2; eauto.
+      red in HSIM. destruct HSIM as [ ? [?  ?] ].
+      apply H5; eauto.
+    - (* Mul case *)
+      (* We push [interp_locals] into the denotations *)
+
+      do 2 setoid_rewrite denote_list_app.
+      repeat setoid_rewrite interp_state_bind.
+
+      (* The Induction hypothesis on [e1] relates the first itrees *)
+      eapply eutt_clo_bind.
+      { eapply IHe1; assumption. }
+      (* We obtain new related environments *)
+      intros [ [l_imp' g_imp'] v] [ [g_asm' l'] [] ]    HSIM.
+      (* The Induction hypothesis on [e2] relates the second itrees *)
+      eapply eutt_clo_bind.
+      { eapply IHe2.
+        eapply sim_rel_Renv; eassumption. }
+      (* And we once again get new related environments *)
+      intros [ [l_imp'' g_imp''] v'] [ [g_asm'' l''] []] HSIM'.
+      (* We can now reduce down to Ret constructs that remains to be related *)
+      tau_steps.
+      red. rewrite <- eqit_Ret. clear -HSIM HSIM'.
+      red. unfold get_reg. split; try split; try tauto.
+      eapply sim_rel_Renv; eauto.
+      eapply sim_rel_find_tmp_n_trans in HSIM' as Hn; eauto. apply sim_rel_find in HSIM' as Hsn.
+      rewrite Hn. rewrite Hsn. unfold update_reg. rewrite Nat.eqb_refl. auto.
+      intros. assert (n <> m). lia. unfold update_reg.
+      apply Nat.eqb_neq in H0. rewrite H0.
+      red in HSIM'. destruct HSIM' as [_ [? ?] ]. rewrite<-  H2; eauto.
+      red in HSIM. destruct HSIM as [ ? [?  ?] ].
+      apply H5; eauto.
+  Qed.
+
+  (** Correctness of the assign statement.
+      The resulting list of instructions is denoted as
+      denoting the expression followed by setting the variable.
+   *)
+  Lemma compile_assign_correct : forall e x,
+      bisimilar eq
+        ((v <- denote_expr e ;; trigger (Store x v)) : itree ((impExcE sensitivity_lat) +' Reg +' Memory +' (IOE sensitivity_lat)) unit)
+        ((denote_list (compile_assign x e)) : itree ((impExcE sensitivity_lat) +' Reg +' Memory +' (IOE sensitivity_lat)) unit).
+  Proof.
+    red; intros.
+    unfold compile_assign.
+    (* We push interpreters inside of the denotations *)
+    unfold interp_imp_inline, interp_asm.
+    rewrite denote_list_app.
+    do 2 rewrite interp_state_bind.
+    (* By correctness of the compilation of expressions,
+       we can match the head trees.
+     *)
+    eapply eutt_clo_bind.
+    { eapply compile_expr_correct; eauto. }
+
+    (* Once again, we get related environments *)
+    intros [ [l_imp' g_imp'] v]  [ [g_asm' l'] y] HSIM.
+    simpl in HSIM.
+
+    (* We can now reduce to Ret constructs *)
+    tau_steps.
+    red. rewrite <- eqit_Ret.
+
+    (* And remains to relate the results *)
+    unfold state_invariant. cbn. split; auto.
+    unfold get_reg. destruct HSIM as [ ? [? ?] ].
+    rewrite H1. apply Renv_write_local; auto.
+  Qed.
+
+  Lemma compile_output_correct : forall s e,
+      bisimilar eq
+        ((v <- denote_expr e ;; trigger (LabelledImp.LabelledPrint _ s v)) : itree ((impExcE sensitivity_lat) +' Reg +' Memory +' (IOE sensitivity_lat)) unit)
+        ((@denote_list  ((impExcE sensitivity_lat) +' Reg +' Memory +' (IOE sensitivity_lat)) _ _ _ (compile_output s e))).
+  Proof.
+    red. intros. unfold compile_output. unfold interp_imp_inline, interp_asm.
+    rewrite denote_list_app.
+    do 2 rewrite interp_state_bind.
+    eapply eutt_clo_bind.
+    { eapply compile_expr_correct; eauto. }
+    intros [ [l_imp' g_imp'] v]  [ [g_asm' l'] y] HSIM.
+    simpl in HSIM. cbn.
+    do 2 setoid_rewrite interp_state_bind. setoid_rewrite bind_bind. repeat setoid_rewrite interp_state_trigger.
+    setoid_rewrite interp_state_ret. cbn. tau_steps.
+    unfold get_reg. destruct HSIM as [? [? ?] ]. rewrite H1.
+    apply eqit_Vis. intros []. repeat setoid_rewrite bind_ret_l.
+    apply eqit_Ret. cbn. split; auto.
+  Qed.
+
+  (* The first parameter of [bisimilar] is unnecessary for this development.
+     The return type is heterogeneous, the singleton type [F 1] on one side
+     and [unit] on the other, hence we instantiate the parameter with the trivial
+     relation.
+   *)
+  Definition TT {A B}: A -> B -> Prop  := fun _ _ => True.
+  Hint Unfold TT: core.
+
+  Definition equivalent (s:stmt ) (t:asm 1 1) : Prop :=
+    bisimilar TT (denote_stmt s) (denote_asm t f0).
+
+  Inductive RI : (unit + unit) -> (unit + unit + unit) -> Prop :=
+  | RI_inl : RI (inl tt) (inl (inl tt))
+  | RI_inr : RI (inr tt) (inr tt).
+
+  (* Utility: slight rephrasing of [while] to facilitate rewriting
+     in the main theorem.*)
+  Lemma while_is_loop {E} (body : itree E (unit+unit)) :
+    while body
+          ≈ iter (C := ktree _) (fun l : unit + unit =>
+                    match l with
+                    | inl _ => x <- body;; match x with inl _ => Ret (inl (inl tt)) | inr _ => Ret (inr tt) end
+                    | inr _ => Ret (inl (inl tt))   (* Enter loop *)
+                    end) (inr tt).
+  Proof.
+    unfold while.
+    rewrite! unfold_iter_ktree.
+    rewrite bind_ret_l, tau_eutt.
+    rewrite unfold_iter_ktree.
+    rewrite unfold_iter.
+    rewrite !bind_bind.
+    eapply eutt_clo_bind. reflexivity.
+    intros. subst.
+    destruct u2 as [[]|[]].
+    2 : { force_right. reflexivity. }
+    rewrite bind_ret_l, !tau_eutt.
+    unfold iter, Iter_Kleisli.
+    apply eutt_iter' with (RI := fun _ r => inl tt = r).
+    - intros _ _ [].
+      rewrite <- bind_ret_r at 1.
+      eapply eutt_clo_bind; try reflexivity.
+      intros [|[]] _ []; apply eqit_Ret; auto; constructor; auto.
+    - constructor.
+  Qed.
+
+  Definition to_itree' {E A} (f : ktree_fin E 1 A) : itree E (fin A) := f f0.
+  Lemma fold_to_itree' {E A} (f : ktree_fin E 1 A) : f f0 = to_itree' f.
+  Proof. reflexivity. Qed.
+
+  Global Instance Proper_to_itree' {E A} :
+    Proper (eq2 ==> eutt eq) (@to_itree' E A).
+  Proof.
+    repeat intro.
+    apply H.
+  Qed.
+(*
+  Notation Inr_Kleisli := Inr_Kleisli.
+  *)
+
+  Definition label_rel {U} (r : U + sensitivity) (l : fin 3) :=
+             match r with
+             | inl _ => proj1_sig l = 0
+             | inr Public => proj1_sig l = 1
+             | inr Private => proj1_sig l = 2 end.
+
+  Lemma throw_prefix_denote_expr (e : expr) :
+     @throw_prefix sensitivity value (Reg +' Memory +' IOE sensitivity_lat) (denote_expr e) ≈ r <- denote_expr e;; Ret (inl r).
+  Proof.
+    induction e.
+    - cbn. setoid_rewrite throw_prefix_ev. rewrite bind_trigger.
+      apply eqit_Vis. intros. rewrite tau_eutt. rewrite throw_prefix_ret.
+      reflexivity.
+    - cbn. rewrite throw_prefix_ret. rewrite bind_ret_l.
+      reflexivity.
+    - simpl. rewrite bind_bind. setoid_rewrite bind_bind. rewrite throw_prefix_bind.
+      rewrite IHe1. rewrite bind_bind. setoid_rewrite bind_ret_l.
+      eapply eutt_clo_bind; try reflexivity. intros; subst.
+      rewrite throw_prefix_bind. rewrite IHe2. rewrite bind_bind.
+      setoid_rewrite bind_ret_l. setoid_rewrite throw_prefix_ret.
+      reflexivity.
+    - simpl. rewrite bind_bind. setoid_rewrite bind_bind. rewrite throw_prefix_bind.
+      rewrite IHe1. rewrite bind_bind. setoid_rewrite bind_ret_l.
+      eapply eutt_clo_bind; try reflexivity. intros; subst.
+      rewrite throw_prefix_bind. rewrite IHe2. rewrite bind_bind.
+      setoid_rewrite bind_ret_l. setoid_rewrite throw_prefix_ret.
+      reflexivity.
+    -  simpl. rewrite bind_bind. setoid_rewrite bind_bind. rewrite throw_prefix_bind.
+      rewrite IHe1. rewrite bind_bind. setoid_rewrite bind_ret_l.
+      eapply eutt_clo_bind; try reflexivity. intros; subst.
+      rewrite throw_prefix_bind. rewrite IHe2. rewrite bind_bind.
+      setoid_rewrite bind_ret_l. setoid_rewrite throw_prefix_ret.
+      reflexivity.
+  Qed.
+
+  Ltac adv := match goal with
+        | u : unit |- _ => destruct u
+        | o : operand |- _ => destruct o
+        | |- context G [denote_operand (Oimm _) ] => cbn
+        | |- context G [denote_operand (Oreg _) ] => cbn
+        | |- forall x, ?P => intro
+        | |- context G [Tau _] => setoid_rewrite tau_eutt
+        | |- context G [throw_prefix (Ret _)] => setoid_rewrite throw_prefix_ret
+        | |- context G [throw_prefix (trigger (SetReg _ _) ) ] => setoid_rewrite throw_prefix_ev
+        | |- context G [throw_prefix (trigger (GetReg _) ) ] => setoid_rewrite throw_prefix_ev
+        | |- context G [throw_prefix (trigger (Store _ _) ) ] => setoid_rewrite throw_prefix_ev
+        | |- context G [throw_prefix (trigger (LabelledImp.LabelledPrint _ _ _) ) ] =>
+          setoid_rewrite throw_prefix_ev
+        | |- context G [throw_prefix (vis (Throw _) _) ] => setoid_rewrite throw_prefix_exc
+        | |- context G [throw_prefix (vis _ _) ] => setoid_rewrite throw_prefix_ev
+        | |- context G [x <- (Vis _ _);; _ ] => setoid_rewrite bind_vis
+        | |- context G [x <- (trigger _ );; _] => setoid_rewrite bind_vis
+        | |- eqit _ _ _ (Vis _ _) (Vis _ _ ) => apply eqit_Vis
+        | |- eutt _ (Vis _ _) (vis _ _ ) => apply eqit_Vis
+        | |- eqit _ _ _ (Vis _ _) (trigger _ ) => apply eqit_Vis
+        | |- eqit _ _ _ (Ret _) (Ret _) => apply eqit_Ret
+        | |- context G [x <- (Ret _);; _ ] => setoid_rewrite bind_ret_l
+        | |- context G [x <- (from_bif _);; _ ] => setoid_rewrite bind_ret_l
+        | |- context G [throw_prefix (y <- _;; _)] => setoid_rewrite throw_prefix_bind
+        | |- context G [throw_prefix (to_bif _)] => setoid_rewrite throw_prefix_ret
+        | |- context G [split_fin_sum _ _ (merge_fin_sum _ _ _)] => rewrite split_merge
+        | |- context G [split_fin_sum _ _ (L _ _ ) ] => rewrite split_fin_sum_L
+        | |- context G [split_fin_sum _ _ (R _ _ ) ] => rewrite split_fin_sum_R
+        | |- eutt _ (Ret _) (to_bif _) => apply eqit_Ret
+        | |- eutt _ (Ret _) (from_bif _) => apply eqit_Ret
+      end.
+
+  Lemma exception_to_sum_correct_instr_aux:
+    forall i : instr,
+      eqit (fun (x : unit + sensitivity) (_ : unit) => x = inl tt) true true
+           (throw_prefix (denote_instr i)) (denote_instr i).
+  Proof.
+    intros i. destruct i; cbn; repeat setoid_rewrite throw_prefix_bind;
+      repeat rewrite bind_bind; try destruct src; cbn; repeat adv; auto.
+  Qed.
+
+
+
+  Lemma exception_to_sum_correct (p : asm 1 1) : eutt label_rel (throw_prefix (denote_asm p f0))
+                                                      (denote_asm (exception_to_sum p) f0).
+  Proof.
+    unfold denote_asm. cbn. repeat setoid_rewrite bind_ret_l.  cbn.
+    setoid_rewrite throw_prefix_iter. cbn. eapply eutt_iter' with (RI := eq); auto.
+    intros; subst. cbn. repeat setoid_rewrite throw_prefix_bind. repeat rewrite bind_bind.
+    destruct p. cbn.
+    induction (code j2).
+    - cbn. rewrite throw_prefix_bind. repeat rewrite bind_bind.
+      set (fun (x : unit + sensitivity) (_ : unit) => x = inl tt) as RR.
+      eapply (eqit_bind' RR); try apply exception_to_sum_correct_instr_aux. unfold RR.
+      intros; subst. auto.
+    - destruct b; cbn; repeat adv.
+      + unfold exception_to_sum_branch_reassoc.
+        destruct (split_fin_sum internal 1 f); cbn; repeat adv; cbn; repeat adv.
+        constructor. cbn. auto. constructor. cbn. destruct f0. cbn. lia.
+      + unfold exception_to_sum_branch_reassoc.
+        repeat adv. destruct u; repeat adv.
+        * destruct (split_fin_sum internal 1 yes); cbn; repeat adv;
+          cbn; repeat adv.
+          apply eqit_Ret. adv. constructor. auto. apply eqit_Ret. adv. constructor.
+          red. destruct f; cbn. lia.
+        * destruct (split_fin_sum internal 1 no); cbn; repeat adv;
+          cbn; repeat adv.
+          apply eqit_Ret. adv. constructor. auto. apply eqit_Ret. adv. constructor.
+          red. destruct f; cbn. lia.
+     + repeat adv. destruct s; cbn; repeat adv.
+       * unfold split_fin_sum. cbn. destruct (lt_dec (internal + 1) internal); try lia.
+         cbn. repeat adv. constructor. red. cbn. lia.
+       * unfold split_fin_sum. cbn. destruct (lt_dec (internal + 2) internal); try lia.
+         cbn. repeat adv. constructor. red. cbn. lia.
+  Qed.
+
+  Definition fin3tosum (f : fin 3) : (fin 1) + sensitivity :=
+    match proj1_sig f with
+    | 0 => inl f0
+    | 1 => inr Public
+    | 2 => inr Private
+    | _ => inl f0 end.
+
+  Definition sumtofin3 (x : fin 1 + sensitivity) : fin 3 :=
+    match x with
+    | inl _ => f0
+    | inr Public => fS f0
+    | inr Private => fS (fS f0) end.
+
+  Lemma eutt_label_rel_to_eutt : forall E (t1 : itree E (fin 1 + sensitivity) ) (t2 : itree E (fin 3)),
+      eutt label_rel t1 t2 -> t1 ≈ (t2 >>= (fun x => Ret (fin3tosum x))).
+  Proof.
+    intros. rewrite <- bind_ret_r. eapply eqit_bind'; eauto.
+    intros. red in H0. destruct r1 as [ ? | [ | ] ]; unfold fin3tosum; rewrite H0; try reflexivity.
+    setoid_rewrite unique_f0. reflexivity.
+  Qed.
+
+
+  (*eq might be too strong without proof irrelevance *)
+  Lemma eutt_label_rel_to_eutt' : forall E (t1 : itree E (fin 1 + sensitivity) ) (t2 : itree E (fin 3)),
+      eutt label_rel t1 t2 -> t2 ≈ (t1 >>= (fun x => Ret (sumtofin3 x))).
+  Proof.
+    intros. rewrite <- bind_ret_r. apply eqit_flip in H. eapply eqit_bind'; eauto.
+    intros. red in H0. destruct r2 as [ ? | [ | ] ]; cbn.
+    - setoid_rewrite (unique_fin _ r1 f0); auto. reflexivity.
+    - setoid_rewrite (unique_fin _ r1 (fS f0)); auto. reflexivity.
+    - setoid_rewrite (unique_fin _ r1 (fS (fS f0))); auto. reflexivity.
+  Qed.
+
+
+  Lemma exception_to_sum_correct_eutt_eq (p : asm 1 1) : eutt eq (throw_prefix (denote_asm p f0))
+                                                      ((denote_asm (exception_to_sum p) f0) >>= (fun x : fin 3 => Ret (fin3tosum x) )).
+  Proof.
+    apply eutt_label_rel_to_eutt. apply exception_to_sum_correct.
+  Qed.
+
+  Lemma exception_to_sum_correct_eutt_eq' (p : asm 1 1) : eutt eq (denote_asm (exception_to_sum p) f0)
+                                                               (throw_prefix (denote_asm p f0) >>= fun x => Ret (sumtofin3 x)).
+  Proof.
+    apply eutt_label_rel_to_eutt'. apply exception_to_sum_correct.
+  Qed.
+
+  Lemma compile_stmt_correct (s : stmt) : valid_stmt s ->
+        bisimilar label_rel (throw_prefix (denote_stmt s)) (denote_asm (compile_stmt s) f0).
+  Proof.
+    induction s; intros Hs.
+    - (* Assign *)
+     simpl. rewrite raw_asm_block_correct. rewrite denote_after.
+     rewrite throw_prefix_bind. rewrite throw_prefix_denote_expr.
+     rewrite bind_bind. setoid_rewrite bind_ret_l.
+     assert (forall r, throw_prefix (Err := sensitivity) (E := (Reg +' Memory +' (IOE _))) (trigger (Store x r) ) ≈ trigger (Store x r);; Ret (inl tt)  ).
+     {
+       intros. rewrite bind_trigger. setoid_rewrite throw_prefix_ev.
+       apply eqit_Vis. setoid_rewrite tau_eutt. intros []. rewrite throw_prefix_ret. reflexivity.
+     }
+     setoid_rewrite H.
+     setoid_rewrite <- bind_ret_r at 6.
+     rewrite <- bind_bind.
+     setoid_rewrite bind_bind at 2.
+     eapply bisimilar_bind'.
+     { eapply compile_assign_correct; eauto. }
+     intros [] [] _. cbn. rewrite bind_ret_l.
+     red. intros. unfold interp_imp_inline, interp_asm. repeat rewrite interp_state_ret.
+     apply eqit_Ret; split; cbn; auto.
+    - (* Seq *)
+      inversion Hs. subst.
+      simpl. Opaque denote_asm. cbn.
+      assert (denote_asm (seq_asm_exc (compile_stmt s1) (compile_stmt s2)) f0 ≈
+              (denote_asm (compile_stmt s1) >>> case_ (denote_asm (compile_stmt s2)) inr_) f0).
+      { specialize (@seq_asm_exc_correct) as Hsaec.
+      do 5 red in Hsaec. rewrite Hsaec.  reflexivity. }
+      rewrite H. rewrite throw_prefix_bind.
+      cbn. eapply bisimilar_bind'; eauto.
+      intros. destruct a; cbn in H0; try destruct s.
+      + destruct u. assert (a' = f0). { apply unique_fin; auto. }
+        subst. setoid_rewrite bind_ret_l. cbn. setoid_rewrite unique_f0.
+        auto.
+      + assert (a' = fS f0). { apply unique_fin; auto. }
+        subst. setoid_rewrite bind_ret_l. cbn. rewrite bind_ret_l.
+        unfold from_bif, FromBifunctor_ktree_fin . cbn.
+        red. intros. unfold interp_imp_inline, interp_asm.
+        repeat rewrite interp_state_ret. apply eqit_Ret.
+        split; auto.
+      + assert (a' = fS (fS f0)). { apply unique_fin; auto. }
+        subst. setoid_rewrite bind_ret_l. cbn. rewrite bind_ret_l.
+        unfold from_bif, FromBifunctor_ktree_fin . cbn.
+        red. intros. unfold interp_imp_inline, interp_asm.
+        repeat rewrite interp_state_ret. apply eqit_Ret.
+        split; auto.
+    - (* If *)
+      inversion Hs. subst.
+      simpl.  rewrite fold_to_itree'. rewrite if_asm_correct.
+      cbn. rewrite throw_prefix_bind. rewrite <- fold_to_itree'.
+      rewrite throw_prefix_denote_expr. rewrite bind_bind. setoid_rewrite bind_ret_l.
+      red. intros. unfold interp_imp_inline, interp_asm. do 2 rewrite interp_state_bind.
+      eapply eutt_clo_bind.
+      { eapply compile_expr_correct; eauto. }
+      intros. destruct u1 as [ [reg0 mem0] v]. destruct u2 as [ [reg mem] ?  ]. destruct u.
+      cbn. assert (Htmp : reg 0 = v).
+      { cbn in H0. tauto. }
+      apply sim_rel_Renv in H0.
+      rewrite interp_state_bind. rewrite interp_state_trigger. cbn.
+      rewrite bind_ret_l. cbn. setoid_rewrite Htmp.
+      destruct v.
+      + apply IHs2; auto.
+      + apply IHs1; auto.
+    - (* While *) (* throw_prefix_bind proof should be the main thing I need *)
+                  (* maybe a throw_prefix_iter as well *)
+      inversion Hs. subst.
+      simpl. rewrite while_is_loop. rewrite fold_to_itree'. rewrite while_asm_exc_correct. rewrite <- fold_to_itree'.
+      setoid_rewrite throw_prefix_iter.
+      unfold loop.
+      (* might have written while_asm_exc wrong *)
+      unfold loop. cbn. setoid_rewrite bind_bind. rewrite bind_ret_l.
+      setoid_rewrite bind_ret_l.
+      eapply bisimilar_iter with (R := fun a l => match a with inl _ => proj1_sig l = 0 | inr _ => proj1_sig l = 1 end);
+      auto.
+      intros [ | ] l Hl.
+      + cbn. assert (l = f0). { apply unique_fin; auto. } rewrite H. cbn.
+        setoid_rewrite bind_bind.
+        setoid_rewrite throw_prefix_bind. rewrite throw_prefix_denote_expr.
+        repeat rewrite bind_bind. setoid_rewrite bind_bind. setoid_rewrite bind_ret_l.
+        red. intros.
+        unfold interp_imp_inline, interp_asm.
+        do 2 rewrite interp_state_bind. eapply eutt_clo_bind.
+        {  eapply compile_expr_correct; auto. }
+        intros [ [reg0 mem0] v] [ [reg mem] [] ]. cbn.
+        intros [HRenv [ Hreg0  ? ] ].
+        destruct v.
+        * setoid_rewrite bind_ret_l. setoid_rewrite throw_prefix_ret. setoid_rewrite bind_ret_l.
+          rewrite bind_trigger. rewrite interp_state_vis. cbn.
+          setoid_rewrite bind_ret_l. rewrite tau_eutt. cbn. unfold get_reg, tmp_if.
+          rewrite Hreg0. repeat setoid_rewrite bind_ret_l. cbn.
+          unfold to_bif, ToBifunctor_ktree_fin. cbn. repeat rewrite interp_state_ret.
+          apply eqit_Ret. split; auto. cbn. constructor. red. auto.
+        * repeat setoid_rewrite bind_bind. setoid_rewrite throw_prefix_bind.
+          setoid_rewrite bind_bind. rewrite bind_trigger. rewrite interp_state_vis.
+          cbn. setoid_rewrite bind_ret_l. rewrite tau_eutt. cbn. unfold get_reg, tmp_if. rewrite Hreg0.
+          setoid_rewrite bind_bind. do 2 rewrite interp_state_bind. eapply eutt_clo_bind.
+          { apply IHs; auto. }
+          intros [ [reg'0 mem'0 ] [ [] | [ | ] ] ] [ [reg' mem' ] l' ] Hst.
+          -- cbn. setoid_rewrite bind_ret_l. setoid_rewrite throw_prefix_ret.
+             setoid_rewrite bind_ret_l. cbn. red in Hst. cbn in Hst. assert (l' = f0).
+             apply unique_fin. cbn; tauto. subst. cbn. repeat setoid_rewrite bind_ret_l.
+             cbn. unfold to_bif, ToBifunctor_ktree_fin. cbn. repeat rewrite interp_state_ret.
+             apply eqit_Ret.  split; try tauto. cbn. constructor. auto.
+          -- destruct Hst. red in H3. cbn in H3. cbn. setoid_rewrite bind_ret_l.
+             assert (l' = fS f0). apply unique_fin. cbn; tauto. subst.
+             cbn. repeat setoid_rewrite bind_ret_l. cbn. unfold to_bif, ToBifunctor_ktree_fin. cbn.
+             repeat rewrite interp_state_ret. apply eqit_Ret. split; auto. constructor. red. auto.
+          -- destruct Hst. red in H3. cbn in H3. cbn. setoid_rewrite bind_ret_l.
+             assert (l' = fS (fS f0)). apply unique_fin. cbn; tauto. subst.
+             cbn. repeat setoid_rewrite bind_ret_l. cbn. unfold to_bif, ToBifunctor_ktree_fin. cbn.
+             repeat rewrite interp_state_ret. apply eqit_Ret. split; auto. constructor. red. auto.
+      + cbn. assert (l = fS f0). { apply unique_fin; auto. } subst. cbn.
+        setoid_rewrite throw_prefix_ret. setoid_rewrite bind_bind. setoid_rewrite bind_ret_l.
+        cbn. setoid_rewrite bind_bind. setoid_rewrite bind_ret_l. cbn. repeat rewrite bind_bind.
+        rewrite bind_ret_l. repeat setoid_rewrite bind_ret_l. cbn.
+        unfold to_bif, ToBifunctor_ktree_fin. cbn. red. intros.
+        unfold interp_imp_inline, interp_asm. repeat rewrite interp_state_ret. apply eqit_Ret.
+        split; auto. cbn. constructor. auto.
+    - (* Skip *)
+      simpl. unfold pure_ret_asm. rewrite fold_to_itree'.
+      rewrite pure_asm_correct. rewrite throw_prefix_ret. cbn.
+      red. intros. unfold interp_imp_inline, interp_asm. repeat rewrite interp_state_ret. apply eqit_Ret.
+      split; cbn; auto.
+    - (* Output *)
+      simpl. rewrite raw_asm_block_correct. rewrite denote_after.
+      rewrite throw_prefix_bind. rewrite throw_prefix_denote_expr.
+      rewrite bind_bind. setoid_rewrite bind_ret_l. cbn.
+      setoid_rewrite throw_prefix_ev. setoid_rewrite tau_eutt. setoid_rewrite throw_prefix_ret.
+      setoid_rewrite <- bind_trigger.
+
+      setoid_rewrite <- bind_ret_r at 6.
+     rewrite <- bind_bind.
+     setoid_rewrite bind_bind at 2.
+     eapply bisimilar_bind'.
+     { eapply compile_output_correct; eauto. }
+     intros [] [] _. cbn. rewrite bind_ret_l.
+     red. intros. unfold interp_imp_inline, interp_asm. repeat rewrite interp_state_ret.
+     apply eqit_Ret; split; cbn; auto.
+    - (* Raise *)
+      simpl. unfold pure_exc_asm. rewrite fold_to_itree'. rewrite pure_asm_correct.
+      cbn. unfold trigger.
+      setoid_rewrite unfold_iter_ktree. cbn. rewrite bind_ret_l.
+      red. intros. unfold interp_imp_inline, interp_asm. repeat rewrite interp_state_ret.
+      apply eqit_Ret. split; cbn; destruct s; auto.
+    - (* TryCatch *)
+      inversion Hs. subst.
+      simpl. rewrite fold_to_itree'. rewrite trycatch_asm_correct.
+      cbn. rewrite throw_prefix_of_try_catch. rewrite try_catch_to_throw_prefix.
+      set (fun (r : unit + sensitivity + sensitivity) (l :fin 3) =>
+             match r with
+             | inl (inl _ ) => label_rel (inl tt) l
+             | inl (inr s) => False
+             | inr s => @label_rel unit (inr s) l end
+          ) as R .
+      eapply bisimilar_bind' with (RAA' := R).
+      + cbn. rewrite throw_prefix_bind. setoid_rewrite <- bind_ret_r at 5.
+        eapply bisimilar_bind'; eauto. intros.
+        destruct a.
+        * rewrite throw_prefix_ret. red. intros.
+          unfold interp_imp_inline, interp_asm. repeat rewrite interp_state_ret.
+          apply eqit_Ret. split; auto.
+        * red. intros.
+          unfold interp_imp_inline, interp_asm. repeat rewrite interp_state_ret.
+          apply eqit_Ret. split; auto.
+      + intros.  destruct a as [ [ | ] | ]; try destruct s; cbn in H; try contradiction.
+        * cbn in H. assert (a' = f0).
+          { apply unique_fin. auto. }
+          subst. repeat setoid_rewrite bind_ret_l. cbn.
+          unfold from_bif, FromBifunctor_ktree_fin.
+          red; intros.
+          unfold interp_imp_inline, interp_asm. repeat rewrite interp_state_ret.
+          apply eqit_Ret. split; auto.
+        *  assert (a' = fS f0).
+          { apply unique_fin. auto. }
+          subst. repeat setoid_rewrite bind_ret_l. cbn.
+          repeat setoid_rewrite bind_ret_l. cbn. unfold id.
+          setoid_rewrite unique_f0. auto.
+        * assert (a' = fS (fS f0)).
+          { apply unique_fin. auto. }
+          subst. repeat setoid_rewrite bind_ret_l. cbn.
+          repeat setoid_rewrite bind_ret_l. cbn. unfold id.
+          setoid_rewrite unique_f0. auto.
+    - (* AsmInline *)
+      inversion Hs. subst. rename H0 into Hp. red in Hp.
+      cbn. unfold denote_asm_inline. rewrite throw_prefix_bind. setoid_rewrite exception_to_sum_correct_eutt_eq'.
+      eapply bisimilar_bind'. Unshelve. 3 : { cbn. apply eq. }
+      + red. intros. eauto.
+      + intros; subst. cbn in a. destruct a; destruct a'; inv H; try setoid_rewrite throw_prefix_ret; cbn.
+        * repeat intro. setoid_rewrite interp_state_ret. apply eqit_Ret; constructor; cbn; auto.
+        * repeat intro; setoid_rewrite interp_state_ret. apply eqit_Ret. constructor; cbn; auto.
+          destruct s0; auto.
+  Qed.
+
+(** Correctness of the compiler.
+      After interpretation of the [Locals], the source _Imp_ statement
+      denoted as an [itree] and the compiled _Asm_ program denoted
+      as an [itree] are equivalent up-to-taus.
+      The correctness is termination sensitive, but nonetheless a simple
+      induction on statements.
+      We are only left with reasoning about the functional correctness of
+      the compiler, all control-flow related reasoning having been handled
+      in isolation.
+   *)
+  Theorem compile_correct (s : stmt) : valid_stmt s ->
+    equivalent s (compile s).
+  Proof.
+    unfold equivalent. intro Hs.  unfold compile. rewrite throw_prefix_bind_decomp.
+    rewrite fold_to_itree'. rewrite seq_asm_correct. rewrite relabel_asm_correct.
+    do 2 rewrite app_asm_correct.  rewrite <- fold_to_itree'. cbn.
+    eapply bisimilar_bind'. eapply compile_stmt_correct; auto.
+    specialize (@pure_asm_correct ) as Hpac. do 5 red in Hpac.
+    intros [ [] | [ | ] ] l Hl; repeat setoid_rewrite bind_ret_l; cbn.
+    - assert (l = f0). { red in Hl. apply unique_fin. auto. } subst.
+      cbn. setoid_rewrite Hpac. repeat setoid_rewrite bind_ret_l.
+      red. intros. unfold interp_imp_inline, interp_asm. repeat rewrite interp_state_ret.  apply eqit_Ret.
+      split; auto.
+    - assert (l = fS f0). { red in Hl. apply unique_fin. auto. } subst.
+      cbn. repeat setoid_rewrite bind_ret_l.
+      red. intros. unfold interp_imp_inline, interp_asm. rewrite bind_bind. rewrite bind_trigger.
+      rewrite interp_state_vis. cbn. setoid_rewrite bind_bind. unfold raise_asm. cbn.
+      Transparent denote_asm. cbn. repeat setoid_rewrite bind_ret_l.
+      setoid_rewrite unfold_iter_ktree at 3. cbn. repeat setoid_rewrite bind_bind.
+      rewrite bind_trigger. rewrite interp_state_bind. rewrite interp_state_trigger.
+      cbn. rewrite bind_bind. rewrite bind_trigger. apply eqit_Vis. intros [].
+    - assert (l = fS (fS f0)). { red in Hl. apply unique_fin. auto. } subst.
+      cbn. repeat setoid_rewrite bind_ret_l.
+      red. intros. unfold interp_imp_inline, interp_asm. rewrite bind_bind. rewrite bind_trigger.
+      rewrite interp_state_vis. cbn. setoid_rewrite bind_bind. unfold raise_asm. cbn.
+      Transparent denote_asm. cbn. repeat setoid_rewrite bind_ret_l.
+      setoid_rewrite unfold_iter_ktree at 3. cbn. repeat setoid_rewrite bind_bind.
+      rewrite bind_trigger. rewrite interp_state_bind. rewrite interp_state_trigger.
+      cbn. rewrite bind_bind. rewrite bind_trigger. apply eqit_Vis. intros [].
+  Qed.
+
+End Correctness.
+
+(*
+c:=
+START
+BJMP [0] l1 l2
+
+l1
+STORE X <- 0
+JMP EXIT
+
+l2
+STORE X <- 1
+JMP EXIT
+
+
+
+if X = 0 then skip else skip; Nuke regs; Inline c
+
+
+*)
+
+
+(* ================================================================= *)
+(** ** Closing word. *)
+
+(** Through this medium-sized example, we have seen how to use [itree]s to
+    denote two languages, how to run them and how to prove correct a compiler
+    between them.
+    We have emphasized that the theory of [ktree]s allowed us to decouple
+    all reasoning about the control-flow from the proof of the compiler itself.
+    The resulting proof is entirely structurally inductive and equational. In
+    particular, we obtain a final theorem relating potentially infinite
+    computations without having to write any cofixed-point.
+
+    If this result is encouraging, one might always wonder how things scale.
+
+    A first good sanity check is to extend the languages with a _Print_
+    instruction.
+    It requires to add a new event to the language and therefore makes the
+    correctness theorem relate trees actually still containing events.
+    This change, which a good exercise to try, turns out to be as
+    straightforward as one would hope. The only new lemma needed is to show
+    that [interp_locals] leaves the new [Print] event untouched.
+    This extension can be found in the _tutorial-print_ branch.
+
+    More importantly, our compiler is fairly stupid and inefficient: it creates
+    blocks for each compiled statement! One would hope to easily write and
+    prove an optimization coalescing elementary blocks together.
+
+    A first example of optimization at the [asm] level proved correct is
+    demonstrated in the _AsmOptimization.v_ file.
+ *)

--- a/secure_example/LabelledImpInline2AsmNoninterferencePres.v
+++ b/secure_example/LabelledImpInline2AsmNoninterferencePres.v
@@ -1,0 +1,180 @@
+From Coq Require Import Morphisms Program.Basics.
+
+From ITree Require Import
+     ITree
+     ITreeFacts
+     Basics.CategorySub
+     Basics.HeterogeneousRelations
+     Events.StateFacts
+     Events.MapDefault
+     Secure.SecureEqHalt
+     Secure.SecureEqEuttTrans
+     Secure.SecureEqProgInsens
+     Secure.SecureEqProgInsensFacts
+.
+
+From SecureExample Require Import
+     Utils_tutorial
+     Fin
+     KTreeFin
+     LabelledImpInline
+     LabelledAsm
+     LabelledImpInline2Asm
+     LabelledImpInline2AsmCorrectness
+     LabelledImpHandler
+     LabelledImpTypes
+     LabelledImpTypesProgInsens
+     Lattice
+.
+
+Import ITreeNotations.
+
+Import Monads.
+Open Scope monad_scope.
+
+
+Section SecurityPreservation.
+
+Context (Γ : var -> sensitivity).
+Context (l : sensitivity).
+
+Instance labell_equiv_equiv {Γ' l'} : Equivalence (labelled_equiv sensitivity_lat Γ' l').
+Proof.
+  constructor; red; intros; red; red; intros; auto.
+  - rewrite H; auto.
+  - rewrite H; auto.
+Qed.
+
+Definition labelled_sim : map -> (registers * memory) -> Prop :=
+  fun g_imp g_asm => labelled_equiv sensitivity_lat Γ l g_imp (snd g_asm).
+
+Definition asm_eq : registers * memory -> registers * memory -> Prop :=
+  fun '(regs1, mem1) '(regs2, mem2) => labelled_equiv sensitivity_lat Γ l mem1 mem2.
+
+Section ProgressSensitive.
+
+Definition labelled_bisimilar {A B : Type} (RAB : A -> B -> Prop)
+           (t1 : itree ((impExcE _) +' Reg +' Memory +' (IOE _)) A ) (t2 : itree ((impExcE _) +'
+ Reg +' Memory +' (IOE _)) B) :=
+  forall (g_imp : map) (g_asm : memory) (regs1 regs2 : registers),
+    labelled_equiv _ Γ l g_imp g_asm ->
+    (*  maybe I can refactor the double product_rel to something nicer, labelled_equiv instead of Renv? *)
+    eqit_secure _ (priv_exc_io sensitivity_lat) (product_rel (product_rel top2 Renv) RAB) true true l
+                (interp_asm t1 (regs1, g_imp )) (interp_asm t2 (regs2, g_asm)).
+
+Lemma compile_preserves_ps_security : forall (c : stmt),
+    valid_stmt c ->
+    labelled_bisimilar TT (denote_stmt c) (denote_stmt c) ->
+    labelled_bisimilar TT (denote_stmt c) (denote_asm (compile c) f0 ) .
+Proof.
+  intros s Hs Hsecs. red in Hsecs. red. intros g_imp g_asm regs1 regs2 Hs'.
+  assert (labelled_equiv _ Γ l g_imp g_imp). reflexivity.
+  specialize (compile_correct s Hs) as Heutt. do 2 red in Heutt.
+  assert (Renv g_asm g_asm). reflexivity.
+  specialize (Hsecs g_imp g_asm regs1 regs2 Hs') as Hsecs'.
+  specialize (Heutt g_asm g_asm regs1 regs2 H0) as Heutt.
+  specialize (eutt_secure_eqit_secure) as Htrans.
+  eapply Htrans in Heutt; eauto.
+  eapply SecureEqEuttHalt.eqit_secure_RR_imp; try apply Heutt.
+  intros. inv PR. inv REL1. destruct x0. destruct r2. clear Hsecs' Htrans Heutt. cbn in *.
+  destruct x1. constructor; auto. constructor; auto. cbn. destruct REL2. cbn in *.
+  destruct H1. cbn in *. etransitivity; eauto.
+Qed.
+
+Lemma compile_preserves_ps_ni : forall (c : stmt),
+    valid_stmt c ->
+    labelled_bisimilar TT (denote_stmt c) (denote_stmt c) ->
+    labelled_bisimilar TT (denote_asm (compile c) f0) (denote_asm (compile c) f0 ) .
+Proof.
+  intros s Hs Hsecs. red. intros g_imp g_asm regs1 regs2 Hs'.
+  specialize (compile_correct s Hs) as Heutt. do 2 red in Heutt.
+  specialize (compile_preserves_ps_security s Hs Hsecs) as Hcomp. unfold interp_imp_inline in *.
+  red in Hsecs. specialize (Hsecs g_imp g_asm regs1 regs2 Hs') as Hsecs'.
+  red in Hcomp.
+  assert (Renv g_asm g_asm). reflexivity.
+  assert (Renv g_imp g_imp). reflexivity.
+  specialize (SecureEqEuttHalt.eqit_secure_trans) as Htrans.
+  assert (Hsec'' : eqit_secure (PreOrderOfLattice sensitivity_lat) (priv_exc_io sensitivity_lat)
+             (product_rel (product_rel top2 Renv) TT) true true l
+             (interp_asm (denote_stmt s) (regs1, g_imp))
+             (interp_asm (denote_asm (compile s) f0 ) (regs2, g_asm) )
+         ).
+  {
+    eapply SecureEqEuttHalt.eqit_secure_RR_imp with (RR1 := rcompose _ _ ).
+    2 : eapply Htrans; eauto. 2 : eapply Hcomp. 2 : reflexivity.
+    intros. inv PR. inv REL1. inv REL2. inv H1. inv H3. constructor; auto.
+    constructor; auto. etransitivity; eauto.
+  }
+  eapply Htrans in Hsec''; eauto.
+  2 : {
+    apply eqit_secure_sym. eapply Hcomp. reflexivity.
+  }
+  Unshelve. 2 : apply regs1.
+  eapply SecureEqEuttHalt.eqit_secure_RR_imp; try apply Hsec''.
+  intros. inv PR. inv REL1. inv REL2. inv H1. inv H3. constructor; auto.
+  constructor; auto. etransitivity; eauto. etransitivity; eauto. symmetry. eauto.
+  reflexivity.
+Qed.
+
+
+End ProgressSensitive.
+
+Section ProgressInsensitive.
+
+Definition labelled_pi_bisimilar {A B : Type} (RAB : A -> B -> Prop)
+           (t1 : itree ((impExcE _) +' Reg +' Memory +' (IOE _)) A ) (t2 : itree ((impExcE _) +'
+ Reg +' Memory +' (IOE _)) B) :=
+  forall (g_imp : map) (g_asm : memory) (regs1 regs2 : registers),
+    labelled_equiv _ Γ l g_imp g_asm ->
+    (*  maybe I can refactor the double product_rel to something nicer *)
+    pi_eqit_secure _ (priv_exc_io sensitivity_lat) (product_rel (product_rel top2 Renv) RAB) true true l
+                (interp_asm t1 (regs1, g_imp )) (interp_asm t2 (regs2, g_asm)).
+
+Lemma compile_preserves_pi_security : forall (c : stmt),
+    valid_stmt c ->
+    labelled_pi_bisimilar TT (denote_stmt c) (denote_stmt c) ->
+    labelled_pi_bisimilar TT (denote_stmt c) (denote_asm (compile c) f0 ) .
+Proof.
+  intros s Hs Hsecs. red in Hsecs. red. intros g_imp g_asm regs1 regs2 Hs'.
+  assert (labelled_equiv _ Γ l g_imp g_imp). reflexivity.
+  specialize (compile_correct s Hs) as Heutt. do 2 red in Heutt.
+  assert (Renv g_asm g_asm). reflexivity.
+  specialize (Hsecs g_imp g_asm regs1 regs2 Hs') as Hsecs'.
+  specialize (Heutt g_asm g_asm regs1 regs2 H0) as Heutt.
+  specialize (pi_eqit_secure_mixed_trans) as Htrans.
+  eapply Htrans in Heutt; eauto.
+  eapply pi_eqit_secure_RR_imp; try apply Heutt.
+  intros. inv H1. inv REL1. inv H1. constructor; auto. constructor; auto.
+  inv REL2. etransitivity; eauto.
+Qed.
+
+
+Lemma compile_preserves_pi_ni : forall (c : stmt),
+    valid_stmt c ->
+    labelled_pi_bisimilar TT (denote_stmt c) (denote_stmt c) ->
+    labelled_pi_bisimilar TT (denote_asm (compile c) f0) (denote_asm (compile c) f0 ) .
+Proof.
+  intros c Hc Hsecc. red. intros g_imp g_asm regs1 regs2. intros Hasmeq.
+  assert (labelled_equiv _ Γ l g_imp g_imp). reflexivity.
+  assert (labelled_equiv _ Γ l g_asm g_asm). reflexivity.
+  specialize (compile_correct c Hc) as Heutt. do 2 red in Heutt.
+  assert (Renv g_imp g_imp). reflexivity.
+  assert (Renv g_asm g_asm). reflexivity.
+  assert (Hmem12 : labelled_equiv _ Γ l g_imp g_asm). auto.
+  apply compile_preserves_pi_security in Hc as Hsecc'; auto.
+  do 2 red in Hsecc'.
+  specialize (Hsecc' g_imp g_asm regs1 regs2 Hasmeq). apply pi_eqit_secure_sym in Hsecc'.
+  specialize (Heutt g_imp g_imp regs1 regs1 H1) as Heutt1.
+  specialize (pi_eqit_secure_mixed_trans) as Htrans.
+  eapply Htrans in Heutt1; eauto. apply pi_eqit_secure_sym.
+  eapply pi_eqit_secure_RR_imp; eauto. unfold flip.
+  intros. inv H3. inv REL1. inv REL2. inv H3. constructor; auto.
+  constructor; auto. etransitivity; eauto. etransitivity; eauto. symmetry. eauto.
+  reflexivity.
+Qed.
+
+
+End ProgressInsensitive.
+
+
+End SecurityPreservation.

--- a/secure_example/LabelledImpInlineTypes.v
+++ b/secure_example/LabelledImpInlineTypes.v
@@ -1,0 +1,1165 @@
+From Coq Require Import Morphisms String.
+
+From ITree Require Import
+     ITree
+     ITreeFacts
+     HeterogeneousRelations
+     Events.MapDefault
+     Events.State
+     Events.StateFacts
+     Events.Exception
+     Events.ExceptionFacts
+     Secure.SecureEqHalt
+     Secure.SecureEqEuttHalt
+     Secure.SecureEqWcompat
+     Secure.SecureEqBind
+     Secure.StrongBisimProper
+.
+
+From SecureExample Require Import
+     Utils_tutorial
+     LabelledImpInline
+     LabelledImpHandler
+     Lattice
+     LabelledAsm
+     LabelledImpInline2AsmNoninterferencePres
+     LabelledImpInline2AsmCorrectness
+.
+
+Import Monads.
+Import MonadNotation.
+Local Open Scope monad_scope.
+Local Open Scope string_scope.
+
+Section LabelledImpTypes.
+
+Ltac case_leq l1 l2 := destruct (leq_dec sensitivity_lat l1 l2) as [Hleq | Hnleq].
+
+Notation privacy_map := LabelledImp.privacy_map.
+
+Definition labelled_equiv (Γ : privacy_map sensitivity_lat) (l : sensitivity) (σ1 σ2 : map)  : Prop :=
+  forall x, leq (Γ x) l -> σ1 x = σ2 x.
+
+Definition top2 {A B} : A -> B -> Prop := fun _ _ => True.
+
+Instance labelled_equit_equiv {Γ l} : Equivalence (labelled_equiv Γ l).
+Proof.
+  constructor; unfold labelled_equiv.
+  - red. intros; auto.
+  - red. intros. symmetry; auto.
+  - red. intros. rewrite H; auto.
+Qed.
+
+Notation impExcE := LabelledImp.impExcE.
+Notation IOE := LabelledImp.IOE.
+Definition label_eqit_secure_impstate  (b1 b2 : bool) (Γ : privacy_map sensitivity_lat) (l : sensitivity) {R1 R2 : Type} (RR : R1 -> R2 -> Prop )
+           (m1 : stateT (registers * map) (itree ((impExcE sensitivity_lat) +' (IOE sensitivity_lat))) R1)
+           (m2 : stateT (registers * map ) (itree ((impExcE sensitivity_lat) +' (IOE sensitivity_lat))) R2) : Prop :=
+  forall σ1 σ2 regs1 regs2, labelled_equiv Γ l σ1 σ2 -> eqit_secure _ (priv_exc_io sensitivity_lat) (product_rel (product_rel top2 (labelled_equiv Γ l)) RR) b1 b2 l (m1 (regs1,σ1)) (m2 (regs2, σ2)).
+
+Definition label_state_sec_eutt {R1 R2} priv l (RR : R1 -> R2 -> Prop) m1 m2 :=
+  label_eqit_secure_impstate true true  priv l RR m1 m2.
+
+Definition sem_stmt (s : stmt) := interp_imp_inline (denote_stmt s).
+
+Definition sem_throw_stmt (s : stmt) := interp_imp_inline (throw_prefix (denote_stmt s) ).
+
+Definition sem_expr (e : expr) := @interp_imp_inline (impExcE sensitivity_lat) (IOE sensitivity_lat) value (denote_expr e).
+
+Definition state_equiv {E R} (m1 m2 : stateT map (itree E) R) := forall (σ : map), m1 σ ≈ m2 σ.
+
+Global Instance proper_eutt_secure_eutt  {E R1 R2 RR Label priv l} : Proper (@eutt E R1 R1 eq ==> @eutt E R2 R2 eq ==> iff)
+                                                               (eqit_secure Label priv RR true true l).
+Proof.
+  eapply proper_eqit_secure_eqit.
+Qed.
+
+Global Instance proper_eq_itree_secure_eutt  {E R1 R2 RR Label priv l} : Proper (@eq_itree E R1 R1 eq ==> @eq_itree E R2 R2 eq ==> iff)
+                                                               (eqit_secure Label priv RR true true l).
+Proof.
+  repeat intro. assert (x ≈ y). rewrite H. reflexivity.
+  assert (x0 ≈ y0). rewrite H0. reflexivity. rewrite H1. rewrite H2. tauto.
+Qed.
+
+
+(* not sure what is going on with this instance
+Global Instance proper_state_equiv_label_state_sec_eutt {R1 R2 RR priv l} : Proper (@state_equiv _ R1 ==> @state_equiv _ R2 ==> iff) (@label_state_sec_eutt R1 R2 priv l RR).
+Proof.
+  repeat intro. split.
+  - intros. do 2 red in H1. do 2 red. intros. red in H0. specialize (H0 σ2). red in H.
+    specialize (H σ1). eapply proper_eutt_secure_eutt; eauto. symmetry. auto. symmetry. auto.
+  - intros. intros. do 2 red in H1. do 2 red. intros. red in H0. specialize (H0 σ2). red in H.
+    specialize (H σ1).  eapply proper_eutt_secure_eutt; eauto.
+Qed.
+*)
+Context (Γ : privacy_map sensitivity_lat).
+
+Variant secure_stmt_at_label (observer pc : sensitivity) (s : stmt) : Prop :=
+  | ssal_leq : (leq pc observer) -> label_state_sec_eutt Γ observer eq (sem_stmt s) (sem_stmt s) -> secure_stmt_at_label observer pc s
+  | ssal_nleq : (~ leq pc observer) -> label_state_sec_eutt Γ observer top2 (sem_stmt s) (ret tt) -> secure_stmt_at_label observer pc s.
+
+
+Variant secure_expr_at_label (observer protection: sensitivity ) (e : expr) : Prop :=
+  | seal_leq : (leq protection observer) -> label_state_sec_eutt Γ observer eq (sem_expr e) (sem_expr e) ->
+               secure_expr_at_label observer protection e
+  | seal_nleq : (~leq protection observer) -> (exists n:value, label_state_sec_eutt Γ observer top2 (sem_expr e) (ret n)) ->
+                secure_expr_at_label observer protection e
+.
+
+Definition secure_expr l e := forall observer, secure_expr_at_label observer l e.
+
+Definition secure_stmt pc s := forall observer, secure_stmt_at_label observer pc s.
+
+Variant is_inl {A B : Type} : A + B -> Prop :=
+  | is_inl_ev (a : A) : is_inl (inl a).
+
+Variant secure_throw_stmt_at_label (observer pc : sensitivity) (s : stmt) : Prop :=
+  | stsal_leq : leq pc observer -> label_state_sec_eutt Γ observer (sum_rel eq (fun l1 l2 => eqlat l1 bot /\ eqlat l2 bot) )
+                                                       (sem_throw_stmt s) (sem_throw_stmt s) -> secure_throw_stmt_at_label observer pc s
+  | stsal_nleq : (~ leq pc observer) -> label_state_sec_eutt Γ observer (fun sum _ => is_inl sum )
+                                                            (sem_throw_stmt s) (ret tt ) ->  secure_throw_stmt_at_label observer pc s.
+
+Definition secure_throw_stmt pc s := forall observer, secure_throw_stmt_at_label observer pc s.
+
+Lemma expr_only_ret_aux1 e observer: forall (n : nat), label_state_sec_eutt Γ observer top2 (sem_expr e) (ret n) .
+Proof.
+  do 2 red. induction e; intros; unfold sem_expr; cbn; unfold interp_imp.
+  - eapply proper_eutt_secure_eutt; try apply interp_state_trigger; try reflexivity. cbn.
+    apply secure_eqit_ret. split; cbv; auto.
+  - rewrite interp_state_ret. apply secure_eqit_ret. split; cbv; auto.
+  - repeat setoid_rewrite interp_state_bind.
+    match goal with |- eqit_secure _ _ _ _ _ _ _ ?t =>
+    assert ( t ≈ ITree.bind (Ret (regs2, σ2, n)) (fun st => ITree.bind (Ret (fst st, n) ) (fun st => Ret (fst st,n))  )  ) end.
+    repeat rewrite bind_ret_l. reflexivity.
+    eapply proper_eutt_secure_eutt; try apply H0; try reflexivity.
+    eapply secure_eqit_bind; try apply IHe1; eauto. intros [? ?] [? ?] [? ?]. inv H1. cbn in *. destruct p; destruct p0. cbn in *.
+    eapply secure_eqit_bind; try apply IHe2; eauto. intros. cbn in *.
+    setoid_rewrite interp_state_ret. apply secure_eqit_ret; split; auto.
+    split; auto. cbn. inv H1. inv H5. etransitivity; eauto. reflexivity.
+  - repeat setoid_rewrite interp_state_bind.
+    match goal with |- eqit_secure _ _ _ _ _ _ _ ?t =>
+    assert ( t ≈ ITree.bind (Ret (regs2, σ2, n)) (fun st => ITree.bind (Ret (fst st, n) ) (fun st => Ret (fst st,n))  )  ) end.
+    repeat rewrite bind_ret_l. reflexivity.
+    eapply proper_eutt_secure_eutt; try apply H0; try reflexivity.
+    eapply secure_eqit_bind; try apply IHe1; eauto. intros [? ?] [? ?] [? ?]. inv H1. cbn in *. destruct p; destruct p0. cbn in *.
+    eapply secure_eqit_bind; try apply IHe2; eauto. intros. cbn in *.
+    setoid_rewrite interp_state_ret. apply secure_eqit_ret; split; auto.
+    split; auto. cbn. inv H1. inv H5. etransitivity; eauto. reflexivity.
+  - repeat setoid_rewrite interp_state_bind.
+    match goal with |- eqit_secure _ _ _ _ _ _ _ ?t =>
+    assert ( t ≈ ITree.bind (Ret (regs2, σ2, n)) (fun st => ITree.bind (Ret (fst st, n) ) (fun st => Ret (fst st,n))  )  ) end.
+    repeat rewrite bind_ret_l. reflexivity.
+    eapply proper_eutt_secure_eutt; try apply H0; try reflexivity.
+    eapply secure_eqit_bind; try apply IHe1; eauto. intros [? ?] [? ?] [? ?]. inv H1. cbn in *. destruct p; destruct p0. cbn in *.
+    eapply secure_eqit_bind; try apply IHe2; eauto. intros. cbn in *.
+    setoid_rewrite interp_state_ret. apply secure_eqit_ret; split; auto.
+    split; auto. cbn. inv H1. inv H5. etransitivity; eauto. reflexivity.
+Qed.
+
+Lemma expr_only_ret e observer:  exists n : value, label_state_sec_eutt Γ observer top2 (sem_expr e) (ret n) .
+Proof.
+  exists 0. apply expr_only_ret_aux1.
+Qed.
+
+Hint Resolve sensitivity_latlaws : core.
+
+Lemma secure_expr_upward_close e l1 l2 : leq l1 l2 ->
+                                         secure_expr l1 e -> secure_expr l2 e.
+Proof.
+  intros Hl He observer. specialize (He observer).
+  inv He.
+  - case_leq l2 observer.
+    + left; auto.
+    + right; auto. apply expr_only_ret.
+  - case_leq l2 observer.
+    + exfalso. eapply H. eapply leq_trans_lat; eauto.
+    + right; auto.
+Qed.
+
+Lemma state_secure_eutt_equiv_ret_aux:
+  forall R RR t1 t2 (observer : sensitivity) (r1 r2 : R),
+    Equivalence RR ->
+    RR r1 r2 ->
+    (forall (σ1 σ2 : map) (regs1 regs2 : registers),
+        labelled_equiv Γ observer σ1 σ2 ->
+        eqit_secure _ (priv_exc_io sensitivity_lat) (product_rel (product_rel top2 (labelled_equiv Γ observer)) RR) true
+                    true observer (interp_imp_inline t1 (regs1,σ1)) (Ret(regs2, σ2,r1))) ->
+    (forall (σ1 σ2 : map) (regs1 regs2 : registers),
+        labelled_equiv Γ observer σ1 σ2 ->
+        eqit_secure _ (priv_exc_io sensitivity_lat) (product_rel (product_rel top2 (labelled_equiv Γ observer)) RR) true
+                    true observer (interp_imp_inline t2 (regs1,σ1)) (Ret(regs2, σ2,r2))) ->
+    forall (σ1 σ2 : map) (regs1 regs2 : registers),
+      labelled_equiv Γ observer σ1 σ2 ->
+      eqit_secure _ (priv_exc_io sensitivity_lat) (product_rel (product_rel top2 (labelled_equiv Γ observer)) RR) true
+                  true observer (interp_imp_inline t1 (regs1, σ1))
+                  (interp_imp_inline t2 (regs2, σ2)).
+Proof.
+  intros R RR t1 t2 observer r1 r2 HRR Hr12 Hr1 Hr2 s1 s2 reg1 regs2 Hs12.
+  set ((product_rel (product_rel top2 (labelled_equiv Γ observer)) RR)) as Rst.
+  apply eqit_secure_RR_imp with (RR1 := rcompose Rst Rst).
+  { intros [ [? ?] ?] [ [? ? ] ?] [? ?]. destruct r5. cbn in *. unfold Rst in *.
+    inv REL1. inv REL2.
+    split. split; [cbv; auto | cbn in *].
+    - inv H. inv H1. cbn in *. etransitivity; eauto.
+    - inv H1. inv H. cbn in *. etransitivity; eauto.
+  }
+  eapply eqit_secure_trans; eauto. eapply eqit_secure_sym.
+  apply eqit_secure_RR_imp with (RR1 := Rst).
+  { intros. split.
+    split; [cbv; auto | unfold Rst in *].
+    inv PR. inv H. symmetry. auto. inv PR. symmetry. auto.
+  }
+  assert (eqit_secure _ (priv_exc_io _) Rst true true observer (Ret (regs2, s2, r2) ) (Ret (regs2, s2,r1))).
+  { apply secure_eqit_ret. unfold Rst in *. split; auto; cbv; auto. symmetry. auto. }
+  apply eqit_secure_RR_imp with (RR1 := rcompose Rst Rst).
+  {
+    intros [ [? ?] ?] [ [? ? ] ?] [? ?]. destruct r5. cbn in *. unfold Rst in *.
+    inv REL1. inv REL2.
+    split. split; [cbv; auto | cbn in *].
+    - inv H0. inv H2. cbn in *. etransitivity; eauto.
+    - inv H0. inv H2. cbn in *. etransitivity; eauto.
+  }
+  eapply eqit_secure_trans; try apply Hr2; eauto. reflexivity.
+Qed.
+
+Lemma state_secure_eutt_throw_ret_aux:
+  forall t1 t2  (observer : sensitivity),
+    label_state_sec_eutt Γ observer
+                         (fun (sum : unit + sensitivity) (_ : unit) =>
+                            is_inl sum) (interp_imp_inline (throw_prefix t1))
+                         (ret tt) ->
+    label_state_sec_eutt Γ observer
+                         (fun (sum : unit + sensitivity) (_ : unit) =>
+                            is_inl sum) (interp_imp_inline (throw_prefix t2))
+                         (ret tt) ->
+    forall (σ3 σ4 : map) (regs1 regs2 : registers),
+      labelled_equiv Γ observer σ3 σ4 ->
+      eqit_secure _ (priv_exc_io sensitivity_lat)
+                  (product_rel (product_rel top2 (labelled_equiv Γ observer))
+                               (sum_rel eq
+                                        (fun l1 l2 : sensitivity =>
+                                           eqlat l1 bot /\ eqlat l2 bot))) true
+                  true observer
+                  (interp_imp_inline
+                                (throw_prefix t1) (regs1, σ3))
+                  (interp_imp_inline
+                                (throw_prefix t2) (regs2, σ4)).
+Proof.
+  intros t1 t2 observer Ht1 Ht2 σ3 σ4 regs1 regs2 Hσ.
+  do 2 red in Ht1, Ht2. cbn in *. set (product_rel
+             (@product_rel registers _ registers _ top2 (labelled_equiv Γ observer))
+             (fun (sum : unit + sensitivity)
+                (_ : unit) => is_inl sum)) as Rst.
+  set (product_rel (@product_rel registers _ registers _ top2 (labelled_equiv Γ observer)) (fun (sum1 sum2 : unit + sensitivity) => is_inl sum1 /\ is_inl sum2)  ) as Rst'.
+  eapply eqit_secure_RR_imp with (RR1 := Rst').
+  { unfold Rst'.
+    intros [ [? ?] [ [] | ?] ] [ [? ?] [ [] | ?] ] [ [? ?] [? ?] ]; cbn in *; inv H1; inv H2.
+    split. split; auto. cbn. constructor. auto.
+  }
+  eapply eqit_secure_RR_imp with (RR1 := rcompose Rst (rcompose eq (fun x1 x2 => Rst x2 x1)) ).
+  { unfold Rst.
+    intros [ [? ?] [ [] | ?] ] [ [? ?] [ [] | ?] ]; intro Hrcomp; unfold Rst'.
+    - split. split; auto. cbv. auto. cbn. inv Hrcomp. inv REL1. inv H. inv REL2. inv REL0. etransitivity; eauto.
+      cbn in *. inv H. symmetry. auto. split; constructor.
+    - inv Hrcomp. inv REL2. inv REL3. inv H0.
+    - inv Hrcomp. inv REL2. inv REL3. inv REL1. inv H1. inv H2.
+    - inv Hrcomp. inv REL2. inv REL3. inv REL1. inv H1. inv H2.
+  }
+  eapply eqit_secure_trans; try eapply Ht1; eauto. eapply eqit_secure_trans with (t2 := (Ret (regs2, σ4, tt) ) ).
+  apply secure_eqit_ret. reflexivity. auto. apply eqit_secure_sym. eapply Ht2. reflexivity.
+Qed.
+
+
+Lemma state_secure_eutt_ret_aux:
+  forall R t1 t2 (observer : sensitivity) (r1 r2 : R),
+    (forall (σ1 σ2 : map) (regs1 regs2 : registers),
+        labelled_equiv Γ observer σ1 σ2 ->
+        eqit_secure _ (priv_exc_io sensitivity_lat) (product_rel (product_rel top2 (labelled_equiv Γ observer)) (@top2 R R)) true
+                    true observer (interp_imp_inline t1 (regs1, σ1)) (Ret(regs2, σ2,r1))) ->
+    (forall (σ1 σ2 : map) (regs1 regs2 : registers),
+        labelled_equiv Γ observer σ1 σ2 ->
+        eqit_secure _ (priv_exc_io sensitivity_lat) (product_rel (product_rel top2 (labelled_equiv Γ observer)) (@top2 R R)) true
+                    true observer (interp_imp_inline t2 (regs1, σ1)) (Ret(regs2, σ2,r2))) ->
+    (forall (σ1 σ2 : map) (regs1 regs2 : registers),
+      labelled_equiv Γ observer σ1 σ2 ->
+      eqit_secure _ (priv_exc_io sensitivity_lat) (product_rel (product_rel top2 (labelled_equiv Γ observer)) top2) true
+                  true observer (interp_imp_inline t1 (regs1, σ1))
+                  (interp_imp_inline t2 (regs2, σ2))).
+Proof.
+  intros. eapply state_secure_eutt_equiv_ret_aux; eauto. 2 : cbv; auto.
+  constructor; constructor.
+Qed.
+Notation update := LabelledImp.update.
+Lemma update_labelled_equiv_invisible:
+  forall (x : var) (observer : sensitivity) Γ,
+    ~ leq (Γ x) observer ->
+    forall (σ1 : map) (v : value) (σ2 : map),
+      labelled_equiv Γ observer σ1 σ2 -> labelled_equiv Γ observer (update x v σ1) (σ2).
+Proof.
+  intros x observer Γ' H σ1 v σ2 H2.
+  red. red in H2. intros.
+  unfold update. destruct (x =? x0) eqn : Heq; auto.
+  exfalso. apply H. apply eqb_eq in Heq. subst; auto.
+Qed.
+
+Lemma update_labelled_equiv_visible:
+  forall (x : var) (observer : sensitivity) Γ,
+    leq (Γ x) observer ->
+    forall (σ1 : map) (v : value) (σ2 : map),
+      labelled_equiv Γ observer σ1 σ2 -> labelled_equiv Γ observer (update x v σ1) (update x v σ2).
+Proof.
+  intros x observer Γ' H σ1 v σ2 H2.
+  red. red in H2. intros. unfold update.
+  destruct (x =? x0) eqn : Heq; auto.
+Qed.
+
+Lemma assign_well_typed_correct x e pc l : secure_expr l e -> leq (join l pc) (Γ x) -> secure_stmt pc (Assign x e).
+Proof.
+  intros Hle Hx.
+  assert (Hpc : leq pc (Γ x) ).
+  { eapply leq_trans_lat; eauto. apply leq_join_r; auto. }
+  assert (Hl : leq l (Γ x) ).
+  { eapply leq_trans_lat; try apply Hx; auto. apply leq_join_l; eauto. }
+  assert (He : secure_expr (Γ x) e ).
+  { eapply secure_expr_upward_close with (l2:= Γ x); eauto. }
+  intros observer.
+  specialize ( He observer). inv He.
+  - left. eapply leq_trans_lat; eauto.
+    do 2 red in H0. do 2 red. intros. unfold sem_stmt.
+    cbn. unfold interp_imp. setoid_rewrite interp_state_bind.
+    eapply secure_eqit_bind; eauto. intros [? ?] [? ?] [? ?].
+    cbn in H2, H3. subst. eapply proper_eutt_secure_eutt; try apply interp_state_trigger.
+    cbn. inv H2. destruct p; destruct p0. apply secure_eqit_ret; split; auto. cbn.
+    split; auto. cbn in *; subst. apply update_labelled_equiv_visible; auto.
+  - case_leq pc observer.
+    + left; auto.
+      destruct H0 as [n Hn]. unfold sem_stmt.
+      cbn. unfold interp_imp_inline, interp_asm. do 2 red. intros. setoid_rewrite interp_state_bind.
+      do 2 red in Hn.
+      eapply secure_eqit_bind with (RR := product_rel (product_rel top2 (labelled_equiv Γ observer)) top2 ); eauto.
+      2 : { eapply state_secure_eutt_ret_aux; try apply Hn; auto. }
+      intros [ [? ?] ?] [ [? ?] ?] [ [? ?] ?]. cbn in *. cbn.
+      eapply proper_eutt_secure_eutt; try apply interp_state_trigger.
+      cbn. apply secure_eqit_ret. split. 2 : cbv; auto. split; cbn; auto.
+      apply update_labelled_equiv_invisible; auto. symmetry.
+      apply update_labelled_equiv_invisible;  auto.
+      symmetry; auto.
+    + right; auto.
+      destruct H0 as [n Hn]. unfold sem_stmt. cbn.
+      do 2 red in Hn. do 2 red. intros. unfold sem_stmt. cbn.
+      setoid_rewrite interp_state_bind.
+      match goal with |- eqit_secure _ _ _ _ _ _ _ ?t =>
+                      assert (t ≈ (ITree.bind (Ret (regs2, σ2, n)) (fun st => Ret (fst st, tt) ))) end.
+      rewrite bind_ret_l. reflexivity.
+      eapply proper_eutt_secure_eutt; try apply H1; try reflexivity.
+      eapply secure_eqit_bind; try apply Hn; eauto.
+      intros [ [? ?] ?] [ [? ?] ?] [ [? ?] ?]. cbn in *.
+      eapply proper_eutt_secure_eutt; try apply interp_state_trigger; try reflexivity.
+      cbn.
+      apply secure_eqit_ret; split; auto.
+      cbn. split; auto. apply update_labelled_equiv_invisible; auto.
+Qed.
+
+Lemma throw_prefix_denote_expr e : @throw_prefix sensitivity value (Reg +' Memory +' IOE sensitivity_lat) (denote_expr e) ≈ (ITree.bind (denote_expr e) (fun v => Ret (inl v))).
+Proof.
+  induction e; cbn.
+  - setoid_rewrite bind_trigger. setoid_rewrite throw_prefix_ev.
+    apply eqit_Vis. setoid_rewrite throw_prefix_ret. intros. rewrite tau_eutt. reflexivity.
+  - rewrite throw_prefix_ret, bind_ret_l. reflexivity.
+  - setoid_rewrite throw_prefix_bind. setoid_rewrite IHe1. repeat rewrite bind_bind.
+    eapply eqit_bind'; try reflexivity. intros; subst. rewrite bind_ret_l. rewrite throw_prefix_bind.
+    rewrite IHe2. repeat rewrite bind_bind. eapply eqit_bind'; try reflexivity. intros; subst. repeat rewrite bind_ret_l.
+    rewrite throw_prefix_ret. reflexivity.
+  - setoid_rewrite throw_prefix_bind. setoid_rewrite IHe1. repeat rewrite bind_bind.
+    eapply eqit_bind'; try reflexivity. intros; subst. rewrite bind_ret_l. rewrite throw_prefix_bind.
+    rewrite IHe2. repeat rewrite bind_bind. eapply eqit_bind'; try reflexivity. intros; subst. repeat rewrite bind_ret_l.
+    rewrite throw_prefix_ret. reflexivity.
+  - setoid_rewrite throw_prefix_bind. setoid_rewrite IHe1. repeat rewrite bind_bind.
+    eapply eqit_bind'; try reflexivity. intros; subst. rewrite bind_ret_l. rewrite throw_prefix_bind.
+    rewrite IHe2. repeat rewrite bind_bind. eapply eqit_bind'; try reflexivity. intros; subst. repeat rewrite bind_ret_l.
+    rewrite throw_prefix_ret. reflexivity.
+Qed.
+
+Lemma expr_only_ret' e s : exists n, sem_expr e s ≈ Ret(s, n).
+Proof.
+  unfold sem_expr, interp_imp_inline, interp_asm. cbn. destruct s.
+  induction e.
+  - cbn. setoid_rewrite interp_state_trigger. cbn. repeat setoid_rewrite bind_ret_l.
+    cbn. eexists; reflexivity.
+  - cbn. setoid_rewrite interp_state_ret.
+    eexists; reflexivity.
+  - destruct IHe1 as [n1 IHn1]. destruct IHe2 as [n2 IHn2].
+    cbn. setoid_rewrite interp_state_bind. setoid_rewrite IHn1.
+    setoid_rewrite bind_ret_l. setoid_rewrite interp_state_bind. setoid_rewrite IHn2.
+    setoid_rewrite bind_ret_l. setoid_rewrite interp_state_ret.
+    eexists; reflexivity.
+  - destruct IHe1 as [n1 IHn1]. destruct IHe2 as [n2 IHn2].
+    cbn. setoid_rewrite interp_state_bind. setoid_rewrite IHn1.
+    setoid_rewrite bind_ret_l. setoid_rewrite interp_state_bind. setoid_rewrite IHn2.
+    setoid_rewrite bind_ret_l. setoid_rewrite interp_state_ret.
+    eexists; reflexivity.
+  - destruct IHe1 as [n1 IHn1]. destruct IHe2 as [n2 IHn2].
+    cbn. setoid_rewrite interp_state_bind. setoid_rewrite IHn1.
+    setoid_rewrite bind_ret_l. setoid_rewrite interp_state_bind. setoid_rewrite IHn2.
+    setoid_rewrite bind_ret_l. setoid_rewrite interp_state_ret.
+    eexists; reflexivity.
+Qed.
+
+Lemma assign_well_typed_correct' x e pc l : secure_expr l e -> leq (join l pc) (Γ x) -> secure_throw_stmt pc (Assign x e).
+Proof.
+  intros Hle Hx.
+  assert (Hpc : leq pc (Γ x) ).
+  { eapply leq_trans_lat; eauto. apply leq_join_r; auto. }
+  assert (Hl : leq l (Γ x) ).
+  { eapply leq_trans_lat; try apply Hx; auto. apply leq_join_l; eauto. }
+  assert (He : secure_expr (Γ x) e ).
+  { eapply secure_expr_upward_close with (l2:= Γ x); eauto. }
+  intros observer.
+  specialize ( He observer). inv He.
+  - left. eapply leq_trans_lat; eauto.
+    do 2 red in H0. do 2 red. intros. unfold sem_throw_stmt.
+    cbn. setoid_rewrite throw_prefix_bind. unfold interp_imp_inline, interp_asm. setoid_rewrite interp_state_bind.
+    eapply secure_eqit_bind with (RR := product_rel (product_rel top2 (labelled_equiv Γ observer)) (fun sum1 sum2 => sum1 = sum2 /\ is_inl sum1) ).
+    + intros [[ regs3 σ3] [v1 | l1] ] [ [regs4 σ4] [v2 | l2] ] [ [ _ Hσ] Hr]; inv Hr; try inv H3; try discriminate.
+      cbn. cbn in H2. inv H2. setoid_rewrite throw_prefix_ev. setoid_rewrite interp_state_vis. cbn.
+      repeat rewrite bind_ret_l. setoid_rewrite throw_prefix_ret. setoid_rewrite interp_state_tau. setoid_rewrite interp_state_ret.
+      cbn. eapply proper_eutt_secure_eutt; repeat rewrite tau_eutt; try reflexivity. apply secure_eqit_ret.
+      split; cbn; auto. split. cbv; auto. cbn in *. apply update_labelled_equiv_visible; auto.
+    + eapply proper_eutt_secure_eutt. eapply eutt_interp_state_eq. apply throw_prefix_denote_expr. reflexivity.
+      reflexivity.
+      setoid_rewrite interp_state_bind. setoid_rewrite throw_prefix_denote_expr.
+      setoid_rewrite interp_state_bind.
+      eapply secure_eqit_bind; eauto. intros [ [regs3 σ3] v1] [ [regs4 σ4] v2] [ [ _ Hσ] Hr]. cbn in Hr; subst. setoid_rewrite interp_state_ret. apply secure_eqit_ret. split; auto. split; auto. red. auto. cbn. split; auto. constructor.
+  - case_leq pc observer.
+    + left; auto.
+      destruct H0 as [n Hn]. unfold sem_throw_stmt.
+      cbn. unfold interp_imp_inline, interp_asm. do 2 red. intros. setoid_rewrite throw_prefix_bind. setoid_rewrite interp_state_bind.
+      eapply proper_eutt_secure_eutt; try setoid_rewrite throw_prefix_denote_expr; try reflexivity.
+      setoid_rewrite interp_state_bind. repeat rewrite bind_bind.
+      assert (label_state_sec_eutt Γ observer top2
+         (sem_expr e) (sem_expr e)).
+      { do 2 red. intros. eapply state_secure_eutt_ret_aux; eauto; apply Hn. }
+      eapply secure_eqit_bind; try apply H1; auto. intros [ [regs3 σ3] v1] [ [regs4 σ4] v2] [ [ _ Hσ] Hv].
+      setoid_rewrite interp_state_ret. cbn. setoid_rewrite bind_ret_l. cbn. setoid_rewrite throw_prefix_ev.
+      setoid_rewrite interp_state_vis. cbn. setoid_rewrite bind_ret_l. setoid_rewrite interp_state_tau.
+      eapply proper_eutt_secure_eutt; repeat rewrite tau_eutt; try reflexivity.
+      setoid_rewrite throw_prefix_ret. setoid_rewrite interp_state_ret. cbn. apply secure_eqit_ret.
+      split; cbn; try constructor; auto. cbn.
+      apply update_labelled_equiv_invisible; auto. symmetry.
+      apply update_labelled_equiv_invisible;  auto. symmetry. auto.
+    + right; auto.
+      destruct H0 as [n Hn]. unfold sem_throw_stmt. cbn.
+      assert (label_state_sec_eutt Γ observer top2
+         (sem_expr e) (sem_expr e)).
+      { do 2 red. intros. eapply state_secure_eutt_ret_aux; eauto; apply Hn. }
+      do 2 red. intros. unfold interp_imp_inline, interp_asm.
+      setoid_rewrite throw_prefix_bind. unfold interp_imp. setoid_rewrite interp_state_bind.
+      eapply proper_eutt_secure_eutt; try setoid_rewrite throw_prefix_denote_expr; try reflexivity.
+      specialize (expr_only_ret' e (regs1, σ1)) as [n' Hn'].
+      setoid_rewrite interp_state_bind.
+      eapply proper_eutt_secure_eutt; try setoid_rewrite Hn'; try reflexivity. rewrite bind_bind.
+      rewrite bind_ret_l. setoid_rewrite interp_state_ret. rewrite bind_ret_l. cbn.
+      setoid_rewrite throw_prefix_ev. setoid_rewrite interp_state_vis. cbn. rewrite bind_ret_l.
+      rewrite interp_state_tau. eapply proper_eutt_secure_eutt; repeat rewrite tau_eutt; try reflexivity.
+      setoid_rewrite throw_prefix_ret. setoid_rewrite interp_state_ret. cbn. apply secure_eqit_ret.
+      split; try constructor; auto. cbn. constructor. cbn. apply update_labelled_equiv_invisible; auto.
+Qed.
+
+
+
+Lemma assign_only_ret e x σ regs : exists σ', sem_stmt (Assign x e) (regs, σ) ≈ Ret (regs, σ', tt).
+Proof.
+  unfold sem_stmt, interp_imp_inline, interp_asm. cbn.
+  setoid_rewrite interp_state_bind. specialize (expr_only_ret' e (regs, σ) ) as He.
+  destruct He as [n Hn]. setoid_rewrite Hn. setoid_rewrite bind_ret_l.
+  setoid_rewrite interp_state_trigger. cbn. eexists; reflexivity.
+Qed.
+
+Lemma output_well_typed_correct l1 le pc e :
+  secure_expr le e -> leq (join le pc) l1 ->
+  secure_stmt pc (Output l1 e).
+Proof.
+  intros He0 Hle1.
+  assert (Hle : leq le l1).
+  { eapply leq_trans_lat; eauto. apply leq_join_l; auto. }
+  assert (Hpc : leq pc l1).
+  { eapply leq_trans_lat; try apply Hle1; auto. apply leq_join_r; eauto.  }
+  assert (He : secure_expr l1 e ).
+  { eapply secure_expr_upward_close with (l1 := le); eauto. }
+  intros observer. specialize (He observer).
+  inv He.
+  - assert (Hobs : leq pc observer). eapply leq_trans_lat; eauto.
+    left; auto.
+    do 2 red in H0. do 2 red. intros. unfold sem_stmt. cbn.
+    unfold interp_imp_inline, interp_asm. setoid_rewrite interp_state_bind.
+    eapply secure_eqit_bind; eauto. intros [ [? ?] ?] [ [? ?] ?] [ [_ ?] ?].
+    cbn in H2, H3. subst. cbn. eapply proper_eutt_secure_eutt; try apply interp_state_trigger.
+    cbn. setoid_rewrite bind_trigger. cbn.
+    apply eqit_secure_public_Vis; try apply H.
+    intros []. apply secure_eqit_ret; auto. split; auto. split; auto. cbv; auto.
+  - case_leq pc observer.
+    + left; auto. destruct H0 as [n Hn]. do 2 red in Hn. cbn in Hn.
+      unfold sem_stmt. cbn. unfold interp_imp_inline, interp_asm. do 2 red.
+      intros. setoid_rewrite interp_state_bind.
+      eapply secure_eqit_bind with (RR := product_rel (product_rel top2 (labelled_equiv Γ observer)) top2 ); eauto.
+      2 : { eapply state_secure_eutt_ret_aux; try apply Hn; auto. }
+      intros [ [ ? ?] ?] [ [ ? ?] ?] [ [ _ ?] ?]. cbn in H1. cbn.
+      eapply proper_eutt_secure_eutt; try apply interp_state_trigger.
+      cbn. setoid_rewrite bind_trigger. apply eqit_secure_private_VisLR; auto.
+      constructor; apply tt. constructor; apply tt. intros [] [].
+      apply secure_eqit_ret. repeat (split; auto).
+    + right; auto. destruct H0 as [n Hn]. do 2 red in Hn.
+      do 2 red. intros. unfold sem_stmt. cbn.
+      unfold interp_imp_inline, interp_asm. setoid_rewrite interp_state_bind.
+      match goal with |- eqit_secure _ _ _ _ _ _ _ ?t =>
+                      assert (t ≈ (ITree.bind (Ret (regs2, σ2, n)) (fun st => Ret (fst st, tt) ))) end.
+      rewrite bind_ret_l. reflexivity.
+      eapply proper_eutt_secure_eutt; try apply H1; try reflexivity.
+      eapply secure_eqit_bind; try apply Hn; eauto.
+      intros [ [? ?] ?] [ [? ?] ?] [ [? ?] ?]. cbn in *.
+      eapply proper_eutt_secure_eutt; try apply interp_state_trigger; try reflexivity.
+      cbn.
+      eapply proper_eutt_secure_eutt; try apply interp_state_trigger; try reflexivity.
+      cbn. setoid_rewrite bind_trigger. cbn.
+      apply eqit_secure_private_VisL; auto. constructor; apply tt.
+      intros []. apply secure_eqit_ret; auto. repeat (split; auto).
+Qed.
+
+Lemma throw_prefix_output l1 e :  throw_prefix (denote_stmt (Output l1 e) ) ≈
+        v <- denote_expr e;; trigger (LabelledImp.LabelledPrint sensitivity_lat l1 v);; Ret (inl tt).
+Proof.
+  cbn. rewrite throw_prefix_bind. rewrite throw_prefix_denote_expr. rewrite bind_bind.
+  eapply eqit_bind'; try reflexivity. intros; subst. rewrite bind_ret_l. setoid_rewrite throw_prefix_ev.
+  rewrite bind_trigger. apply eqit_Vis. intros []. rewrite tau_eutt. rewrite throw_prefix_ret. reflexivity.
+Qed.
+
+Lemma output_well_typed_correct' l1 le pc e :
+  secure_expr le e -> leq (join le pc) l1 ->
+  secure_throw_stmt pc (Output l1 e).
+Proof.
+  intros He0 Hle1.
+  assert (Hle : leq le l1).
+  { eapply leq_trans_lat; eauto. apply leq_join_l; auto. }
+  assert (Hpc : leq pc l1).
+  { eapply leq_trans_lat; try apply Hle1; auto. apply leq_join_r; eauto.  }
+  assert (He : secure_expr l1 e ).
+  { eapply secure_expr_upward_close with (l1 := le); eauto. }
+  intros observer. specialize (He observer).
+  inv He.
+  - assert (Hobs : leq pc observer). eapply leq_trans_lat; eauto.
+    left; auto.
+    do 2 red in H0. do 2 red. intros. unfold sem_throw_stmt.
+     unfold interp_imp_inline, interp_asm.
+    eapply proper_eutt_secure_eutt; try rewrite throw_prefix_output; try reflexivity.
+    setoid_rewrite interp_state_bind.
+    eapply secure_eqit_bind; eauto.
+    intros [ [? ?] ?] [ [? ?] ?] [ [ _ ?] ?].
+    cbn in H2, H3. subst. cbn. eapply proper_eutt_secure_eutt; try rewrite interp_state_bind, interp_state_trigger; try reflexivity.
+    cbn. setoid_rewrite bind_trigger. setoid_rewrite bind_vis.
+    apply eqit_secure_public_Vis; try apply H.
+    intros []. setoid_rewrite bind_ret_l. setoid_rewrite interp_state_ret. apply secure_eqit_ret; auto.
+    cbn. split; auto. repeat (split; auto). constructor. auto.
+  - case_leq pc observer.
+    + left; auto. destruct H0 as [n Hn]. do 2 red in Hn. cbn in Hn.
+      unfold sem_throw_stmt. do 2 red. intros. unfold interp_imp_inline, interp_asm.
+      eapply proper_eutt_secure_eutt; try rewrite throw_prefix_output; try reflexivity.
+      cbn. unfold interp_imp.
+      setoid_rewrite interp_state_bind.
+      eapply secure_eqit_bind with (RR := product_rel (product_rel top2 (labelled_equiv Γ observer)) top2 ); eauto.
+      2 : { eapply state_secure_eutt_ret_aux; try apply Hn; auto. }
+      intros [ [? ?] ?] [ [? ?] ?] [ [ _ ?] ?]. cbn in H2.
+      setoid_rewrite interp_state_bind.
+      eapply proper_eutt_secure_eutt; try setoid_rewrite interp_state_trigger; try reflexivity. cbn.
+      setoid_rewrite bind_bind. setoid_rewrite bind_trigger. apply eqit_secure_private_VisLR; auto.
+      all : try (constructor; apply tt; fail). intros [] []. setoid_rewrite bind_ret_l.
+      setoid_rewrite interp_state_ret. apply secure_eqit_ret. split; try constructor; auto.
+    + right; auto. destruct H0 as [n Hn]. do 2 red in Hn.
+      do 2 red. intros. unfold sem_throw_stmt.
+      unfold interp_imp_inline, interp_asm.
+      eapply proper_eutt_secure_eutt; try rewrite throw_prefix_output; try reflexivity.
+      setoid_rewrite interp_state_bind.
+      match goal with |- eqit_secure _ _ _ _ _ _ _ ?t =>
+                      assert (t ≈ (ITree.bind (Ret (regs2, σ2, n)) (fun st => Ret (fst st, tt) ))) end.
+      rewrite bind_ret_l. reflexivity.
+      eapply proper_eutt_secure_eutt; try apply H1; try reflexivity.
+      eapply secure_eqit_bind; try apply Hn; eauto.
+      intros [ [? ?] ?] [ [ ? ?] ?] [ [ _ ?] ?]. cbn. setoid_rewrite interp_state_bind.
+      eapply proper_eutt_secure_eutt; try rewrite interp_state_trigger; try reflexivity. cbn.
+      rewrite bind_bind, bind_trigger. apply eqit_secure_private_VisL; auto. constructor; constructor.
+      intros []. rewrite bind_ret_l. rewrite interp_state_ret.
+      apply secure_eqit_ret; auto. repeat (split; auto).
+Qed.
+
+Lemma seq_well_typed_correct pc s1 s2 :
+  secure_stmt pc s1 -> secure_stmt pc s2 ->
+  secure_stmt pc (Seq s1 s2).
+Proof.
+  intros Hc1 Hc2. red. intros.
+  specialize (Hc1 observer) as Hc1obs. specialize (Hc2 observer) as Hc2obs.
+  inv Hc1obs.
+  - do 2 red in H0. left; auto. unfold sem_stmt.
+    cbn. unfold interp_imp_inline, interp_asm. do 2 red. intros. setoid_rewrite interp_state_bind.
+    eapply secure_eqit_bind; eauto. intros [ [ ? ?] [] ] [ [ ? ?] [] ] [ [ _ ?] ?].
+    cbn in *. clear H3. cbn.
+    inv Hc2obs; try apply H4; auto.
+    do 2 red in H4.
+    eapply eqit_secure_RR_imp with (RR1 := product_rel (product_rel top2 ( labelled_equiv Γ observer)) top2 ).
+    { intros [ ? [] ] [? [] ] [? ?] . split; auto. }
+    eapply state_secure_eutt_ret_aux; try apply H4; eauto.
+    (* I think this ends up being fine*)
+  - right; auto. unfold sem_stmt, interp_imp_inline, interp_asm. cbn. do 2 red. intros.
+    setoid_rewrite interp_state_bind.
+    inv Hc2obs.
+    { exfalso. apply H. auto. }
+      match goal with |- eqit_secure _ _ _ _ _ _ _ ?t =>
+                      assert (t ≈ (ITree.bind (Ret (regs2, σ2, tt)) (fun st => Ret (fst st, tt) ))) end.
+    rewrite bind_ret_l. reflexivity.
+    eapply proper_eutt_secure_eutt; try apply H4; try reflexivity.
+    eapply secure_eqit_bind; try eapply H0; auto.
+    intros [ [ ? ?] ?] [ [? ?] ?] [ [ _ ?] ?]. apply H3; auto.
+Qed.
+
+Lemma seq_well_typed_correct' pc s1 s2 :
+  secure_throw_stmt pc s1 -> secure_throw_stmt pc s2 ->
+  secure_throw_stmt pc (Seq s1 s2).
+Proof.
+  intros Hc1 Hc2. red. intros.
+  specialize (Hc1 observer) as Hc1obs. specialize (Hc2 observer) as Hc2obs.
+  inv Hc1obs.
+  - do 2 red in H0. left; auto. unfold sem_throw_stmt.
+    cbn. unfold interp_imp_inline, interp_asm. do 2 red. intros. setoid_rewrite throw_prefix_bind. setoid_rewrite interp_state_bind.
+    eapply secure_eqit_bind; eauto.
+    intros [ [ ? σ3] [ [] | ?] ] [ [ ? σ4] [ [] | ? ]] [ [ _ Hσ] Hr] ; inv Hr.
+    + cbn. inv Hc2obs; try contradiction. eapply H3; eauto.
+    + destruct H4; subst; cbn. setoid_rewrite interp_state_ret. apply secure_eqit_ret. split; try constructor; auto.
+      constructor.
+  - right; auto. unfold sem_throw_stmt, interp_imp_inline, interp_asm. cbn. do 2 red. intros.
+    setoid_rewrite throw_prefix_bind. setoid_rewrite interp_state_bind.
+    inv Hc2obs; try contradiction.
+      match goal with |- eqit_secure _ _ _ _ _ _ _ ?t =>
+                      assert (t ≈ (ITree.bind (Ret (regs2, σ2, tt)) (fun st => Ret (fst st, tt) ))) end.
+    rewrite bind_ret_l. reflexivity.
+    eapply proper_eutt_secure_eutt; try apply H4; try reflexivity.
+    eapply secure_eqit_bind; try eapply H0; auto.
+    intros [ [ ? σ3] [ [] | ?] ] [ [ ? σ4]  [] ] [ [ _ Hσ] Hr] ; inv Hr.
+    cbn. eapply H3; eauto.
+Qed.
+
+Lemma if_well_typed_correct pc le e s1 s2 :
+  secure_expr le e -> secure_stmt (join pc le) s1 -> secure_stmt (join pc le) s2 ->
+  secure_stmt pc (If e s1 s2).
+Proof.
+  intros He Hc1 Hc2. red. intros.
+  specialize (Hc1 observer) as Hc1obs. specialize (Hc2 observer) as Hc2obs.
+  specialize (He observer).
+  inv Hc1obs; inv Hc2obs; try contradiction.
+  - left. eapply leq_trans_lat; eauto. apply leq_join_l; auto.
+    inv He. 2 : { exfalso. apply H3. eapply leq_trans_lat; eauto. apply leq_join_r; auto. }
+    unfold sem_stmt, interp_imp_inline, interp_asm.
+    cbn. do 2 red. intros. setoid_rewrite interp_state_bind. eapply secure_eqit_bind; try apply H4; auto.
+    intros [ [ ? ?] ?] [ [ ? ?] ?] [ [ _ ?] ?]. cbn in H6, H7. subst. cbn. destruct v0; eauto.
+  - case_leq pc observer.
+    + left; auto. unfold sem_stmt, interp_imp_inline, interp_asm. cbn. do 2 red. intros.
+      setoid_rewrite interp_state_bind.
+      inv He; try contradiction.
+      * eapply secure_eqit_bind; try apply H5; eauto.
+        intros [ [ ? ?] ?] [ [? ?] ?] [ [ _ ?] ?]. cbn in H7, H6. cbn. subst. do 2 red in H0, H2.
+        eapply eqit_secure_RR_imp with (RR1 := product_rel (product_rel top2 (labelled_equiv Γ observer)) top2 ).
+        { intros [ [ ? ?] [] ] [ [? ?] [] ] [ [ _ ?] ?]. repeat (split; auto). }
+        destruct v0; try eapply  state_secure_eutt_ret_aux; cbn in *; eauto.
+      * destruct H5 as [n Hn]. do 2 red in Hn.
+        eapply secure_eqit_bind; try eapply  state_secure_eutt_ret_aux; cbn in Hn; eauto.
+        intros [ [ ? ?] ?] [ [ ? ?] ?] [ [ _ ?] ?]. cbn. cbn in H6.
+        eapply eqit_secure_RR_imp with (RR1 := product_rel (product_rel top2 (labelled_equiv Γ observer)) top2 ).
+        { intros [ [ ? ?] [] ] [ [ ? ?] [] ] [ [ _ ?] ?]. repeat (split; auto). }
+        destruct v; destruct v0;
+        try eapply state_secure_eutt_ret_aux; try apply H0; try apply H2; eauto.
+     + right; auto. do 2 red. intros. unfold sem_stmt, interp_imp_inline, interp_asm. cbn.
+       setoid_rewrite interp_state_bind.
+      match goal with |- eqit_secure _ _ _ _ _ _ _ ?t =>
+                      assert (t ≈ (ITree.bind (Ret (regs2, σ2, 0)) (fun st => Ret (fst st, tt) ))) end.
+       rewrite bind_ret_l. reflexivity.
+       eapply proper_eutt_secure_eutt; try apply H4; try reflexivity.
+       inv He.
+       * eapply secure_eqit_bind with (RR := product_rel (product_rel top2 (labelled_equiv Γ observer)) top2) .
+         2 : {  apply expr_only_ret_aux1; auto. }
+         intros [ [ ? ?] ?] [ [ ? ?] ?] [ [ _ ?] ?]. cbn. destruct v; cbn in *; eauto.
+       * destruct H6. eapply secure_eqit_bind; try apply expr_only_ret_aux1; auto.
+         intros [ [? ?] ?] [ [? ?] ?] [ [ _ ?] ?]. cbn. destruct v; cbn in *; eauto.
+Qed.
+
+Lemma if_well_typed_correct' pc le e s1 s2 :
+  secure_expr le e -> secure_throw_stmt (join pc le) s1 -> secure_throw_stmt (join pc le) s2 ->
+  secure_throw_stmt pc (If e s1 s2).
+Proof.
+  intros He Hc1 Hc2. red. intros.
+  specialize (Hc1 observer) as Hc1obs. specialize (Hc2 observer) as Hc2obs.
+  specialize (He observer).
+  inv Hc1obs; inv Hc2obs; try contradiction.
+  - left. eapply leq_trans_lat; eauto. apply leq_join_l; auto.
+    inv He. 2 : { exfalso. apply H3. eapply leq_trans_lat; eauto. apply leq_join_r; auto. }
+    unfold sem_throw_stmt, interp_imp_inline, interp_asm.
+    cbn. do 2 red. intros. setoid_rewrite throw_prefix_bind.
+    eapply proper_eutt_secure_eutt; try setoid_rewrite throw_prefix_denote_expr; try reflexivity.
+    rewrite bind_bind. setoid_rewrite interp_state_bind; setoid_rewrite bind_ret_l.
+    eapply secure_eqit_bind; try apply H4; auto.
+    intros [ [ ? ?] ?] [ [ ? ?] ?] [ [ _ ?] ?]. cbn in H6, H7. subst. cbn. destruct v0; eauto.
+  - (* ~ leq (join pc le) observer  *)
+    case_leq pc observer.
+    + (* leq pc observer *)
+      left; auto. unfold sem_throw_stmt, interp_imp_inline, interp_asm. cbn. do 2 red. intros.
+      setoid_rewrite throw_prefix_bind.
+      setoid_rewrite interp_state_bind.
+      inv He; try contradiction.
+      * (* leq le observer *)
+        eapply proper_eutt_secure_eutt; try setoid_rewrite throw_prefix_denote_expr; try reflexivity.
+        setoid_rewrite interp_state_bind. repeat rewrite bind_bind.
+        eapply secure_eqit_bind; try eapply H6; eauto.
+        setoid_rewrite interp_state_ret. setoid_rewrite bind_ret_l; cbn.
+        intros [ [ ? σ3] v1 ] [ [? σ4] v2 ] [ [ _ Hσ] Hv]; cbn in Hv; subst. destruct v2; cbn; eauto;
+        try eapply state_secure_eutt_throw_ret_aux; eauto.
+      * eapply proper_eutt_secure_eutt; try setoid_rewrite throw_prefix_denote_expr; try reflexivity.
+        setoid_rewrite interp_state_bind. setoid_rewrite bind_bind.
+        destruct H5 as [n Hn].
+        eapply secure_eqit_bind; try eapply state_secure_eutt_ret_aux; try eapply Hn; eauto.
+        intros [ [ ?  σ3] v1] [ [ ? σ4] v2] [ [ _ Hσ] _ ]. setoid_rewrite interp_state_ret. cbn.
+        setoid_rewrite bind_ret_l. cbn. destruct v1; destruct v2; try eapply state_secure_eutt_throw_ret_aux; eauto.
+   + (* ~ leq pc observer *)
+     right; auto. unfold sem_throw_stmt, interp_imp_inline, interp_asm. cbn. do 2 red. intros. setoid_rewrite throw_prefix_bind.
+     setoid_rewrite interp_state_bind.
+      match goal with |- eqit_secure _ _ _ _ _ _ _ ?t =>
+                      assert (t ≈ (ITree.bind (Ret (regs2, σ2, 0)) (fun st => Ret (fst st, tt) ))) end.
+     rewrite bind_ret_l. reflexivity.
+     eapply proper_eutt_secure_eutt; try apply H5; try reflexivity.
+     inv He.
+     * eapply proper_eutt_secure_eutt; try setoid_rewrite throw_prefix_denote_expr; try reflexivity.
+       eapply proper_eutt_secure_eutt; try apply H4; try reflexivity.
+       setoid_rewrite interp_state_bind. rewrite bind_bind.
+       eapply secure_eqit_bind; try eapply expr_only_ret_aux1; eauto.
+       intros [ [ ? σ3] v1] [ [ ? σ4] v2] [ [ _ Hσ] _ ]. setoid_rewrite interp_state_ret. setoid_rewrite bind_ret_l.
+       cbn. destruct v1; cbn in *; eauto.
+     * destruct H6 as [n Hn]. eapply proper_eutt_secure_eutt; try setoid_rewrite throw_prefix_denote_expr; try apply H4; try reflexivity.
+       setoid_rewrite interp_state_bind. rewrite bind_bind.
+       eapply secure_eqit_bind; try eapply expr_only_ret_aux1; eauto.
+       setoid_rewrite interp_state_ret. setoid_rewrite bind_ret_l. cbn.
+       intros [ [ ? σ3] v1] [ [ ? σ4] v2] [ [ _ Hσ] _ ]. destruct v1; cbn in *; eauto.
+Qed.
+
+Lemma while_well_typed_correct e s :
+  secure_expr bot e -> secure_stmt bot s ->
+  secure_stmt bot (While e s).
+Proof.
+  intros He Hc. red. intros.
+  assert (leq bot observer); cbn; auto.
+  specialize (He observer).
+  specialize (Hc observer).
+  inv He; inv Hc; try contradiction.
+  left; auto. unfold sem_stmt, interp_imp. cbn. unfold while.
+  specialize @interp_state_iter' as Hisi. red in Hisi. do 2 red. intros.
+  setoid_rewrite Hisi. eapply secure_eqit_iter with (RA := product_rel (product_rel top2 (labelled_equiv Γ observer)) eq).
+  { repeat (split; auto). }
+  intros [ [? ?] [] ] [ [ ? ?] [] ] [ [ _ ?] ?]. cbn.
+  setoid_rewrite interp_state_bind. setoid_rewrite bind_bind.
+  eapply secure_eqit_bind; try apply H1; auto.
+  intros [ [ ? ?] ?] [ [? ?] ?] [ [_ ?] ?]. cbn. cbn in H7, H8; subst. destruct v0.
+  - setoid_rewrite interp_state_ret. setoid_rewrite bind_ret_l. cbn.
+    apply secure_eqit_ret. constructor. repeat (split; auto).
+  - setoid_rewrite interp_state_bind. setoid_rewrite bind_bind.
+    eapply secure_eqit_bind; try apply H3; auto.
+    intros [ [ ? ?] [] ] [ [ ? ?] [] ] [ [ _ ?] ?]. cbn. cbn in H8.
+    setoid_rewrite interp_state_ret. setoid_rewrite bind_ret_l. cbn.
+    apply secure_eqit_ret. constructor. repeat (split; auto).
+Qed.
+
+Lemma while_well_typed_correct' e s :
+  secure_expr bot e -> secure_throw_stmt bot s ->
+  secure_throw_stmt bot (While e s).
+Proof.
+  intros He Hc. red. intros.
+  assert (leq bot observer); cbn; auto.
+  specialize (He observer).
+  specialize (Hc observer).
+  inv He; inv Hc; try contradiction.
+  left; auto. unfold sem_throw_stmt in *.
+  cbn. do 2 red. intros. unfold interp_imp_inline, interp_asm in *. setoid_rewrite throw_prefix_iter.
+  specialize @interp_state_iter' as Hisi. red in Hisi.
+  setoid_rewrite Hisi. cbn.
+  eapply secure_eqit_iter with (RA := product_rel (product_rel top2 (labelled_equiv Γ observer)) eq ).
+  repeat (split; auto). intros [ [ ? σ3] [] ] [ [ ? σ4] [] ] [ [ _ Hσ] _]. cbn.
+  setoid_rewrite throw_prefix_bind. repeat setoid_rewrite interp_state_bind.
+  repeat rewrite bind_bind.
+  eapply proper_eutt_secure_eutt;
+    try setoid_rewrite throw_prefix_denote_expr; try reflexivity.
+  setoid_rewrite interp_state_bind. setoid_rewrite bind_bind.
+  eapply secure_eqit_bind; try eapply H1; eauto.
+  intros [ [ ? σ5] v1] [ [ ? σ6] v2] [ [ _ Hσ'] Heq]; cbn in Heq; subst. cbn.
+  setoid_rewrite interp_state_ret. setoid_rewrite bind_ret_l. cbn.
+  destruct v2.
+  - cbn. setoid_rewrite throw_prefix_ret. setoid_rewrite interp_state_ret.
+    setoid_rewrite bind_ret_l. cbn. setoid_rewrite interp_state_ret.
+    setoid_rewrite bind_ret_l. cbn. apply secure_eqit_ret. constructor. repeat (split; auto).
+    constructor. auto.
+  - setoid_rewrite throw_prefix_bind. setoid_rewrite interp_state_bind.
+    setoid_rewrite bind_bind. eapply secure_eqit_bind; try eapply H3; eauto.
+    intros [ [ ? σ7] [ [] | l1] ] [ [ ? σ8] [ [] | l2] ] [ [ _ Hσ''] Hsum]; inv Hsum.
+    + cbn. setoid_rewrite throw_prefix_ret. setoid_rewrite interp_state_ret.
+      setoid_rewrite bind_ret_l. cbn. setoid_rewrite interp_state_ret.
+      setoid_rewrite bind_ret_l. cbn. apply secure_eqit_ret.
+      constructor. repeat (split; auto).
+    + cbn. setoid_rewrite interp_state_ret. setoid_rewrite bind_ret_l.
+      cbn. setoid_rewrite interp_state_ret. setoid_rewrite bind_ret_l.
+      cbn. apply secure_eqit_ret. destruct H7; subst. constructor.
+      repeat (split; auto). constructor. auto.
+Qed.
+
+Lemma well_typed_raise : secure_stmt bot (Raise bot).
+Proof.
+  red. intros. left. cbn. auto.
+  red. red. intros. unfold sem_stmt, interp_imp_inline, interp_asm.
+  cbn. setoid_rewrite interp_state_bind. eapply secure_eqit_bind with (RR := eq).
+  intros [ _ [] ].
+  eapply proper_eutt_secure_eutt; try apply interp_state_trigger; try reflexivity.
+  cbn. setoid_rewrite bind_trigger. apply eqit_secure_public_Vis.
+  cbn. auto. intros [].
+Qed.
+
+Lemma well_typed_raise' : secure_throw_stmt bot (Raise bot).
+Proof.
+  red. intros. left. apply leq_bot; auto.
+  red. red. intros. unfold sem_throw_stmt, interp_imp_inline, interp_asm. cbn.
+  setoid_rewrite throw_prefix_bind. setoid_rewrite interp_state_bind.
+  eapply secure_eqit_bind with (RR :=  (product_rel (product_rel top2 (labelled_equiv Γ observer)) (fun r1 r2 : void + sensitivity => r1 = inr (@bot sensitivity_lat) /\ r2 = inr  (@bot sensitivity_lat))) ).
+  - intros [ [ ? σ3] [ [] | l1 ] ] [ [ ? σ4] [ [] | l2 ] ] Heq; subst. cbn. destruct Heq. cbn in *. subst.
+    destruct H1. injection H1; injection H2; intros; subst.
+    setoid_rewrite interp_state_ret. apply secure_eqit_ret.
+    split; auto. constructor. split; auto.
+  - setoid_rewrite throw_prefix_exc. setoid_rewrite interp_state_ret. apply secure_eqit_ret.
+    repeat (split; auto).
+Qed.
+
+
+Lemma try_catch_public_exc R RR (t1 t2 catch1 catch2 : itree _ R ) observer :
+  label_state_sec_eutt Γ observer (sum_rel RR (fun l1 l2 => eqlat l1 bot /\ eqlat l2 bot) )
+                       (interp_imp_inline (throw_prefix t1) ) (interp_imp_inline (throw_prefix t2) )  ->
+  label_state_sec_eutt Γ observer RR (interp_imp_inline t1) (interp_imp_inline t2) ->
+  label_state_sec_eutt Γ observer RR (interp_imp_inline catch1) (interp_imp_inline catch2) ->
+  label_state_sec_eutt Γ observer RR
+              (interp_imp_inline (try_catch t1 (fun _ => catch1))) (interp_imp_inline (try_catch t2 (fun _ => catch2))).
+Proof.
+  unfold interp_imp_inline, interp_asm. intros Hthrow Hsect Hsecc σ1 σ2 regs1 regs2 Hσ.
+  (* try_catch_to_throw_prefix *)
+  eapply proper_eutt_secure_eutt; try setoid_rewrite try_catch_to_throw_prefix;
+    try setoid_rewrite interp_state_bind; try reflexivity.
+  eapply secure_eqit_bind; eauto.
+  intros [ [ ? σ3] [r1 | l1] ] [ [? σ4] [r2 | l2] ] Htry; destruct Htry as [ [ _ Hσ34] Hsum];
+    inv Hsum.
+  - cbn. repeat rewrite interp_state_ret. apply secure_eqit_ret.
+    repeat (split; auto).
+  - destruct H1; subst. cbn. apply Hsecc. auto.
+Qed.
+
+Lemma try_catch_throw_secure_stmt pc s catch :
+  secure_stmt pc s -> secure_throw_stmt pc s -> secure_stmt pc catch ->
+  secure_stmt pc (TryCatch s catch).
+Proof.
+  intros Hs Hthrows Hcatch. intros observer.
+  specialize (Hs observer). specialize (Hthrows observer). specialize (Hcatch observer).
+  inv Hs; inv Hthrows; inv Hcatch; try contradiction.
+  - left; auto. unfold sem_stmt. cbn. eapply try_catch_public_exc; eauto.
+  - right; auto. unfold sem_stmt. cbn. cbn in H2. unfold sem_throw_stmt in H2.
+    do 2 red. intros. eapply H0 in H5 as H6. cbn in H6. unfold interp_imp_inline, interp_asm.
+    eapply proper_eutt_secure_eutt; try setoid_rewrite try_catch_to_throw_prefix; try reflexivity.
+    setoid_rewrite <- bind_ret_r at 6.
+    setoid_rewrite interp_state_bind.
+    eapply secure_eqit_bind; eauto.
+    intros [ [ ? σ3] [ [] | l] ] [ [ ? σ4] []] [ [ _ Hσ] Hsum]; inv Hsum. cbn.
+    setoid_rewrite interp_state_ret. apply secure_eqit_ret; split; cbv; eauto.
+    Unshelve. all : auto.
+Qed.
+
+Lemma try_catch_throw_secure_stmt' pc s catch :
+  secure_stmt pc s -> secure_throw_stmt pc s -> secure_throw_stmt pc catch ->
+  secure_throw_stmt pc (TryCatch s catch).
+Proof.
+  intros Hs1 Hs2 Hcatch observer.
+  specialize (Hs1 observer). specialize (Hs2 observer). specialize (Hcatch observer).
+  inv Hs1; inv Hs2; inv Hcatch; try contradiction.
+  - left; auto. unfold sem_throw_stmt in *. cbn.
+    do 2 red. intros. unfold interp_imp_inline, interp_asm in *.
+    eapply proper_eutt_secure_eutt; try setoid_rewrite throw_prefix_of_try_catch;
+       try setoid_rewrite try_catch_to_throw_prefix; try reflexivity.
+    setoid_rewrite interp_state_bind.
+    setoid_rewrite throw_prefix_bind. setoid_rewrite interp_state_bind.
+    setoid_rewrite bind_bind. clear H0.
+    eapply secure_eqit_bind; try eapply H2; eauto.
+    try reflexivity.
+    intros [ [ ? σ3] [ [] | l1] ] [ [ ? σ4] [ [] | l2] ] [ [ _ Hσ] Hsum]; inv Hsum; cbn.
+    + setoid_rewrite throw_prefix_ret. setoid_rewrite interp_state_ret.
+      setoid_rewrite bind_ret_l. cbn. setoid_rewrite interp_state_ret.
+      apply secure_eqit_ret. repeat (split; auto). constructor. auto.
+    + setoid_rewrite interp_state_ret. setoid_rewrite bind_ret_l.
+      destruct H7; subst. cbn. eauto.
+  - right; auto. unfold sem_throw_stmt in *. cbn.
+    do 2 red. intros.
+    unfold interp_imp_inline, interp_asm in *.
+    eapply proper_eutt_secure_eutt; try setoid_rewrite throw_prefix_of_try_catch;
+       try setoid_rewrite try_catch_to_throw_prefix; try reflexivity.
+    setoid_rewrite throw_prefix_bind. rewrite bind_bind.
+    match goal with |- eqit_secure _ _ _ _ _ _ _ ?t =>
+                      assert (t ≈ (ITree.bind (Ret (regs2, σ2, tt)) (fun st => Ret (fst st, tt) ))) end.
+     rewrite bind_ret_l. reflexivity.
+     eapply proper_eutt_secure_eutt; try rewrite H6; try reflexivity.
+     unfold interp_imp_inline, interp_asm. setoid_rewrite interp_state_bind.
+     eapply secure_eqit_bind; try eapply H2; eauto.
+     intros [ [ ? σ3] [[] | l] ] [ [ ? σ4] [] ] [ [ _ Hσ] Hsum]; inv Hsum.
+     cbn. rewrite throw_prefix_ret, bind_ret_l. rewrite interp_state_ret.
+     apply secure_eqit_ret. repeat (split; auto).
+Qed.
+
+Lemma well_typed_skip pc : secure_stmt pc Skip.
+Proof.
+  intro observer. case_leq pc observer.
+  - left; auto. unfold sem_stmt, interp_imp_inline, interp_asm. do 2 red. intros.
+    cbn. setoid_rewrite interp_state_ret. apply secure_eqit_ret; auto.
+    repeat (split; auto).
+  - right; auto. unfold sem_stmt, interp_imp_inline, interp_asm. do 2 red. intros.
+    cbn. setoid_rewrite interp_state_ret. apply secure_eqit_ret; auto.
+    repeat (split; auto).
+Qed.
+
+Lemma well_typed_skip' pc : secure_throw_stmt pc Skip.
+Proof.
+  intro observer. case_leq pc observer.
+  - left; auto. unfold sem_throw_stmt, interp_imp_inline, interp_asm. do 2 red. intros.
+    cbn. setoid_rewrite throw_prefix_ret.
+    setoid_rewrite interp_state_ret. apply secure_eqit_ret; auto.
+    repeat (split; auto). constructor. auto.
+  - right; auto. unfold sem_throw_stmt, interp_imp_inline, interp_asm. do 2 red. intros.
+    cbn. setoid_rewrite throw_prefix_ret.
+    setoid_rewrite interp_state_ret. apply secure_eqit_ret; auto.
+    repeat (split; auto).
+Qed.
+
+Inductive well_typed_expr : sensitivity -> expr -> Prop :=
+  | wte_lit l n : well_typed_expr l (Lit n)
+  | wte_var x l : leq (Γ x) l -> well_typed_expr l (Var x)
+  | wte_plus l1 l2 l3 e1 e2 : well_typed_expr l1 e1 -> well_typed_expr l2 e2 ->
+                              eqlat (join l1 l2) l3 ->
+                              well_typed_expr l3 (Plus e1 e2)
+  | wte_min l1 l2 l3 e1 e2 : well_typed_expr l1 e1 -> well_typed_expr l2 e2 ->
+                             eqlat (join l1 l2) l3 ->
+                             well_typed_expr l3 (Minus e1 e2)
+  | wte_mult l1 l2 l3 e1 e2 : well_typed_expr l1 e1 -> well_typed_expr l2 e2 ->
+                              eqlat (join l1 l2) l3 ->
+                              well_typed_expr l3 (Mult e1 e2)
+.
+
+(* rework this definition to have only public exceptions*)
+Inductive well_typed_stmt : sensitivity -> stmt -> Prop :=
+  | wts_manual pc s : secure_stmt pc s /\ secure_throw_stmt pc s /\ valid_stmt s -> well_typed_stmt pc s
+  | wts_skip pc : well_typed_stmt pc Skip
+  | wts_seq pc s1 s2 : well_typed_stmt pc s1 -> well_typed_stmt pc s2 ->
+                                   well_typed_stmt pc  (Seq s1 s2)
+  | wts_assign pc l x e : well_typed_expr l e -> leq (join l pc) (Γ x) ->
+                          well_typed_stmt pc (Assign x e)
+  | wts_print pc le lp e : well_typed_expr le e -> leq (join le pc) lp ->
+                           well_typed_stmt pc (Output lp e)
+  | wts_if pc le e s1 s2 : well_typed_expr le e -> well_typed_stmt (join pc le) s1 -> well_typed_stmt (join pc le) s2 ->
+                                       well_typed_stmt pc (If e s1 s2)
+  | wts_while e s : well_typed_expr bot e -> well_typed_stmt bot s ->
+                         well_typed_stmt bot (While e s)
+  | wts_raise : well_typed_stmt bot (Raise bot)
+  | wts_try pc s1 s2 : well_typed_stmt pc s1 -> well_typed_stmt pc s2 ->
+                                   well_typed_stmt pc (TryCatch s1 s2)
+.
+
+Instance proper_eqlat_expr : Proper (eqlat ==> eq ==> Basics.flip Basics.impl) well_typed_expr.
+Proof.
+  intros l1 l2 Hl e1 e2 He. subst. intro Htype.
+  generalize dependent l1. induction Htype.
+  - intros. constructor.
+  - intros. constructor. destruct sensitivity_latlaws. rewrite Hl. auto.
+  - intros. destruct sensitivity_latlaws. rewrite <- H in Hl.
+    econstructor; eauto. rewrite Hl. reflexivity.
+  - intros. destruct sensitivity_latlaws.
+    econstructor; eauto. rewrite Hl. auto.
+  - intros. destruct sensitivity_latlaws. rewrite <- H in Hl.
+    econstructor; eauto. rewrite Hl. reflexivity.
+Qed.
+
+Instance proper_eqlat_expr' : Proper (eqlat ==> eq ==> Basics.impl) well_typed_expr.
+Proof.
+  intros l1 l2 Hl e1 e2 He. subst. intro Htype.
+  generalize dependent l2. induction Htype.
+  - intros. constructor.
+  - intros. constructor. destruct sensitivity_latlaws. rewrite <- Hl. auto.
+  - intros. destruct sensitivity_latlaws. rewrite Hl in H.
+    econstructor; eauto.
+  - intros. destruct sensitivity_latlaws. rewrite Hl in H.
+    econstructor; eauto.
+  - intros. destruct sensitivity_latlaws. rewrite Hl in H.
+    econstructor; eauto.
+Qed.
+
+Lemma well_typed_expr_upward_close l1 l2 e : leq l1 l2 -> well_typed_expr l1 e -> well_typed_expr l2 e.
+Proof.
+  revert l1 l2.
+  induction e; intros; try inv H0.
+  - constructor. eapply leq_trans_lat; eauto.
+  - constructor.
+  - cbn in H. setoid_rewrite <- H. destruct sensitivity_latlaws.
+    econstructor; try reflexivity; eauto. eapply IHe1; eauto.
+    apply leq_trans_lat with (l2 := join_sense l0 l3); auto.
+    apply leq_join_l; auto. rewrite H6. cbn in *. destruct l1; auto.
+    eapply IHe2; eauto.
+    apply leq_trans_lat with (l2 := join_sense l0 l3); auto.
+    apply leq_join_r; auto. rewrite H6. auto.
+  - cbn in H. setoid_rewrite <- H. destruct sensitivity_latlaws.
+    econstructor; try reflexivity; eauto. eapply IHe1; eauto.
+    apply leq_trans_lat with (l2 := join_sense l0 l3); auto.
+    apply leq_join_l; auto. rewrite H6. cbn. destruct l1; auto.
+    eapply IHe2; eauto.
+    apply leq_trans_lat with (l2 := join_sense l0 l3); auto.
+    apply leq_join_r; auto. rewrite H6. auto.
+  - cbn in H. setoid_rewrite <- H. destruct sensitivity_latlaws.
+    econstructor; try reflexivity; eauto. eapply IHe1; eauto.
+    apply leq_trans_lat with (l2 := join_sense l0 l3); auto.
+    apply leq_join_l; auto. rewrite H6. cbn. destruct l1; auto.
+    eapply IHe2; eauto.
+    apply leq_trans_lat with (l2 := join_sense l0 l3); auto.
+    apply leq_join_r; auto. rewrite H6. auto.
+Qed.
+
+Lemma well_typed_expr_correct l e : well_typed_expr l e -> secure_expr l e.
+Proof.
+  revert l. red. induction e; intros l Htype observer.
+  - inv Htype. case_leq l observer.
+    + left; auto. unfold sem_expr. cbn. unfold interp_imp_inline, interp_asm.
+      do 2 red. intros. eapply proper_eutt_secure_eutt; try apply interp_state_trigger.
+      cbn.
+      unfold get. apply secure_eqit_ret; repeat (split; auto). cbn.
+      red in H. apply H. eapply leq_trans_lat; eauto.
+    + right; auto. apply expr_only_ret.
+  - case_leq l observer.
+    + left; auto. unfold sem_expr. cbn. unfold interp_imp_inline, interp_asm. do 2 red.
+      intros. setoid_rewrite interp_state_ret. apply secure_eqit_ret.
+      repeat (split; auto).
+    + right; auto. exists 0. unfold sem_expr. cbn. unfold interp_imp_inline, interp_asm. do 2 red.
+      intros. setoid_rewrite interp_state_ret. apply secure_eqit_ret. repeat (split; auto).
+  - inv Htype.
+    assert (well_typed_expr l e1 ). eapply well_typed_expr_upward_close; eauto.
+    eapply leq_trans_lat with (l2 := join_sense l1 l2); auto. apply leq_join_l; auto.
+    cbn. destruct sensitivity_latlaws. rewrite H4. destruct l; auto.
+    assert (well_typed_expr l e2 ). eapply well_typed_expr_upward_close; eauto.
+    apply leq_trans_lat with (l2 := join_sense l1 l2); auto. apply leq_join_r; auto.
+    cbn. destruct sensitivity_latlaws. rewrite H4. destruct l; auto.
+    apply IHe1 with (observer := observer) in H.
+    apply IHe2 with (observer := observer) in H0. inv H; inv H0; try contradiction.
+    + left; auto.
+      unfold sem_expr. cbn. unfold interp_imp_inline, interp_asm. do 2 red. intros.
+      repeat setoid_rewrite interp_state_bind.
+      eapply secure_eqit_bind. 2 : eapply H5; eauto.
+      intros [ [ ? s3] r1] [ [ ? s4] r2] Hprod. destruct Hprod. cbn in *. subst.
+      eapply secure_eqit_bind. 2 : eapply H6; eauto.
+      intros [ [ ? ?] ?] [ [ ? ?] ?] [ [ _ ?] ?]. cbn in *. subst. setoid_rewrite interp_state_ret.
+      apply secure_eqit_ret. repeat (split; auto). inv H7. auto.
+    + right; auto. apply expr_only_ret.
+  - inv Htype.
+    assert (well_typed_expr l e1 ). eapply well_typed_expr_upward_close; eauto.
+    eapply leq_trans_lat with (l2 := join_sense l1 l2); auto. apply leq_join_l; auto.
+    cbn. destruct sensitivity_latlaws. rewrite H4. destruct l; auto.
+    assert (well_typed_expr l e2 ). eapply well_typed_expr_upward_close; eauto.
+    apply leq_trans_lat with (l2 := join_sense l1 l2); auto. apply leq_join_r; auto.
+    cbn. destruct sensitivity_latlaws. rewrite H4. destruct l; auto.
+    apply IHe1 with (observer := observer) in H.
+    apply IHe2 with (observer := observer) in H0. inv H; inv H0; try contradiction.
+    + left; auto.
+      unfold sem_expr. cbn. unfold interp_imp_inline, interp_asm. do 2 red. intros.
+      repeat setoid_rewrite interp_state_bind.
+      eapply secure_eqit_bind. 2 : eapply H5; eauto.
+      intros [ [ ? s3] r1] [ [ ? s4] r2] Hprod. destruct Hprod. cbn in *. subst.
+      eapply secure_eqit_bind. 2 : eapply H6; eauto.
+      intros [ [ ? ?] ?] [ [ ? ?] ?] [ [ _ ?] ?]. cbn in *. subst. setoid_rewrite interp_state_ret.
+      apply secure_eqit_ret. repeat (split; auto). inv H7. auto.
+    + right; auto. apply expr_only_ret.
+  - inv Htype.
+    assert (well_typed_expr l e1 ). eapply well_typed_expr_upward_close; eauto.
+    eapply leq_trans_lat with (l2 := join_sense l1 l2); auto. apply leq_join_l; auto.
+    cbn. destruct sensitivity_latlaws. rewrite H4. destruct l; auto.
+    assert (well_typed_expr l e2 ). eapply well_typed_expr_upward_close; eauto.
+    apply leq_trans_lat with (l2 := join_sense l1 l2); auto. apply leq_join_r; auto.
+    cbn. destruct sensitivity_latlaws. rewrite H4. destruct l; auto.
+    apply IHe1 with (observer := observer) in H.
+    apply IHe2 with (observer := observer) in H0. inv H; inv H0; try contradiction.
+    + left; auto.
+      unfold sem_expr. cbn. unfold interp_imp_inline, interp_asm. do 2 red. intros.
+      repeat setoid_rewrite interp_state_bind.
+      eapply secure_eqit_bind. 2 : eapply H5; eauto.
+      intros [ [ ? s3] r1] [ [ ? s4] r2] Hprod. destruct Hprod. cbn in *. subst.
+      eapply secure_eqit_bind. 2 : eapply H6; eauto.
+      intros [ [ ? ?] ?] [ [ ? ?] ?] [ [ _ ?] ?]. cbn in *. subst. setoid_rewrite interp_state_ret.
+      apply secure_eqit_ret. repeat (split; auto). inv H7. auto.
+    + right; auto. apply expr_only_ret.
+Qed.
+
+Lemma well_typed_stmt_sound s pc : well_typed_stmt pc s -> secure_stmt pc s.
+Proof.
+  intros Htype. enough (secure_stmt pc s /\ secure_throw_stmt pc s); try tauto.
+  induction Htype; eauto; try tauto.
+  - (* Skip *) split; try apply well_typed_skip; try apply well_typed_skip'.
+  - (* Seq *)
+    split; try apply seq_well_typed_correct; try apply seq_well_typed_correct'; tauto.
+  - (* Assign *)
+    split; try eapply assign_well_typed_correct; try eapply assign_well_typed_correct';
+      try apply well_typed_expr_correct; eauto.
+  - (* Output *)
+    split; try eapply output_well_typed_correct; try eapply output_well_typed_correct';
+      try apply well_typed_expr_correct; eauto.
+  - (* If *)
+    apply well_typed_expr_correct in H.
+    split; try eapply if_well_typed_correct; try eapply if_well_typed_correct'; eauto; try tauto.
+  - (* While *)
+    destruct IHHtype. apply well_typed_expr_correct in H.
+    split; try eapply while_well_typed_correct; try eapply while_well_typed_correct'; eauto.
+  - (* Raise *)
+    split; try eapply well_typed_raise; try eapply well_typed_raise'; eauto.
+  - (* TryCatch *)
+    destruct IHHtype1. destruct IHHtype2.
+    split; try eapply try_catch_throw_secure_stmt; try eapply try_catch_throw_secure_stmt'; eauto.
+Qed.
+
+Lemma well_typed_stmt_valid s pc : well_typed_stmt pc s -> valid_stmt s.
+Proof.
+  intros Htype. induction Htype; try tauto; constructor; eauto.
+Qed.
+
+Lemma secure_stmt_lower_pc:
+  forall (pc2 : sensitivity) (s : stmt),
+    secure_stmt pc2 s -> forall pc1 : L, leq pc1 pc2 -> secure_stmt pc1 s.
+Proof.
+  intros pc2 s H pc1 Hpc observer.
+  specialize (H observer). inv H.
+  - left. eapply leq_trans_lat; eauto. auto.
+  - case_leq pc1 observer.
+    + left; auto. cbn in H1. intros σ1 σ2 regs1 regs2 Hσ.
+      eapply eqit_secure_RR_imp with (RR1 := product_rel (product_rel top2 (labelled_equiv Γ observer)) top2 ).
+        { intros [? [] ] [? [] ] [? ?]. split; auto. }
+      eapply state_secure_eutt_equiv_ret_aux; eauto.
+      constructor. all : try cbv; tauto.
+    + right; auto.
+Qed.
+
+Lemma secure_throw_stmt_lower_pc:
+  forall (pc : sensitivity) (s : stmt),
+    secure_throw_stmt pc s -> forall pc1 : L, leq pc1 pc -> secure_throw_stmt pc1 s.
+Proof.
+  intros pc s H pc1 Hpc observer.
+  specialize (H observer). inv H.
+  - left. eapply leq_trans_lat; eauto. auto.
+  - case_leq pc1 observer.
+    + left; auto. cbn in H1. intros σ1 σ2 Hσ.
+      eapply state_secure_eutt_throw_ret_aux; eauto.
+    + right; auto.
+Qed.
+
+End LabelledImpTypes.

--- a/secure_example/LabelledImpInlineTypesProgInsens.v
+++ b/secure_example/LabelledImpInlineTypesProgInsens.v
@@ -1,0 +1,1089 @@
+From Coq Require Import Morphisms.
+
+From ITree Require Import
+     ITree
+     ITreeFacts
+     HeterogeneousRelations
+     Events.State
+     Events.StateFacts
+     Events.Exception
+     Events.ExceptionFacts
+     Secure.SecureEqHalt
+     Secure.SecureEqProgInsens
+     Secure.SecureEqProgInsensFacts
+.
+
+From SecureExample Require Import
+     Lattice
+     LabelledAsm
+     LabelledImpInline
+     LabelledImpHandler
+     LabelledImpInlineTypes
+     LabelledImpInline2AsmCorrectness
+.
+
+Import Monads.
+Import MonadNotation.
+Local Open Scope monad_scope.
+
+Section LabelledImpTypesProgInsens.
+
+Notation label := sensitivity.
+
+Definition labelled_equiv  :=
+  LabelledImpTypes.labelled_equiv sensitivity_lat.
+
+
+Ltac case_leq l1 l2 := destruct (leq_dec sensitivity_lat l1 l2) as [?Hleq | ?Hnleq].
+
+Instance labelled_equit_equiv {Γ l} : Equivalence (labelled_equiv Γ l).
+Proof.
+  constructor; unfold labelled_equiv.
+  - red. red. intros; auto.
+  - do 2 red. intros. symmetry; auto.
+  - do 2 red. intros. rewrite H; auto.
+Qed.
+Notation privacy_map := LabelledImp.privacy_map.
+Notation impExcE := LabelledImp.impExcE.
+Notation IOE := LabelledImp.IOE.
+Definition label_pi_eqit_secure_impstate  (b1 b2 : bool) (Γ : privacy_map sensitivity_lat) (l : label) {R1 R2 : Type} (RR : R1 -> R2 -> Prop )
+           (m1 : stateT (registers * map) (itree ((impExcE sensitivity_lat) +' (IOE sensitivity_lat))) R1)
+           (m2 : stateT (registers * map ) (itree ((impExcE sensitivity_lat) +' (IOE sensitivity_lat))) R2) : Prop :=
+  forall σ1 σ2 regs1 regs2, labelled_equiv Γ l σ1 σ2 -> pi_eqit_secure _ (priv_exc_io sensitivity_lat) (product_rel (product_rel top2 (labelled_equiv Γ l)) RR) b1 b2 l (m1 (regs1,σ1)) (m2 (regs2, σ2)).
+
+Definition label_state_pi_sec_eutt {R1 R2} priv l (RR : R1 -> R2 -> Prop) m1 m2 :=
+  label_pi_eqit_secure_impstate true true  priv l RR m1 m2.
+
+Definition sem_stmt (s : stmt) := interp_imp_inline (denote_stmt s).
+
+Definition sem_throw_stmt (s : stmt) := interp_imp_inline (throw_prefix (denote_stmt s) ).
+
+Definition sem_expr (e : expr) := LabelledImpInlineTypes.sem_expr e.
+
+Definition state_equiv {E R} (m1 m2 : stateT map (itree E) R) := forall (σ : map), m1 σ ≈ m2 σ.
+
+Global Instance proper_eutt_pi_secure_eutt  {E R1 R2 RR Label priv l} : Proper (@eutt E R1 R1 eq ==> @eutt E R2 R2 eq ==> Basics.flip Basics.impl)
+                                                               (pi_eqit_secure Label priv RR true true l).
+Proof.
+  eapply pi_eqit_secure_eq_itree_proper. all : apply true.
+Qed.
+
+Global Instance proper_eq_itree_secure_eutt  {E R1 R2 RR Label priv l} : Proper (@eq_itree E R1 R1 eq ==> @eq_itree E R2 R2 eq ==> Basics.flip Basics.impl)
+                                                               (pi_eqit_secure Label priv RR true true l).
+Proof.
+  repeat intro. assert (x ≈ y). rewrite H. reflexivity.
+  assert (x0 ≈ y0). rewrite H0. reflexivity. setoid_rewrite H3. rewrite H2. auto.
+Qed.
+
+(*
+Global Instance proper_state_equiv_label_state_sec_eutt {R1 R2 RR priv l} : Proper (@state_equiv _ R1 ==> @state_equiv _ R2 ==> iff) (@label_state_pi_sec_eutt R1 R2 priv l RR).
+Proof.
+  repeat intro. split.
+  - intros. do 2 red in H1. do 2 red. intros. red in H0. specialize (H0 σ2). red in H.
+    specialize (H σ1). eapply proper_eutt_pi_secure_eutt; eauto. symmetry. auto. symmetry. auto.
+  - intros. intros. do 2 red in H1. do 2 red. intros. red in H0. specialize (H0 σ2). red in H.
+    specialize (H σ1).  eapply proper_eutt_pi_secure_eutt; eauto.
+Qed.
+*)
+Context (Γ : privacy_map sensitivity_lat).
+
+Variant secure_stmt_at_label (observer pc lexn : label) (s : stmt) : Prop :=
+  | ssal_leq : (leq pc observer) -> label_state_pi_sec_eutt Γ observer eq (sem_stmt s) (sem_stmt s) -> secure_stmt_at_label observer pc lexn s
+  | ssal_nleq : (~ leq pc observer) -> label_state_pi_sec_eutt Γ observer top2 (sem_stmt s) (ret tt) -> secure_stmt_at_label observer pc lexn s.
+
+
+
+Variant secure_expr_at_label (observer protection: label ) (e : expr) : Prop :=
+  | seal_leq : (leq protection observer) -> label_state_pi_sec_eutt Γ observer eq (sem_expr e) (sem_expr e) ->
+               secure_expr_at_label observer protection e
+  | seal_nleq : (~leq protection observer) -> (exists n:value, label_state_pi_sec_eutt Γ observer top2 (sem_expr e) (ret n)) ->
+                secure_expr_at_label observer protection e
+.
+
+Definition secure_expr l e := forall observer, secure_expr_at_label observer l e.
+
+Definition secure_stmt pc lexn s := forall observer, secure_stmt_at_label observer pc lexn s.
+
+Variant is_inl {A B : Type} : A + B -> Prop :=
+  | is_inl_ev (a : A) : is_inl (inl a).
+
+
+(* I need cases like rsense_termlexcr so for when public observers look at private
+   exceptions throw the sum type lense *)
+Variant Rsense (observer lexn : label) : unit + label -> unit + label -> Prop :=
+  | rsense_termlr : Rsense observer lexn (inl tt) (inl tt)
+  | rsense_exclr l1 l2 : leq l1 lexn -> leq l2 lexn -> Rsense observer lexn (inr l1) (inr l2)
+  | rsense_termlexcr lpriv : leq lpriv lexn -> ~ leq lpriv observer -> Rsense observer lexn (inl tt) (inr lpriv)
+  | rsense_excltermr lpriv : leq lpriv lexn -> ~ leq lpriv observer -> Rsense observer lexn (inr lpriv) (inl tt)
+.
+
+Instance sym_rsense {observer lexn} : Symmetric (Rsense observer lexn).
+Proof.
+  red. intros. inv H; constructor; auto.
+Qed.
+
+Variant Rsense_unpriv (observer lexn : label) : unit + label -> Prop :=
+  | rup_inl : Rsense_unpriv observer lexn (inl tt)
+  | rup_priv_exc lpriv : ~ leq lpriv observer -> leq lpriv lexn -> Rsense_unpriv observer lexn (inr lpriv).
+
+Variant secure_throw_stmt_at_label (observer pc lexn : label) (s : stmt) : Prop :=
+  | stsal_leq : leq pc observer -> label_state_pi_sec_eutt Γ observer (Rsense observer lexn )
+                                                       (sem_throw_stmt s) (sem_throw_stmt s) -> secure_throw_stmt_at_label observer pc lexn s
+  | stsal_nleq : (~ leq pc observer) -> label_state_pi_sec_eutt Γ observer (fun sum _ => Rsense_unpriv observer lexn sum )
+                                                            (sem_throw_stmt s) (ret tt ) ->  secure_throw_stmt_at_label observer pc lexn s
+  .
+
+Definition secure_throw_stmt pc lexn s := forall observer, secure_throw_stmt_at_label observer pc lexn s.
+
+Lemma pi_sem_stmt_ret_aux:
+  forall (s1 s2 : stmt ) (observer : label) (σ3 σ4 : map) (regs1 regs2 : registers),
+    (forall (σ1 σ2 : map) (regs1 regs2 : registers),
+        labelled_equiv Γ observer σ1 σ2 ->
+        pi_eqit_secure _ (priv_exc_io sensitivity_lat) (product_rel (product_rel top2 (labelled_equiv Γ observer)) top2)
+                       true true observer (sem_stmt s1 (regs1, σ1)) (Ret ((regs2, σ2, tt)))) ->
+    (forall (σ1 σ2 : map) (regs1 regs2 : registers),
+        labelled_equiv Γ observer σ1 σ2 ->
+        pi_eqit_secure _ (priv_exc_io sensitivity_lat) (product_rel (product_rel top2 (labelled_equiv Γ observer)) top2)
+                       true true observer (sem_stmt s2 (regs1, σ1)) (Ret (regs2, σ2, tt))) ->
+    labelled_equiv Γ observer σ3 σ4 ->
+    pi_eqit_secure _ (priv_exc_io sensitivity_lat) (product_rel (product_rel top2 (labelled_equiv Γ observer)) eq) true
+                   true observer (interp_imp_inline (denote_stmt s1) (regs1, σ3))
+                   (interp_imp_inline (denote_stmt s2) (regs2, σ4)) .
+Proof.
+  intros s1 s2 observer σ3 σ4 ? ? Hσ Hs1 Hs2.
+  eapply pi_eqit_secure_RR_imp with (RR1 := rcompose  (product_rel (product_rel top2 (labelled_equiv Γ observer)) (@top2 unit unit))
+                                                      (Basics.flip (product_rel (product_rel top2 (labelled_equiv Γ observer)) top2))).
+  { intros [ [ ? σ5] [] ] [ [ ? σ6] [] ] Hr. inv Hr. inv REL1. inv REL2. split; auto.
+    destruct r2 as [ [? σ7] [] ]. split; auto. inv H1. inv H. cbn in *. etransitivity; eauto. symmetry. auto.
+  }
+  eapply pi_eqit_secure_trans_ret; eauto.
+  apply pi_eqit_secure_sym. eapply Hs1. reflexivity. Unshelve. auto.
+Qed.
+
+Lemma pi_sem_throw_stmt_ret_aux:
+  forall (lexn: label) (s1 s2 : stmt) (observer : label) (σ3 σ4 : map) (regs3 regs4 : registers),
+    (forall (σ1 σ2 : map) (regs1 regs2 : registers),
+        labelled_equiv Γ observer σ1 σ2 ->
+        pi_eqit_secure _ (priv_exc_io sensitivity_lat)
+                       (product_rel (product_rel top2 (labelled_equiv Γ observer))
+                                    (fun (sum : unit + label) (_ : unit) => Rsense_unpriv observer lexn sum)) true true observer
+                       (sem_throw_stmt s1 (regs1, σ1)) (Ret (regs2, σ2, tt))) ->
+    (forall (σ1 σ2 : map) (regs1 regs2 : registers),
+        labelled_equiv Γ observer σ1 σ2 ->
+        pi_eqit_secure _ (priv_exc_io sensitivity_lat)
+                       (product_rel (product_rel top2 (labelled_equiv Γ observer))
+                                    (fun (sum : unit + label) (_ : unit) => Rsense_unpriv observer lexn sum)) true true observer
+                       (sem_throw_stmt s2 (regs1, σ1)) (Ret (regs2, σ2, tt))) ->
+    labelled_equiv Γ observer σ3 σ4 ->
+    pi_eqit_secure _ (priv_exc_io sensitivity_lat)
+                   (product_rel (product_rel top2 (labelled_equiv Γ observer)) (Rsense observer lexn)) true true
+                   observer (interp_imp_inline (throw_prefix (denote_stmt s1)) (regs3, σ3))
+                   (interp_imp_inline (throw_prefix (denote_stmt s2)) (regs4, σ4)).
+Proof.
+  intros lexn s1 s2 observer σ3 σ4 regs3 regs4 Hs1 Hs2 Hσ.
+  (*  *)
+  set (product_rel (product_rel (@top2 registers registers) (labelled_equiv Γ observer)) (fun (sum : unit + label) ( _ : unit) => Rsense_unpriv observer lexn sum ) ) as HR.
+  eapply pi_eqit_secure_RR_imp with (RR1 := rcompose HR (Basics.flip HR) ).
+  { unfold HR. intros [ [ ? σ5] r1] [ [ ? σ6] r2] Hr. inv Hr. inv REL1. inv REL2.
+    inv H. inv H1. cbn in *. repeat (split; cbn; auto). etransitivity; eauto. symmetry. auto.
+    destruct r3 as [ [regs σ7] [ ]  ]; cbn in *. inv H0; inv H2; eauto; constructor; auto.
+  }
+  eapply pi_eqit_secure_trans_ret; eauto. apply pi_eqit_secure_sym.
+  eapply Hs2. reflexivity.
+  Unshelve. auto.
+Qed.
+
+Lemma lower_lexn_sound lexn1 lexn2 t1 t2 observer :
+  leq lexn1 lexn2 ->
+  pi_eqit_secure _ (priv_exc_io sensitivity_lat)
+                 (product_rel (product_rel (@top2 registers registers) (labelled_equiv Γ observer)) (Rsense observer lexn1)) true true
+                 observer t1 t2 ->
+  pi_eqit_secure _ (priv_exc_io sensitivity_lat)
+                 (product_rel (product_rel (@top2 registers registers) (labelled_equiv Γ observer)) (Rsense observer lexn2)) true true
+                 observer t1 t2.
+Proof.
+  intros. eapply pi_eqit_secure_RR_imp; try apply H0.
+  intros [ [ ? σ1] r1] [ [ ? σ2] r2] [ [ _ Hσ] Hr]. inv Hr.
+  all : repeat (split; auto).
+  - cbn in *; subst; constructor.
+  - cbn in H3; cbn in H4; subst. constructor; auto.
+    all : eapply leq_trans_lat; eauto; apply sensitivity_latlaws.
+  - cbn in H3; cbn in H4; subst. constructor; auto.
+    eapply leq_trans_lat; eauto; apply sensitivity_latlaws.
+  - cbn in H3; cbn in H4; subst. constructor; auto.
+    eapply leq_trans_lat; eauto; apply sensitivity_latlaws.
+Qed.
+
+Lemma lower_lexn_sound' lexn1 lexn2 t1 t2 observer :
+  leq lexn1 lexn2 ->
+  pi_eqit_secure _ (priv_exc_io sensitivity_lat)
+                 (product_rel (product_rel (@top2 registers registers) (labelled_equiv Γ observer)) (fun (sum : unit + label) (_ : unit) => Rsense_unpriv observer lexn1 sum)) true true
+                 observer t1 t2 ->
+  pi_eqit_secure _ (priv_exc_io sensitivity_lat)
+                 (product_rel (product_rel (@top2 registers registers) (labelled_equiv Γ observer)) (fun (sum : unit + label) (_ : unit) => Rsense_unpriv observer lexn2 sum)) true true
+                 observer t1 t2.
+Proof.
+  intros. eapply pi_eqit_secure_RR_imp; try apply H0.
+  intros [ [ ? σ1] r1] [ [ ? σ2] [] ] [ [ _ Hσ] Hr]; inv Hr.
+  - cbn in H1; subst. repeat (split; auto). constructor.
+  - cbn in H3. subst. repeat (split; auto).
+    constructor; auto. eapply leq_trans_lat; eauto; apply sensitivity_latlaws.
+Qed.
+
+
+
+Lemma seq_well_typed_correct pc lexn1 lexn2 s1 s2 :
+  secure_stmt pc lexn1 s1 -> secure_stmt (join pc lexn1) lexn2 s2 ->
+  secure_stmt pc (join lexn1 lexn2) (Seq s1 s2).
+Proof.
+  intros Hs1 Hs2 observer.
+  specialize (Hs1 observer). inv Hs1.
+  - left; auto. unfold sem_stmt, interp_imp.
+    cbn. do 2 red. intros σ1 σ2 regs1 regs2 Hσ. setoid_rewrite interp_state_bind.
+    eapply pi_eqit_secure_bind; eauto. intros [ [ ? σ3] [] ] [ [ ? σ4] [] ] [ [ _ Hσ'] _ ].
+    specialize (Hs2 observer). inv Hs2; eauto. cbn. do 2 red in H2. cbn in H2.
+    eapply pi_sem_stmt_ret_aux; eauto.
+  - right; auto. cbn in H0. unfold sem_stmt, interp_imp. cbn.
+    do 2 red. intros σ1 σ2 regs1 regs2 Hσ.
+    setoid_rewrite <- bind_ret_r with (s := Ret (regs2, σ2, tt) ).
+    setoid_rewrite interp_state_bind.
+    eapply pi_eqit_secure_bind; eauto.
+    intros [ [ ? σ3] [] ] [ [ ? σ4] [] ] [ [ _ Hσ'] _ ].
+    specialize (Hs2 observer). inv Hs2; eauto.
+    + exfalso. apply H. eapply leq_trans_lat; eauto; apply sensitivity_latlaws.
+      cbn. destruct pc; destruct lexn1; auto.
+    + cbn in H2. eauto.
+Qed.
+
+Lemma seq_well_typed_correct' pc lexn1 lexn2 s1 s2 :
+  secure_throw_stmt pc lexn1 s1 -> secure_throw_stmt (join pc lexn1) lexn2 s2 ->
+  secure_throw_stmt pc (join lexn1 lexn2) (Seq s1 s2).
+Proof.
+  intros Hs1 Hs2 observer.
+  specialize (Hs1 observer). inv Hs1.
+  - left; auto. unfold sem_throw_stmt, interp_imp_inline, interp_asm. cbn. do 2 red.
+    intros σ1 σ2 regs1 regs2 Hσ. setoid_rewrite throw_prefix_bind.
+    setoid_rewrite interp_state_bind.
+    eapply pi_eqit_secure_bind; eauto.
+    intros [ [ ? σ3] r1] [ [ ? σ4] r2] [ [ _ Hσ'] Hr]. inv Hr.
+    + specialize (Hs2 observer). cbn in *. subst. inv Hs2; eauto.
+      * cbn in *.
+        eapply pi_eqit_secure_RR_imp; try eapply H2; eauto.
+        intros. inv H3. inv H4. repeat (split; auto). inv H5.
+        constructor.  constructor; destruct l1; destruct l2; destruct lexn1; destruct lexn2; cbn in *; try discriminate; auto.
+        constructor. destruct lpriv; destruct lexn1; destruct lexn2; cbn in *; try discriminate; auto. auto.
+        constructor; auto. destruct lpriv; destruct lexn1; destruct lexn2; cbn in *; try discriminate; auto.
+      * cbn in *. cbn.
+        cbn in Hσ'.
+        eapply lower_lexn_sound. apply leq_join_r; auto. apply sensitivity_latlaws.
+        eapply pi_sem_throw_stmt_ret_aux; eauto.
+    + cbn in H3, H4. subst. cbn. setoid_rewrite interp_state_ret. apply pi_eqit_secure_ret.
+      repeat (split; auto); constructor; eapply leq_trans_lat; eauto; try apply sensitivity_latlaws;
+      cbn; destruct lexn1; destruct lexn2; auto.
+    + specialize (Hs2 observer). inv Hs2; eauto.
+      * exfalso. apply H2. eapply leq_trans_lat; eauto; try apply sensitivity_latlaws.
+        cbn. destruct pc; destruct lexn1; destruct observer; cbn in *; try discriminate; auto.
+      * cbn in H3, H4. subst. cbn. setoid_rewrite interp_state_ret. cbn.
+        cbn in H6. do 2 red in H6.
+        match goal with
+      |- pi_eqit_secure _ _ _ _ _ _ _ ?t => assert (t ≈ ITree.bind (Ret (r0, σ4,tt) ) (fun '(σ',x) => Ret (σ', inr lpriv) )) end.
+        rewrite bind_ret_l. reflexivity.
+        rewrite H3. rewrite <- bind_ret_r.
+        eapply pi_eqit_secure_bind; eauto.
+        intros [ [ ? σ5] r3] [ [ ? σ6] r4] [ [ _ Hσ''] Hr']; inv Hr'.
+        -- cbn in H4. subst. apply pi_eqit_secure_ret. repeat (split; auto).
+           constructor; auto. eapply leq_trans_lat; eauto; try apply leq_join_l; auto; apply sensitivity_latlaws.
+        -- cbn in H8. subst. apply pi_eqit_secure_ret. repeat (split; auto).
+           constructor; auto. eapply leq_trans_lat; eauto. apply sensitivity_latlaws. apply leq_join_r; auto.
+           apply sensitivity_latlaws.
+           eapply leq_trans_lat; eauto; try apply leq_join_l; auto; apply sensitivity_latlaws.
+    + specialize (Hs2 observer). inv Hs2; eauto.
+      * exfalso. apply H2. eapply leq_trans_lat; eauto;
+        try eapply leq_trans_lat; eauto; try apply leq_join_r; auto; apply sensitivity_latlaws.
+      * cbn. cbn in H3, H4. subst. setoid_rewrite interp_state_ret. cbn.
+        cbn in H6.
+        match goal with
+        |- pi_eqit_secure _ _ _ _ _ _ ?t _ => assert (t ≈ ITree.bind (Ret (r, σ3,tt) ) (fun '(σ',x) => Ret (σ', inr lpriv) )) end.
+        rewrite bind_ret_l. reflexivity. rewrite H3.
+        setoid_rewrite <- bind_ret_r at 4.
+        apply pi_eqit_secure_sym. symmetry in Hσ'. eapply pi_eqit_secure_bind; eauto.
+        intros [ [ ? σ5] r3] [ [ ? σ6] [] ] [ [ _ Hσ''] Hr']; inv Hr'.
+        -- cbn in H4. subst. apply pi_eqit_secure_ret. repeat (split; auto). symmetry. auto.
+           cbn.
+           constructor; auto. eapply leq_trans_lat; eauto; try apply leq_join_l; auto; apply sensitivity_latlaws.
+        -- cbn in H8. subst. apply pi_eqit_secure_ret. repeat (split; auto). symmetry. auto.
+           constructor; eapply leq_trans_lat; eauto; try apply leq_join_l; auto;
+           try eapply leq_trans_lat; eauto; try eapply leq_join_r; auto; apply sensitivity_latlaws.
+           Unshelve. 2 : apply lexn1. destruct lexn1; destruct lexn2; cbn; auto.
+  - right; auto. intros σ1 σ2 regs1 regs2 Hσ. unfold sem_throw_stmt, interp_imp_inline, interp_asm.
+    cbn. setoid_rewrite throw_prefix_bind. setoid_rewrite interp_state_bind.
+    cbn in H0. rewrite <- bind_ret_r with (s := Ret (regs2, σ2, tt) ).
+    eapply pi_eqit_secure_bind; eauto. intros [ [ ? σ3] r1] [ [ ? σ4] [] ] [ [ _ Hσ'] Hr]. inv Hr.
+    -- cbn in H1. subst. cbn. specialize (Hs2 observer). inv Hs2.
+       ++ do 2 red in H2. exfalso. apply H. eapply leq_trans_lat; eauto; try apply leq_join_l; auto; apply sensitivity_latlaws.
+       ++ do 2 red in H2. cbn in H2. eapply lower_lexn_sound'; eauto; try apply leq_join_r; auto; apply sensitivity_latlaws.
+    -- cbn in H3. subst. cbn.  setoid_rewrite interp_state_ret.
+       apply pi_eqit_secure_ret. repeat (split; auto). constructor; auto.
+       eapply leq_trans_lat; eauto; try apply leq_join_l; auto; apply sensitivity_latlaws.
+Qed.
+
+Hint Resolve sensitivity_latlaws : core.
+
+Lemma try_catch_well_typed_correct pc lexn1 lexn2 s1 s2 :
+  secure_stmt pc lexn1 s1 -> secure_throw_stmt pc lexn1 s1 ->
+  secure_stmt (join pc lexn1) lexn2 s2 ->
+  secure_stmt pc lexn2 (TryCatch s1 s2).
+Proof.
+  intros Hs1 Hs1t Hs2 observer.
+  specialize (Hs1 observer). specialize (Hs1t observer).
+  inv Hs1; inv Hs1t; try contradiction.
+  - left; auto. unfold sem_stmt, interp_imp_inline, interp_asm. do 2 red. intros σ1 σ2 regs1 regs2 Hσ.
+    cbn. setoid_rewrite try_catch_to_throw_prefix.
+    setoid_rewrite interp_state_bind. eapply pi_eqit_secure_bind; eauto.
+    intros [ [ ? σ3] r1 ] [ [ ? σ4] r2 ] [ [ _ Hσ'] Hr] ; inv Hr; cbn.
+    + cbn in H3, H4. subst. setoid_rewrite interp_state_ret. apply pi_eqit_secure_ret. repeat (split; auto).
+    + cbn in H5, H6. subst. specialize (Hs2 observer). inv Hs2; eauto. do 2 red in H6.
+      cbn in H6. eapply pi_sem_stmt_ret_aux; eauto.
+    + specialize (Hs2 observer). inv Hs2.
+      * exfalso. apply H4. eapply leq_trans_lat; eauto.
+        eapply leq_trans_lat; auto. apply leq_join_r; auto. eauto.
+      * apply pi_eqit_secure_sym. do 2 red in H8. cbn in H8.
+        apply pi_eqit_secure_RR_imp with (RR1 := product_rel (product_rel (@top2 registers registers) (labelled_equiv Γ observer)) top2).
+        { intros [ [ ? ?] [] ] [ [ ? ?] [] ] [ [? ?] ? ] . repeat (split; auto). symmetry. auto. }
+        cbn in H5, H6. subst. setoid_rewrite interp_state_ret. eapply H8. symmetry. auto.
+    + specialize (Hs2 observer). inv Hs2.
+      * exfalso. apply H4. eapply leq_trans_lat; eauto.
+        eapply leq_trans_lat; auto. apply leq_join_r; auto. eauto.
+      * do 2 red in H8.
+        apply pi_eqit_secure_RR_imp with (RR1 := product_rel (product_rel top2 (labelled_equiv Γ observer)) top2).
+        { intros [ [ ? ?] [] ] [ [ ? ?] [] ] [ [? ?] ? ] . inv H9. repeat (split; auto). }
+        cbn in H8. cbn in H5, H6. subst. setoid_rewrite interp_state_ret. eapply H8. auto.
+  - right; auto. unfold sem_stmt, interp_imp_inline, interp_asm. do 2 red. intros σ1 σ2 regs1 regs2 Hσ.
+    cbn. setoid_rewrite try_catch_to_throw_prefix.
+    (* rewrite the ret into a trivial bind *)
+    match goal with
+      |- pi_eqit_secure _ _ _ _ _ _ _ ?t => assert (t ≈ ITree.bind (Ret (regs2, σ2,tt) ) (fun x => Ret x)) end.
+    rewrite bind_ret_r. reflexivity. rewrite H3.
+    setoid_rewrite interp_state_bind. cbn in H2.
+    eapply pi_eqit_secure_bind; eauto.
+    intros [ [ ? σ3] r1] [ [ ? σ4] [] ] [ [ _ Hσ'] Hr]; inv Hr.
+    + cbn in H4. subst. tau_steps. apply pi_eqit_secure_ret. repeat (split; auto).
+    + specialize (Hs2 observer). inv Hs2; eauto.
+      * exfalso. apply H. eapply leq_trans_lat; eauto. apply leq_join_l; auto.
+      * cbn in H8. cbn in H6, H7. subst. cbn. eauto.
+Qed.
+
+Lemma try_catch_well_typed_correct' pc lexn1 lexn2 s1 s2 :
+  secure_stmt pc lexn1 s1 -> secure_throw_stmt pc lexn1 s1 ->
+  secure_throw_stmt (join pc lexn1) lexn2 s2 ->
+  secure_throw_stmt pc lexn2 (TryCatch s1 s2).
+Proof.
+  intros Hs1 Hs1t Hs2 observer. specialize (Hs1 observer).
+  specialize (Hs1t observer). inv Hs1; inv Hs1t; try contradiction.
+  - left; auto. unfold sem_throw_stmt, interp_imp_inline, interp_asm. cbn. do 2 red.
+    intros σ1 σ2 regs1 regs2 Hσ. rewrite throw_prefix_of_try_catch.
+    setoid_rewrite try_catch_to_throw_prefix.
+    setoid_rewrite throw_prefix_bind.
+    repeat setoid_rewrite interp_state_bind. setoid_rewrite bind_bind.
+    eapply pi_eqit_secure_bind; eauto.
+    intros [ [ ? σ3] r1] [ [ ? σ4] r2] [ [ _ Hσ'] Hr]; inv Hr; cbn;
+      try setoid_rewrite throw_prefix_ret; try setoid_rewrite interp_state_ret;
+        try setoid_rewrite bind_ret_l; cbn.
+    + cbn in H3, H4. subst. cbn. setoid_rewrite throw_prefix_ret. setoid_rewrite interp_state_ret.
+      setoid_rewrite bind_ret_l. cbn. setoid_rewrite interp_state_ret.
+      apply pi_eqit_secure_ret.
+      repeat (split; auto). constructor.
+    + cbn in *. subst. setoid_rewrite interp_state_ret. setoid_rewrite bind_ret_l. cbn. specialize (Hs2 observer). inv Hs2; eauto.
+      eapply pi_sem_throw_stmt_ret_aux; eauto.
+    + specialize (Hs2 observer). inv Hs2; eauto.
+      * exfalso. apply H4. eapply leq_trans_lat; eauto.
+        eapply leq_trans_lat; eauto. apply leq_join_r; auto.
+      * cbn in H5, H6. subst. apply pi_eqit_secure_sym. cbn in H8. do 2 red in H8.
+        setoid_rewrite interp_state_ret. setoid_rewrite throw_prefix_ret. setoid_rewrite interp_state_ret.
+        setoid_rewrite bind_ret_l. cbn. setoid_rewrite interp_state_ret.
+        match goal with
+        |- pi_eqit_secure _ _ _ _ _ _ _ ?t => assert (t ≈ ITree.bind (Ret (r, σ3, tt) ) (fun '(σ, x) => Ret (σ, inl x) ) ) end.
+        rewrite bind_ret_l. reflexivity. rewrite H5.
+        rewrite <- bind_ret_r. symmetry in Hσ'. eapply pi_eqit_secure_bind; eauto.
+        intros [ [ ? σ5] r'] [ [ ? σ6] [] ] Hr. inv Hr. inv H9.
+        -- apply pi_eqit_secure_ret. repeat (split; auto). symmetry. inv H6. auto. cbn in H10. subst.
+           constructor.
+        -- cbn in H12. subst. apply pi_eqit_secure_ret. repeat (split; auto). symmetry. cbn in *. inv H6; auto.
+           constructor; auto.
+    + specialize (Hs2 observer). inv Hs2; eauto.
+      * exfalso. apply H4. eapply leq_trans_lat; eauto.
+        eapply leq_trans_lat; eauto. apply leq_join_r; auto.
+      * cbn in H5, H6. subst. setoid_rewrite throw_prefix_ret. setoid_rewrite interp_state_ret.
+        setoid_rewrite bind_ret_l. cbn.
+        setoid_rewrite interp_state_ret.
+         match goal with
+        |- pi_eqit_secure _ _ _ _ _ _ _ ?t => assert (t ≈ ITree.bind (Ret (r0, σ4, tt) ) (fun '(σ, x) => Ret (σ, inl x) ) ) end.
+        rewrite bind_ret_l. reflexivity. rewrite H5. cbn in H8.
+        rewrite <- bind_ret_r. eapply pi_eqit_secure_bind; eauto.
+        intros [ [ ? σ5] r'] [ [ ? σ6] [] ] Hr. inv Hr. inv H9.
+        -- cbn in H10. subst. apply pi_eqit_secure_ret. repeat (split; auto). constructor.
+        -- cbn in H12. subst. apply pi_eqit_secure_ret. repeat (split; auto).
+           constructor; auto.
+  - right; auto. unfold sem_throw_stmt, interp_imp_inline, interp_asm. cbn. do 2 red.
+    intros σ1 σ2 regs1 regs2 Hσ. rewrite throw_prefix_of_try_catch.
+    rewrite try_catch_to_throw_prefix.
+    rewrite throw_prefix_bind. repeat rewrite interp_state_bind.
+    rewrite bind_bind.
+    setoid_rewrite <- bind_ret_r with (s := Ret (regs2, σ2, tt) ).
+    cbn in H2.
+    eapply pi_eqit_secure_bind; eauto.
+    intros [ [ ? σ3] r1] [ [ ? σ4] r2] [ [ _ Hσ'] Hr]; inv Hr.
+    + cbn in H3. subst. cbn. rewrite throw_prefix_ret, interp_state_ret, bind_ret_l. cbn.
+      rewrite interp_state_ret. apply pi_eqit_secure_ret. repeat (split; auto).
+      constructor.
+    + specialize (Hs2 observer). inv Hs2; eauto.
+      * exfalso. apply H. eapply leq_trans_lat; eauto. apply leq_join_l; auto.
+      * cbn in H4, H5. subst. setoid_rewrite interp_state_ret. rewrite bind_ret_l.
+        cbn. destruct r2. do 2 red in H7. cbn in H7. eauto.
+Qed.
+
+Lemma pi_eqit_secure_while_ret_aux:
+  forall (e : expr) (s : stmt) (observer : label),
+    label_state_pi_sec_eutt Γ observer top2 (sem_stmt s) (ret tt) ->
+    forall (σ1 σ2 : map) (regs1 regs2 : registers),
+      labelled_equiv Γ observer σ1 σ2 ->
+      pi_eqit_secure _ (priv_exc_io sensitivity_lat)
+                     (product_rel (product_rel top2 (labelled_equiv Γ observer)) top2) true true
+                     observer (sem_stmt (While e s) (regs1, σ1)) (Ret (regs2, σ2, tt)).
+Proof.
+  intros e s observer H0 σ1 σ2 regs1 regs2 H3.
+  unfold sem_stmt, interp_imp_inline, interp_asm.
+  cbn. specialize (@interp_state_iter') as Hisi. red in Hisi. setoid_rewrite Hisi.
+  eapply pi_eqit_secure_iter_ret with (Rinv := product_rel (product_rel top2 (labelled_equiv Γ observer)) eq ).
+  2 : repeat (split; auto).
+  intros [ [ ? σ3] [] ] [ [ _ Hσ3] _ ]. cbn.
+  setoid_rewrite interp_state_bind. rewrite bind_bind.
+  specialize (expr_only_ret' e (r, σ3)) as [n Hn]. setoid_rewrite Hn.
+  rewrite bind_ret_l. destruct n.
+  + cbn. rewrite interp_state_ret, bind_ret_l. cbn. apply pi_eqit_secure_ret.
+    constructor. repeat (split; auto).
+  + cbn. rewrite interp_state_bind. rewrite bind_bind.
+    rewrite <- (bind_ret_r (Ret (regs2, σ2, tt))).
+    cbn in H0.
+    eapply pi_eqit_secure_bind; eauto.
+    intros [ [ ? σ4] [] ] [ [ ? σ5] [] ] [ [ _ Hσ'] _ ]. rewrite interp_state_ret, bind_ret_l. cbn.
+    apply pi_eqit_secure_ret. constructor. repeat (split; auto).
+Qed.
+
+Lemma pi_eqit_secure_while_ret_throw_aux:
+  forall (e : expr) (s : stmt) (observer lexn : label),
+    label_state_pi_sec_eutt Γ observer (fun (sum : unit + label) (_ : unit) => Rsense_unpriv observer lexn sum)
+                            (sem_throw_stmt s) (ret tt) ->
+    forall (σ1 σ2 : map) (regs1 regs2 : registers),
+      labelled_equiv Γ observer σ1 σ2 ->
+      pi_eqit_secure _ (priv_exc_io sensitivity_lat)
+                     (product_rel (product_rel top2 (labelled_equiv Γ observer))
+                                  (fun (sum : unit + label) (_ : unit) => Rsense_unpriv observer lexn sum)) true true observer
+                     (sem_throw_stmt (While e s) (regs1, σ1)) (Ret (regs2, σ2, tt)).
+Proof.
+  intros e s observer lexn H0 σ1 σ2 regs1 regs2 Hσ.
+  unfold sem_throw_stmt, interp_imp_inline, interp_asm.
+  cbn. setoid_rewrite throw_prefix_iter.
+  specialize (@interp_state_iter') as Hisi. red in Hisi. setoid_rewrite Hisi.
+  apply pi_eqit_secure_iter_ret with (Rinv := product_rel (product_rel top2 (labelled_equiv Γ observer)) eq).
+  2 : repeat (split; auto).
+  intros [ [ ? σ3] [] ] [ [ _ Hσ3] _ ]. cbn. cbn in Hσ3. setoid_rewrite throw_prefix_bind.
+  repeat setoid_rewrite interp_state_bind. repeat rewrite bind_bind.
+  rewrite throw_prefix_denote_expr. rewrite interp_state_bind, bind_bind.
+  specialize (expr_only_ret' e (r, σ3)) as [n Hn].
+  setoid_rewrite Hn.
+  rewrite bind_ret_l, interp_state_ret, bind_ret_l. cbn.
+  destruct n.
+  + rewrite throw_prefix_ret, interp_state_ret, bind_ret_l. cbn.
+    rewrite interp_state_ret. rewrite bind_ret_l. cbn.
+    apply pi_eqit_secure_ret. constructor. repeat (split; auto).
+    constructor.
+  + rewrite throw_prefix_bind. rewrite interp_state_bind. rewrite bind_bind.
+    rewrite <- (bind_ret_r (Ret (regs2, σ2, tt))).
+    cbn in H0.
+    eapply pi_eqit_secure_bind; eauto.
+    intros [ [ ? σ4] r1] [ [ ? σ5] r2'] [ [ _ Hσ'] Hr]; inv Hr.
+     * cbn in H. subst. tau_steps. apply pi_eqit_secure_ret.
+      constructor; auto. repeat (split; auto). destruct r2'. auto.
+    * cbn in H2. subst. tau_steps.
+      apply pi_eqit_secure_ret. constructor. repeat (split; auto). constructor; auto.
+Qed.
+
+Lemma while_well_typed_correct e le pc lexn s :
+  secure_expr le e -> secure_stmt (join pc (join le lexn)) lexn s -> secure_stmt pc lexn (While e s).
+Proof.
+  intros He Hs observer.
+  specialize (He observer). specialize (Hs observer).
+  inv Hs; inv He.
+  - left. eapply leq_trans_lat; try apply H; auto. apply leq_join_l; auto.
+    do 2 red. intros σ1 σ2 regs1 regs2 Hσ. unfold sem_stmt, interp_imp_inline, interp_asm. cbn.
+    specialize (@interp_state_iter') as Hisi. red in Hisi. setoid_rewrite Hisi.
+    apply secure_eqit_iter with (RA := product_rel (product_rel top2 (labelled_equiv Γ observer)) eq );
+      auto.
+    clear σ1 σ2 Hσ. intros [ [ ? σ1] [] ] [ [ ? σ2] [] ] [ [ _ Hσ] _ ].
+    cbn. setoid_rewrite interp_state_bind. repeat rewrite bind_bind.
+    eapply pi_eqit_secure_bind; eauto.
+    intros [ [ ? σ3] v1] [ [ ? σ4] v2] [ [ _ Hσ'] Hv]; cbn in Hv; subst. cbn.
+    destruct v2.
+    + setoid_rewrite interp_state_ret. setoid_rewrite bind_ret_l.
+      cbn. apply pi_eqit_secure_ret. constructor. repeat (split; auto).
+    + setoid_rewrite interp_state_bind. setoid_rewrite bind_bind.
+      eapply pi_eqit_secure_bind; eauto.
+      intros [ [ ? σ5] [] ] [ [ ? σ6] [] ] [ [ _ Hσ''] _ ]. setoid_rewrite interp_state_ret.
+      setoid_rewrite bind_ret_l. cbn. apply pi_eqit_secure_ret.
+      constructor; repeat (split; auto).
+    + repeat (split; auto).
+  - exfalso. apply H1.
+    eapply leq_trans_lat with (l2 := join_sense le lexn); eauto.
+    apply leq_join_l; auto.
+    eapply leq_trans_lat; try apply leq_join_r; auto. eauto.
+  - case_leq pc observer.
+    + left; auto. intros σ1 σ2 regs1 regs2 Hσ.
+      specialize (pi_eqit_secure_while_ret_aux e s observer H0) as Hwhile.
+      eapply pi_sem_stmt_ret_aux; eauto.
+    + right; auto. cbn. do 2 red. intros. eapply pi_eqit_secure_while_ret_aux; eauto.
+  - case_leq pc observer.
+    + left; auto. intros σ1 σ2 regs1 regs2 Hσ.
+      specialize (pi_eqit_secure_while_ret_aux e s observer H0) as Hwhile.
+      eapply pi_sem_stmt_ret_aux; eauto.
+    + right; auto. cbn. do 2 red. intros. eapply pi_eqit_secure_while_ret_aux; eauto.
+Qed.
+
+
+
+Lemma while_well_typed_correct' e le pc lexn s :
+  secure_expr le e -> secure_throw_stmt (join pc (join le lexn)) lexn s -> secure_throw_stmt pc lexn (While e s).
+Proof.
+  intros He Hs observer.
+  specialize (He observer). specialize (Hs observer).
+  inv Hs; inv He.
+  - left. eapply leq_trans_lat; try apply H; auto. apply leq_join_l; auto.
+    do 2 red. intros σ1 σ2 regs1 regs2 Hσ. unfold sem_throw_stmt, interp_imp_inline, interp_asm. cbn.
+    setoid_rewrite throw_prefix_iter.
+    specialize (@interp_state_iter') as Hisi. red in Hisi. setoid_rewrite Hisi.
+    eapply secure_eqit_iter with (RA := product_rel (product_rel top2 (labelled_equiv Γ observer)) eq ); auto.
+    intros [ [ ? σ3] [] ] [ [ ? σ4] [] ] [ [ _ Hσ'] _ ]. cbn. setoid_rewrite throw_prefix_bind.
+    repeat setoid_rewrite interp_state_bind. repeat rewrite bind_bind.
+    setoid_rewrite throw_prefix_denote_expr. setoid_rewrite interp_state_bind.
+    setoid_rewrite bind_bind.
+    eapply pi_eqit_secure_bind; eauto. intros [ [ ? σ5] v1] [ [ ? σ6] v2] [ [ _ Hσ''] Hv]; cbn in Hv; subst.
+    setoid_rewrite interp_state_ret. setoid_rewrite bind_ret_l. cbn.
+    destruct v2; cbn.
+    + setoid_rewrite throw_prefix_ret. tau_steps.
+      apply pi_eqit_secure_ret. constructor. repeat (split; auto). constructor.
+    + setoid_rewrite throw_prefix_bind. setoid_rewrite interp_state_bind.
+      setoid_rewrite bind_bind.
+      eapply pi_eqit_secure_bind; eauto.
+      intros [ [ ? σ7] r1'] [ [ ? σ8] r2'] [ [ _ Hσ'''] Hr]. cbn in Hr. inv Hr.
+      * setoid_rewrite throw_prefix_ret. tau_steps.
+        apply pi_eqit_secure_ret. constructor. repeat (split; auto).
+      * tau_steps. apply pi_eqit_secure_ret. constructor. repeat (split; auto).
+        constructor; auto.
+      * exfalso. apply H4.
+        eapply leq_trans_lat; eauto.
+        eapply leq_trans_lat; try apply H; auto.
+        eapply leq_trans_lat with (l2 := join_sense le lexn); eauto.
+        apply leq_join_r; auto. apply leq_join_r; auto.
+      * exfalso.  apply H4.
+        eapply leq_trans_lat; eauto.
+        eapply leq_trans_lat; try apply H; auto.
+        eapply leq_trans_lat with (l2 := join_sense le lexn); eauto.
+        apply leq_join_r; auto. apply leq_join_r; auto.
+    + repeat (split; auto).
+  - exfalso. apply H1. eapply leq_trans_lat; eauto.
+    eapply leq_trans_lat with (l2 := join_sense le lexn); auto.
+    apply leq_join_l; auto. apply leq_join_r; auto.
+  - case_leq pc observer.
+    + left; auto. intros σ1 σ2 regs1 regs2 Hσ.
+      specialize (pi_eqit_secure_while_ret_throw_aux e s observer) as Hwhile.
+      eapply pi_sem_throw_stmt_ret_aux; eauto.
+    + right; auto. cbn. intros σ1 σ2 regs1 regs2 Hσ.
+      eapply pi_eqit_secure_while_ret_throw_aux; eauto.
+  - case_leq pc observer.
+    + left; auto. intros σ1 σ2 regs1 regs2 Hσ.
+      specialize (pi_eqit_secure_while_ret_throw_aux e s observer) as Hwhile.
+      eapply pi_sem_throw_stmt_ret_aux; eauto.
+    + right; auto. cbn. intros σ1 σ2 regs1 regs2 Hσ.
+      eapply pi_eqit_secure_while_ret_throw_aux; eauto.
+Qed.
+
+Lemma if_well_typed_correct e le pc lexn1 lexn2 s1 s2 :
+  secure_expr le e -> secure_stmt (join pc le) lexn1 s1 ->
+  secure_stmt (join pc le) lexn2 s2 ->
+  secure_stmt pc (join lexn1 lexn2) (If e s1 s2).
+Proof.
+  intros He Hs1 Hs2 observer.
+  specialize (Hs1 observer). specialize (Hs2 observer).
+  specialize (He observer).
+  inv Hs1; inv Hs2; inv He; try contradiction.
+  - left; auto. eapply leq_trans_lat with (l2 := join_sense pc le);  eauto.
+    apply leq_join_l; auto.
+    intros σ1 σ2 regs1 regs2 Hσ. unfold sem_stmt, interp_imp_inline, interp_asm.
+    cbn. setoid_rewrite interp_state_bind.
+    eapply pi_eqit_secure_bind; eauto.
+    intros [ [ ? σ3] v1] [ [ ? σ4] v2] [ [ _ Hσ'] Hv]; cbn in Hv; subst.
+    destruct v2; cbn; eauto.
+  - exfalso. apply H3. eapply leq_trans_lat; eauto.
+    apply leq_join_r; auto.
+  - right. intro. apply H. apply leq_join_lub; auto.
+    intros σ1 σ2 regs1 regs2 Hσ. unfold sem_stmt, interp_imp_inline. cbn.
+    setoid_rewrite interp_state_bind.
+    specialize (expr_only_ret' e (regs1, σ1)) as [n Hn]. setoid_rewrite Hn.
+    rewrite bind_ret_l. destruct n; cbn in *; eauto.
+  - case_leq pc observer.
+    + left; auto. intros σ1 σ2 regs1 regs2 Hσ. unfold sem_stmt, interp_imp_inline. cbn.
+      setoid_rewrite interp_state_bind.
+      specialize (expr_only_ret' e (regs1, σ1)) as [n1 Hn1]. setoid_rewrite Hn1.
+      specialize (expr_only_ret' e (regs2, σ2)) as [n2 Hn2]. setoid_rewrite Hn2.
+      setoid_rewrite bind_ret_l.
+      destruct n1; destruct n2; cbn;
+        eapply pi_sem_stmt_ret_aux; eauto.
+    + right; auto.
+      intros σ1 σ2 regs1 regs2 Hσ. unfold sem_stmt, interp_imp_inline, interp_asm. cbn.
+      setoid_rewrite interp_state_bind.
+      specialize (expr_only_ret' e (regs1, σ1)) as [n1 Hn1]. setoid_rewrite Hn1.
+      rewrite bind_ret_l. destruct n1; cbn in *; eauto.
+Qed.
+
+Lemma if_well_typed_correct' e le pc lexn1 lexn2 s1 s2 :
+  secure_expr le e -> secure_throw_stmt (join pc le) lexn1 s1 ->
+  secure_throw_stmt (join pc le) lexn2 s2 ->
+  secure_throw_stmt pc (join lexn1 lexn2) (If e s1 s2).
+Proof.
+  intros He Hs1 Hs2 observer.
+  specialize (Hs1 observer). specialize (Hs2 observer).
+  specialize (He observer).
+  inv Hs1; inv Hs2; inv He; try contradiction.
+  - left; auto. eapply leq_trans_lat with (l2 := join_sense pc le);  eauto.
+    apply leq_join_l; auto.
+    unfold sem_throw_stmt, interp_imp_inline, interp_asm. intros σ1 σ2 regs1 regs2 Hσ.
+    cbn. setoid_rewrite throw_prefix_bind.
+    rewrite throw_prefix_denote_expr.
+    repeat setoid_rewrite interp_state_bind.
+    repeat setoid_rewrite bind_bind.
+    eapply pi_eqit_secure_bind; eauto.
+    intros [ [ ? σ3] v1] [ [ ? σ4] v2] [ [ _ Hσ'] Hv]; cbn in Hv; subst.
+    setoid_rewrite interp_state_ret. setoid_rewrite bind_ret_l.
+    cbn. destruct v2; eauto.
+    eapply lower_lexn_sound; eauto. apply leq_join_r; auto.
+    eapply lower_lexn_sound; eauto. apply leq_join_l; auto.
+  - exfalso. apply H3. eapply leq_trans_lat; eauto. apply leq_join_r; auto.
+  - right. intro. apply H.
+    apply leq_join_lub; auto.
+    intros σ1 σ2 regs1 regs2 Hσ. unfold sem_throw_stmt, interp_imp_inline, interp_asm.
+    cbn. setoid_rewrite throw_prefix_bind.
+    setoid_rewrite throw_prefix_denote_expr.
+    repeat rewrite interp_state_bind. repeat rewrite bind_bind.
+    specialize (expr_only_ret' e (regs1, σ1)) as [n1 Hn1]. setoid_rewrite Hn1.
+    rewrite bind_ret_l. rewrite interp_state_ret, bind_ret_l.
+    cbn.
+    destruct n1; cbn in *; eapply lower_lexn_sound'; eauto.
+    apply leq_join_r; auto. apply leq_join_l; auto.
+  - case_leq pc observer.
+    + left; auto. intros σ1 σ2 regs1 regs2 Hσ. unfold sem_throw_stmt, interp_imp_inline, interp_asm.
+      cbn. setoid_rewrite throw_prefix_bind. setoid_rewrite interp_state_bind.
+      setoid_rewrite throw_prefix_denote_expr. setoid_rewrite interp_state_bind.
+      repeat rewrite bind_bind.
+      specialize (expr_only_ret' e (regs1, σ1)) as [n1 Hn1]. setoid_rewrite Hn1.
+      specialize (expr_only_ret' e (regs2, σ2)) as [n2 Hn2]. setoid_rewrite Hn2.
+      setoid_rewrite bind_ret_l. setoid_rewrite interp_state_ret.
+      setoid_rewrite bind_ret_l. cbn.
+      assert (label_state_pi_sec_eutt Γ observer
+         (fun (sum : unit + label) (_ : unit) => Rsense_unpriv observer (join lexn1 lexn2) sum)
+         (sem_throw_stmt s1) (ret tt)).
+      { do 2 red. intros. eapply lower_lexn_sound'; eauto. apply leq_join_l; auto. }
+      assert (label_state_pi_sec_eutt Γ observer
+         (fun (sum : unit + label) (_ : unit) => Rsense_unpriv observer (join lexn1 lexn2) sum)
+         (sem_throw_stmt s2) (ret tt)).
+      { do 2 red. intros. eapply lower_lexn_sound'; eauto. apply leq_join_r; auto. }
+      destruct n1; destruct n2; cbn in *; try eapply pi_sem_throw_stmt_ret_aux; eauto.
+   + right; auto.
+     intros σ1 σ2 regs1 regs2 Hσ. unfold sem_throw_stmt, interp_imp_inline, interp_asm. cbn.
+     setoid_rewrite throw_prefix_bind. setoid_rewrite throw_prefix_denote_expr.
+     repeat rewrite interp_state_bind. repeat rewrite bind_bind.
+     specialize (expr_only_ret' e (regs1, σ1)) as [n1 Hn1]. setoid_rewrite Hn1.
+     rewrite bind_ret_l. rewrite interp_state_ret, bind_ret_l. cbn.
+     destruct n1; try eapply lower_lexn_sound'; cbn in *; eauto.
+     destruct lexn1; destruct lexn2; auto. destruct lexn1; destruct lexn2; auto.
+Qed.
+
+Lemma secure_expr_upward_close
+     : forall (e : expr) (l1 l2 : L),
+       leq l1 l2 -> secure_expr l1 e -> secure_expr l2 e.
+Proof.
+  intros e l1 l2 Hl He observer.
+  specialize (He observer). inv He.
+  - case_leq l2 observer.
+    + left; auto.
+    + right; auto.
+      exists 0. do 2 red. intros. cbn.
+      specialize (expr_only_ret' e (regs1, σ1)) as [n Hn]. rewrite Hn.
+      apply pi_eqit_secure_ret. repeat (split; auto).
+  - case_leq l2 observer.
+    + left; auto. exfalso. apply H. eapply leq_trans_lat; eauto.
+    + right; auto.
+Qed.
+
+Lemma assign_well_typed_correct e le pc x :
+  secure_expr le e -> leq (join le pc) (Γ x) ->
+  secure_stmt pc bot (Assign x e).
+Proof.
+  intros Hle Hx.
+  assert (Hpc : leq pc (Γ x) ).
+  { eapply leq_trans_lat; eauto. apply leq_join_r; auto. }
+  assert (Hl : leq le (Γ x) ).
+  { eapply leq_trans_lat; try apply H5; auto. apply leq_join_l; auto. eauto. }
+  assert (He : secure_expr (Γ x) e ).
+  { eapply secure_expr_upward_close with (l2:= Γ x); eauto. }
+  intros observer.
+  specialize ( He observer). inv He.
+  - left. eapply leq_trans_lat; eauto.
+    do 2 red in H0. do 2 red. intros. unfold sem_stmt.
+    cbn. unfold interp_imp_inline, interp_asm.
+    setoid_rewrite interp_state_bind. eapply pi_eqit_secure_bind; eauto.
+    intros [ [ ? σ3] v1] [ [ ? σ4] v2] [ [ _ Hσ] Hv]; cbn in Hv; subst.
+    setoid_rewrite interp_state_trigger. cbn. apply pi_eqit_secure_ret.
+    repeat (split; auto). cbn. eapply update_labelled_equiv_visible; auto.
+  - case_leq pc observer.
+    + left; auto.
+      destruct H0 as [n Hn]. unfold sem_stmt.
+      cbn. unfold interp_imp_inline, interp_asm. do 2 red. intros. setoid_rewrite interp_state_bind.
+      specialize (expr_only_ret' e (regs1, σ1)) as [n1 Hn1]. setoid_rewrite Hn1.
+      specialize (expr_only_ret' e (regs2, σ2)) as [n2 Hn2]. setoid_rewrite Hn2.
+      setoid_rewrite bind_ret_l. cbn. setoid_rewrite interp_state_trigger.
+      cbn. apply pi_eqit_secure_ret. repeat (split; auto).
+      cbn. apply update_labelled_equiv_invisible; auto. symmetry.
+      apply update_labelled_equiv_invisible; auto. symmetry; auto.
+    + right; auto.
+      unfold sem_stmt, interp_imp_inline, interp_asm. cbn. intros σ1 σ2 regs1 regs2 Hσ.
+      setoid_rewrite interp_state_bind.
+      specialize (expr_only_ret' e (regs1, σ1)) as [n1 Hn1]. setoid_rewrite Hn1.
+      rewrite bind_ret_l. setoid_rewrite interp_state_trigger.
+      cbn. apply pi_eqit_secure_ret. repeat (split; auto).
+      cbn. apply update_labelled_equiv_invisible; auto.
+Qed.
+
+Lemma assign_well_typed_correct' e le pc x :
+  secure_expr le e -> leq (join le pc) (Γ x) ->
+  secure_throw_stmt pc bot (Assign x e).
+Proof.
+  intros Hle Hx.
+  assert (Hpc : leq pc (Γ x) ).
+  { eapply leq_trans_lat; eauto. apply leq_join_r; auto. }
+  assert (Hl : leq le (Γ x) ).
+  { eapply leq_trans_lat; try apply H5; auto. apply leq_join_l; auto. eauto. }
+  assert (He : secure_expr (Γ x) e ).
+  { eapply secure_expr_upward_close with (l2:= Γ x); eauto. }
+  intros observer.
+  specialize ( He observer). inv He.
+  - left. eapply leq_trans_lat; eauto.
+    do 2 red in H0. do 2 red. intros. unfold sem_throw_stmt.
+    cbn. unfold interp_imp_inline, interp_asm. setoid_rewrite throw_prefix_bind.
+    setoid_rewrite throw_prefix_denote_expr.
+    setoid_rewrite interp_state_bind.
+    setoid_rewrite interp_state_bind. repeat rewrite bind_bind.
+    eapply pi_eqit_secure_bind; eauto.
+    intros [ [ ? σ3] v1] [ [ ? σ4] v2] [ [ _ Hσ] Hv]; cbn in Hv; subst.
+    setoid_rewrite interp_state_ret. setoid_rewrite bind_ret_l. cbn.
+    setoid_rewrite throw_prefix_ev.
+    setoid_rewrite interp_state_vis. cbn.
+    setoid_rewrite bind_ret_l. tau_steps.
+    apply pi_eqit_secure_ret.
+    repeat (split; auto). cbn. eapply update_labelled_equiv_visible; auto.
+    constructor.
+  - case_leq pc observer.
+    + left; auto.
+      destruct H0 as [n Hn]. unfold sem_throw_stmt.
+      cbn. unfold interp_imp_inline, interp_asm. do 2 red. intros.
+      setoid_rewrite throw_prefix_bind. setoid_rewrite throw_prefix_denote_expr.
+      repeat setoid_rewrite interp_state_bind.
+      specialize (expr_only_ret' e (regs1, σ1)) as [n1 Hn1]. setoid_rewrite Hn1.
+      specialize (expr_only_ret' e (regs2, σ2)) as [n2 Hn2]. setoid_rewrite Hn2.
+      repeat rewrite bind_ret_l. tau_steps.
+      apply pi_eqit_secure_ret. repeat (split; auto).
+      cbn. apply update_labelled_equiv_invisible; auto. symmetry.
+      apply update_labelled_equiv_invisible; auto. symmetry; auto.
+      constructor.
+    + right; auto.
+      unfold sem_throw_stmt, interp_imp_inline, interp_asm. cbn. intros σ1 σ2 regs1 regs2 Hσ.
+      setoid_rewrite throw_prefix_bind.
+      setoid_rewrite interp_state_bind. rewrite throw_prefix_denote_expr.
+      setoid_rewrite interp_state_bind.
+      specialize (expr_only_ret' e (regs1, σ1)) as [n1 Hn1]. setoid_rewrite Hn1.
+      tau_steps.
+      apply pi_eqit_secure_ret.
+      repeat (split; auto). 2 : constructor. cbn. apply update_labelled_equiv_invisible; auto.
+Qed.
+
+
+Lemma print_well_typed_correct pc le lp e :
+  secure_expr le e -> leq (join le pc) lp ->
+  secure_stmt pc bot (Output lp e).
+Proof.
+  intros He0 Hle1.
+  assert (Hle : leq le lp).
+  { eapply leq_trans_lat; eauto. apply leq_join_l; auto. }
+  assert (Hpc : leq pc lp).
+  { eapply leq_trans_lat; try apply H5; auto. apply leq_join_r; eauto. eauto.  }
+  assert (He : secure_expr lp e ).
+  { eapply secure_expr_upward_close with (l1 := le); eauto. }
+  intros observer. specialize (He observer).
+  inv He.
+  - left. eapply leq_trans_lat; eauto.
+    unfold sem_stmt, interp_imp_inline, interp_asm. intros σ1 σ2 regs1 regs2 Hσ.
+    cbn. setoid_rewrite interp_state_bind.
+    eapply pi_eqit_secure_bind; eauto.
+    intros [ [ ? σ3] v1] [ [ ? σ4] v4] [ [ _ Hσ'] Hv]; cbn in Hv; subst.
+    cbn. setoid_rewrite interp_state_trigger. cbn.
+    setoid_rewrite bind_trigger. apply pi_eqit_secure_pub_vis.
+    auto. intros []. apply pi_eqit_secure_ret. repeat (split; auto).
+  - case_leq pc observer.
+    + left; auto. unfold sem_stmt, interp_imp_inline, interp_asm. intros σ1 σ2 regs1 regs2 Hσ.
+      cbn. setoid_rewrite interp_state_bind.
+      specialize (expr_only_ret' e (regs1, σ1)) as [n1 Hn1]. setoid_rewrite Hn1.
+      specialize (expr_only_ret' e (regs2, σ2)) as [n2 Hn2]. setoid_rewrite Hn2.
+      setoid_rewrite bind_ret_l. setoid_rewrite interp_state_trigger.
+      cbn. setoid_rewrite bind_trigger. apply pi_eqit_secure_priv_vislr; auto.
+      intros [] []. apply pi_eqit_secure_ret. repeat (split; auto).
+    + right; auto. unfold sem_stmt, interp_imp_inline, interp_asm. intros σ1 σ2 regs1 regs2 Hσ.
+      cbn. setoid_rewrite interp_state_bind.
+      specialize (expr_only_ret' e (regs1, σ1)) as [n1 Hn1]. setoid_rewrite Hn1.
+      rewrite bind_ret_l. rewrite interp_state_trigger. cbn. rewrite bind_trigger.
+      apply pi_eqit_secure_priv_visl; auto. intros [].
+      apply pi_eqit_secure_ret. repeat (split; auto).
+Qed.
+
+Lemma print_well_typed_correct' pc le lp e :
+  secure_expr le e -> leq (join le pc) lp ->
+  secure_throw_stmt pc bot (Output lp e).
+Proof.
+  intros He0 Hle1.
+  assert (Hle : leq le lp).
+  { eapply leq_trans_lat; eauto. apply leq_join_l; auto. }
+  assert (Hpc : leq pc lp).
+  { eapply leq_trans_lat; try apply H5; auto. apply leq_join_r; eauto. eauto.  }
+  assert (He : secure_expr lp e ).
+  { eapply secure_expr_upward_close with (l1 := le); eauto. }
+  intros observer. specialize (He observer).
+  inv He.
+  - left. eapply leq_trans_lat; eauto.
+    unfold sem_throw_stmt, interp_imp_inline, interp_asm. intros σ1 σ2 regs1 regs2 Hσ.
+    cbn. setoid_rewrite throw_prefix_bind. setoid_rewrite interp_state_bind.
+    setoid_rewrite throw_prefix_denote_expr. setoid_rewrite interp_state_bind.
+    repeat rewrite bind_bind.
+    eapply pi_eqit_secure_bind; eauto.
+    intros [ [ ? σ3] v1] [ [ ? σ4] v4] [ [ _ Hσ'] Hv]; cbn in Hv; subst.
+    setoid_rewrite interp_state_ret. setoid_rewrite bind_ret_l.
+    cbn. setoid_rewrite throw_prefix_ev. setoid_rewrite interp_state_vis.
+    cbn. setoid_rewrite bind_trigger. setoid_rewrite bind_vis.
+    apply pi_eqit_secure_pub_vis; auto. intros [].
+    setoid_rewrite bind_ret_l. setoid_rewrite throw_prefix_ret.
+    tau_steps. apply pi_eqit_secure_ret. repeat (split; auto); constructor.
+  - case_leq pc observer.
+    + left; auto. unfold sem_throw_stmt, interp_imp_inline, interp_asm. intros σ1 σ2 regs1 regs2 Hσ.
+      cbn. setoid_rewrite throw_prefix_bind.
+      setoid_rewrite throw_prefix_denote_expr.
+      repeat setoid_rewrite interp_state_bind.
+      repeat rewrite bind_bind.
+      specialize (expr_only_ret' e (regs1, σ1)) as [n1 Hn1]. setoid_rewrite Hn1.
+      specialize (expr_only_ret' e (regs2, σ2)) as [n2 Hn2]. setoid_rewrite Hn2.
+      setoid_rewrite bind_ret_l.
+      setoid_rewrite interp_state_ret. setoid_rewrite bind_ret_l. cbn.
+      setoid_rewrite throw_prefix_ev.
+      setoid_rewrite interp_state_vis.
+      cbn. setoid_rewrite bind_trigger.
+      setoid_rewrite bind_vis.
+      apply pi_eqit_secure_priv_vislr; auto.
+      intros [] []. tau_steps. apply pi_eqit_secure_ret. repeat (split; auto). constructor.
+    + right; auto. unfold sem_throw_stmt, interp_imp_inline, interp_asm. intros σ1 σ2 regs1 regs2 Hσ.
+      cbn.
+      setoid_rewrite throw_prefix_bind. setoid_rewrite interp_state_bind.
+      setoid_rewrite throw_prefix_denote_expr.
+      setoid_rewrite interp_state_bind.
+      specialize (expr_only_ret' e (regs1, σ1)) as [n1 Hn1]. setoid_rewrite Hn1.
+      repeat rewrite bind_ret_l.
+      rewrite interp_state_ret. rewrite bind_ret_l. cbn.
+      setoid_rewrite throw_prefix_ev.
+      rewrite interp_state_vis. cbn. rewrite bind_trigger.
+      rewrite bind_vis.
+      apply pi_eqit_secure_priv_visl; auto. intros [].
+      tau_steps.
+      apply pi_eqit_secure_ret. repeat (split; auto). constructor.
+Qed.
+
+Lemma skip_well_typed_correct pc :
+  secure_stmt pc bot Skip.
+Proof.
+  intros observer. case_leq pc observer.
+  - left; auto. do 2 red. unfold sem_stmt. intros σ1 σ2 regs1 regs2 Hσ.
+    cbn. setoid_rewrite interp_state_ret. apply pi_eqit_secure_ret.
+    repeat (split; auto).
+  - right; auto. do 2 red. unfold sem_stmt. intros σ1 σ2 regs1 regs2 Hσ.
+    cbn. setoid_rewrite interp_state_ret. apply pi_eqit_secure_ret.
+    repeat (split; auto).
+Qed.
+
+Lemma skip_well_typed_correct' pc :
+  secure_throw_stmt pc bot Skip.
+Proof.
+  intros observer. case_leq pc observer.
+  - left; auto. do 2 red. unfold sem_throw_stmt. intros σ1 σ2 regs1 regs2 Hσ.
+    cbn. setoid_rewrite throw_prefix_ret.
+    setoid_rewrite interp_state_ret. apply pi_eqit_secure_ret.
+    repeat (split; auto). constructor.
+  - right; auto. do 2 red. unfold sem_throw_stmt. intros σ1 σ2 regs1 regs2 Hσ.
+    cbn. setoid_rewrite throw_prefix_ret.
+    setoid_rewrite interp_state_ret. apply pi_eqit_secure_ret.
+    repeat (split; auto). constructor.
+Qed.
+
+Lemma raise_well_typed pc lexn :
+  leq pc lexn -> secure_stmt pc lexn (Raise lexn).
+Proof.
+  intros Hpc observer. case_leq pc observer.
+  - left; auto. unfold sem_stmt, interp_imp. do 2 red. intros.
+    cbn. setoid_rewrite bind_trigger. setoid_rewrite interp_state_vis.
+    cbn. setoid_rewrite bind_trigger. setoid_rewrite bind_vis.
+    case_leq lexn observer.
+    + apply pi_eqit_secure_pub_vis. auto. intros [].
+    + apply pi_eqit_secure_priv_vislr; auto. intros [].
+  - right; auto. unfold sem_stmt, interp_imp. do 2 red. intros.
+    cbn. setoid_rewrite bind_trigger. setoid_rewrite interp_state_vis.
+    cbn. setoid_rewrite bind_trigger. setoid_rewrite bind_vis.
+    apply pi_eqit_secure_priv_visl. 2 : intros []. intro.
+    apply Hnleq. eapply leq_trans_lat; eauto.
+Qed.
+
+Lemma raise_well_typed' pc lexn :
+  leq pc lexn -> secure_throw_stmt pc lexn (Raise lexn).
+Proof.
+  intros Hpc observer. case_leq pc observer.
+  - left; auto. unfold sem_throw_stmt, interp_imp_inline, interp_asm.
+    cbn. do 2 red. intros. setoid_rewrite bind_trigger.
+    setoid_rewrite throw_prefix_exc. setoid_rewrite interp_state_ret.
+    apply pi_eqit_secure_ret; auto. repeat split; auto. constructor.
+    all : eapply leq_refl_lat; auto.
+  - right; auto. do 2 red. intros. unfold sem_throw_stmt, interp_imp_inline, interp_asm.
+    cbn. setoid_rewrite bind_trigger.
+    setoid_rewrite throw_prefix_exc. setoid_rewrite interp_state_ret.
+    apply pi_eqit_secure_ret. repeat (split; auto).
+    constructor. 2 : apply leq_refl_lat; auto.
+    intro.
+    apply Hnleq. eapply leq_trans_lat; eauto.
+Qed.
+
+Definition well_typed_expr := LabelledImpInlineTypes.well_typed_expr Γ.
+
+
+(* rework this definition to have only public exceptions*)
+Inductive well_typed_stmt : label -> label -> stmt -> Prop :=
+  | wts_manual pc lexn s : secure_stmt pc lexn s /\ secure_throw_stmt pc lexn s /\ valid_stmt s ->
+                           well_typed_stmt pc lexn s
+  | wts_skip pc : well_typed_stmt pc bot Skip
+  | wts_seq pc lexn1 lexn2 s1 s2 : well_typed_stmt pc lexn1 s1 -> well_typed_stmt (join pc lexn1) lexn2 s2 ->
+                                   well_typed_stmt pc (join lexn1 lexn2) (Seq s1 s2)
+  | wts_assign pc l x e : well_typed_expr l e -> leq (join l pc) (Γ x) ->
+                          well_typed_stmt pc bot (Assign x e)
+  | wts_print pc le lp e : well_typed_expr le e -> leq (join le pc) lp ->
+                           well_typed_stmt pc bot (Output lp e)
+  | wts_if pc le e lexn1 lexn2 s1 s2 : well_typed_expr le e -> well_typed_stmt (join pc le) lexn1 s1 -> well_typed_stmt (join pc le) lexn2 s2 ->
+                                       well_typed_stmt pc (join lexn1 lexn2) (If e s1 s2)
+  | wts_while e le pc lexn s : well_typed_expr le e -> well_typed_stmt (join pc (join le lexn)) lexn s ->
+                         well_typed_stmt pc lexn (While e s)
+  | wts_raise pc lexn : leq pc lexn -> well_typed_stmt pc lexn (Raise lexn)
+  | wts_try pc lexn1 lexn2 s1 s2 : well_typed_stmt pc lexn1 s1 -> well_typed_stmt (join pc lexn1) lexn2 s2 ->
+                                   well_typed_stmt pc lexn2 (TryCatch s1 s2)
+.
+
+Lemma well_typed_expr_correct e l :
+  well_typed_expr l e -> secure_expr l e.
+Proof.
+  intros He observer.
+  apply well_typed_expr_correct in He; auto.
+  specialize (He observer). inv He.
+  - left; auto. do 2 red. intros. eapply eqit_secure_imp_pi_eqit_scure; eauto.
+  - right; auto. destruct H0 as [n Hn]. exists n.
+    do 2 red. intros. eapply eqit_secure_imp_pi_eqit_scure; eauto.
+Qed.
+
+
+Lemma well_typed_stmt_sound pc s lexn : well_typed_stmt pc lexn s -> secure_stmt pc lexn s.
+Proof.
+  intros Htype. enough (secure_stmt pc lexn  s/\ secure_throw_stmt pc lexn s); try tauto.
+  induction Htype; eauto; try tauto.
+  - (* Skip *) split; try apply skip_well_typed_correct; try apply skip_well_typed_correct'.
+  - (* Seq *)
+    split; try apply seq_well_typed_correct; try apply seq_well_typed_correct'; tauto.
+  - (* Assign *)
+    split; try eapply assign_well_typed_correct; try eapply assign_well_typed_correct';
+      try apply well_typed_expr_correct; eauto.
+  - (* Output *)
+    split; try eapply print_well_typed_correct; try eapply print_well_typed_correct';
+      try apply well_typed_expr_correct; eauto.
+  - (* If *)
+    apply well_typed_expr_correct in H.
+    split; try eapply if_well_typed_correct; try eapply if_well_typed_correct'; eauto; try tauto.
+  - (* While *)
+    destruct IHHtype. apply well_typed_expr_correct in H.
+    split; try eapply while_well_typed_correct; try eapply while_well_typed_correct'; eauto.
+  - (* Raise *)
+    split; try eapply raise_well_typed; try eapply raise_well_typed'; eauto.
+  - (* TryCatch *)
+    destruct IHHtype1. destruct IHHtype2.
+    split; try eapply try_catch_well_typed_correct; try eapply try_catch_well_typed_correct'; eauto.
+Qed.
+
+Lemma well_typed_stmt_valid pc s lexn : well_typed_stmt pc lexn s -> valid_stmt s.
+Proof.
+  intros Htype. induction Htype; try tauto; constructor; eauto.
+Qed.
+
+Lemma secure_stmt_lower_pc:
+  forall (pc2 : label) lexn (s : stmt),
+    secure_stmt pc2 lexn s -> forall pc1 : L, leq pc1 pc2 -> secure_stmt pc1 lexn s.
+Proof.
+  intros pc2 lexn s H pc1 Hpc observer.
+  specialize (H observer). inv H.
+  - left. eapply leq_trans_lat; eauto. auto.
+  - case_leq pc1 observer.
+    + left; auto. cbn in H1. intros σ1 σ2 regs1 regs2 Hσ.
+      eapply pi_sem_stmt_ret_aux; eauto.
+    + right; auto.
+Qed.
+
+Lemma secure_throw_stmt_lower_pc:
+  forall (pc lexn : label) (s : stmt),
+    secure_throw_stmt pc lexn s -> forall pc1 : L, leq pc1 pc -> secure_throw_stmt pc1 lexn s.
+Proof.
+  intros pc lexn s H pc1 Hpc observer.
+  specialize (H observer). inv H.
+  - left. eapply leq_trans_lat; eauto. auto.
+  - case_leq pc1 observer.
+    + left; auto. cbn in H1. intros σ1 σ2 regs1 regs2 Hσ.
+      eapply pi_sem_throw_stmt_ret_aux; eauto.
+    + right; auto.
+Qed.
+(* Would need to make annoying changes to type system for this to technically hold
+Lemma lower_pc_sound s lexn pc1 pc2 :
+  leq pc1 pc2 -> well_typed_stmt pc2 lexn s -> well_typed_stmt pc1 lexn s.
+Proof.
+  intros Hpc Hs. generalize dependent pc1. induction Hs; intros.
+  - constructor. destruct H. split. eapply secure_stmt_lower_pc; eauto.
+    eapply secure_throw_stmt_lower_pc; eauto.
+  - apply wts_skip.
+  - apply wts_seq; eauto. eapply IHHs2.
+    destruct pc1; destruct pc; destruct lexn1; cbv; auto; try contradiction.
+  - eapply wts_assign; eauto. eapply leq_trans_lat; eauto.
+    destruct l; destruct pc; destruct pc1; cbv; auto; contradiction.
+  - eapply wts_print; eauto. eapply leq_trans_lat; eauto.
+    destruct le; destruct pc; destruct pc1; cbv; auto; contradiction.
+  - eapply wts_if; eauto. eapply IHHs1. 2: eapply IHHs2.
+    all :  destruct le; destruct pc; destruct pc1; cbv; auto; contradiction.
+  - eapply wts_while; eauto. eapply IHHs.
+    destruct le; destruct pc; destruct pc1; destruct lexn; cbv; auto; contradiction.
+  - apply wts_raise. eapply leq_trans_lat; eauto.
+  - eapply wts_try; eauto. eapply IHHs2.
+    destruct pc; destruct pc1; destruct lexn1; cbv; auto; contradiction.
+Qed.
+*)
+End LabelledImpTypesProgInsens.

--- a/secure_example/LabelledImpTypes.v
+++ b/secure_example/LabelledImpTypes.v
@@ -1,0 +1,1300 @@
+From Coq Require Import Morphisms String.
+
+From ITree Require Import
+     ITree
+     ITreeFacts
+     HeterogeneousRelations
+     Events.MapDefault
+     Events.State
+     Events.StateFacts
+     Events.Exception
+     Events.ExceptionFacts
+     Secure.SecureEqHalt
+     Secure.SecureEqEuttHalt
+     Secure.SecureEqWcompat
+     Secure.SecureEqBind
+     Secure.StrongBisimProper
+.
+
+From SecureExample Require Import
+     Utils_tutorial
+     LabelledImp
+     LabelledImpHandler
+     Lattice
+     LabelledAsm
+.
+
+Import Monads.
+Import MonadNotation.
+Local Open Scope monad_scope.
+Local Open Scope string_scope.
+
+Section LabelledImpTypes.
+Context (Labels : Lattice).
+Context (LabelLattice : LatticeLaws Labels).
+
+
+Arguments interp_imp {Labels} {R}.
+Arguments denote_expr {Labels}.
+Notation label := (@T Labels).
+
+Ltac case_leq l1 l2 := destruct (leq_dec Labels l1 l2) as [Hleq | Hnleq].
+
+Definition labelled_equiv (Γ : privacy_map Labels) (l : label) (σ1 σ2 : map)  : Prop :=
+  forall x, leq (Γ x) l -> σ1 x = σ2 x.
+
+Definition top2 {A B} : A -> B -> Prop := fun _ _ => True.
+
+Instance labelled_equit_equiv {Γ l} : Equivalence (labelled_equiv Γ l).
+Proof.
+  constructor; unfold labelled_equiv.
+  - red. intros; auto.
+  - red. intros. symmetry; auto.
+  - red. intros. rewrite H; auto.
+Qed.
+
+Definition label_eqit_secure_impstate  (b1 b2 : bool) (Γ : privacy_map Labels) (l : label) {R1 R2 : Type} (RR : R1 -> R2 -> Prop )
+           (m1 : stateT map (itree ((impExcE Labels) +' (IOE Labels))) R1)
+           (m2 : stateT map (itree ((impExcE Labels) +' (IOE Labels))) R2) : Prop :=
+  forall σ1 σ2, labelled_equiv Γ l σ1 σ2 -> eqit_secure _ (priv_exc_io Labels) (product_rel (labelled_equiv Γ l) RR) b1 b2 l (m1 σ1) (m2 σ2).
+
+Definition label_state_sec_eutt {R1 R2} priv l (RR : R1 -> R2 -> Prop) m1 m2 :=
+  label_eqit_secure_impstate true true  priv l RR m1 m2.
+
+Definition sem_stmt (s : stmt Labels) := interp_imp (denote_stmt Labels s).
+
+Definition sem_throw_stmt (s : stmt Labels) := interp_imp (throw_prefix (denote_stmt Labels s) ).
+
+Definition sem_expr (e : expr) := interp_imp (denote_expr e).
+
+Definition state_equiv {E R} (m1 m2 : stateT map (itree E) R) := forall (σ : map), m1 σ ≈ m2 σ.
+
+Global Instance proper_eutt_secure_eutt  {E R1 R2 RR Label priv l} : Proper (@eutt E R1 R1 eq ==> @eutt E R2 R2 eq ==> iff)
+                                                               (eqit_secure Label priv RR true true l).
+Proof.
+  eapply proper_eqit_secure_eqit.
+Qed.
+
+Global Instance proper_eq_itree_secure_eutt  {E R1 R2 RR Label priv l} : Proper (@eq_itree E R1 R1 eq ==> @eq_itree E R2 R2 eq ==> iff)
+                                                               (eqit_secure Label priv RR true true l).
+Proof.
+  repeat intro. assert (x ≈ y). rewrite H. reflexivity.
+  assert (x0 ≈ y0). rewrite H0. reflexivity. rewrite H1. rewrite H2. tauto.
+Qed.
+
+Global Instance proper_state_equiv_label_state_sec_eutt {R1 R2 RR priv l} : Proper (@state_equiv _ R1 ==> @state_equiv _ R2 ==> iff) (@label_state_sec_eutt R1 R2 priv l RR).
+Proof.
+  repeat intro. split.
+  - intros. do 2 red in H1. do 2 red. intros. red in H0. specialize (H0 σ2). red in H.
+    specialize (H σ1). eapply proper_eutt_secure_eutt; eauto. symmetry. auto. symmetry. auto.
+  - intros. intros. do 2 red in H1. do 2 red. intros. red in H0. specialize (H0 σ2). red in H.
+    specialize (H σ1).  eapply proper_eutt_secure_eutt; eauto.
+Qed.
+
+Context (Γ : privacy_map Labels).
+
+Variant secure_stmt_at_label (observer pc : label) (s : stmt Labels) : Prop :=
+  | ssal_leq : (leq pc observer) -> label_state_sec_eutt Γ observer eq (sem_stmt s) (sem_stmt s) -> secure_stmt_at_label observer pc s
+  | ssal_nleq : (~ leq pc observer) -> label_state_sec_eutt Γ observer top2 (sem_stmt s) (ret tt) -> secure_stmt_at_label observer pc s.
+
+
+Variant secure_expr_at_label (observer protection: label ) (e : expr) : Prop :=
+  | seal_leq : (leq protection observer) -> label_state_sec_eutt Γ observer eq (sem_expr e) (sem_expr e) ->
+               secure_expr_at_label observer protection e
+  | seal_nleq : (~leq protection observer) -> (exists n:value, label_state_sec_eutt Γ observer top2 (sem_expr e) (ret n)) ->
+                secure_expr_at_label observer protection e
+.
+
+Definition secure_expr l e := forall observer, secure_expr_at_label observer l e.
+
+Definition secure_stmt pc s := forall observer, secure_stmt_at_label observer pc s.
+
+Variant is_inl {A B : Type} : A + B -> Prop :=
+  | is_inl_ev (a : A) : is_inl (inl a).
+
+Variant secure_throw_stmt_at_label (observer pc : label) (s : stmt Labels) : Prop :=
+  | stsal_leq : leq pc observer -> label_state_sec_eutt Γ observer (sum_rel eq (fun l1 l2 => eqlat l1 bot /\ eqlat l2 bot) )
+                                                       (sem_throw_stmt s) (sem_throw_stmt s) -> secure_throw_stmt_at_label observer pc s
+  | stsal_nleq : (~ leq pc observer) -> label_state_sec_eutt Γ observer (fun sum _ => is_inl sum )
+                                                            (sem_throw_stmt s) (ret tt ) ->  secure_throw_stmt_at_label observer pc s.
+
+Definition secure_throw_stmt pc s := forall observer, secure_throw_stmt_at_label observer pc s.
+
+Lemma expr_only_ret_aux1 e observer: forall (n : nat), label_state_sec_eutt Γ observer top2 (sem_expr e) (ret n) .
+Proof.
+  do 2 red. induction e; intros; unfold sem_expr; cbn; unfold interp_imp.
+  - eapply proper_eutt_secure_eutt; try apply interp_state_trigger; try reflexivity. cbn.
+    apply secure_eqit_ret. split; cbv; auto.
+  - rewrite interp_state_ret. apply secure_eqit_ret. split; cbv; auto.
+  - repeat setoid_rewrite interp_state_bind.
+    match goal with |- eqit_secure _ _ _ _ _ _ _ ?t =>
+    assert ( t ≈ ITree.bind (Ret (σ2, n)) (fun st : map * nat => ITree.bind (Ret (fst st, n) ) (fun st : map * nat => Ret (fst st,n))  )  ) end.
+    { repeat rewrite bind_ret_l. reflexivity. }
+    eapply proper_eutt_secure_eutt; try apply H0; try reflexivity.
+    eapply secure_eqit_bind; try apply IHe1; eauto. intros [? ?] [? ?] [? ?]. cbn in *.
+    eapply secure_eqit_bind; try apply IHe2; eauto. intros [? ?] [? ?] [? ?]. cbn in *.
+    setoid_rewrite interp_state_ret. apply secure_eqit_ret; split; auto.
+  - repeat setoid_rewrite interp_state_bind.
+    match goal with |- eqit_secure _ _ _ _ _ _ _ ?t =>
+    assert ( t ≈ ITree.bind (Ret (σ2, n)) (fun st : map * nat => ITree.bind (Ret (fst st, n) ) (fun st : map * nat => Ret (fst st,n))  )  ) end.
+    { repeat rewrite bind_ret_l. reflexivity. }
+    eapply proper_eutt_secure_eutt; try apply H0; try reflexivity.
+    eapply secure_eqit_bind; try apply IHe1; eauto. intros [? ?] [? ?] [? ?]. cbn in *.
+    eapply secure_eqit_bind; try apply IHe2; eauto. intros [? ?] [? ?] [? ?]. cbn in *.
+    setoid_rewrite interp_state_ret. apply secure_eqit_ret; split; auto.
+   - repeat setoid_rewrite interp_state_bind.
+    match goal with |- eqit_secure _ _ _ _ _ _ _ ?t =>
+    assert ( t ≈ ITree.bind (Ret (σ2, n)) (fun st : map * nat => ITree.bind (Ret (fst st, n) ) (fun st : map * nat => Ret (fst st,n))  )  ) end.
+    { repeat rewrite bind_ret_l. reflexivity. }
+    eapply proper_eutt_secure_eutt; try apply H0; try reflexivity.
+    eapply secure_eqit_bind; try apply IHe1; eauto. intros [? ?] [? ?] [? ?]. cbn in *.
+    eapply secure_eqit_bind; try apply IHe2; eauto. intros [? ?] [? ?] [? ?]. cbn in *.
+    setoid_rewrite interp_state_ret. apply secure_eqit_ret; split; auto.
+Qed.
+
+Lemma expr_only_ret e observer:  exists n : value, label_state_sec_eutt Γ observer top2 (sem_expr e) (ret n) .
+Proof.
+  exists 0. apply expr_only_ret_aux1.
+Qed.
+
+Lemma secure_expr_upward_close e l1 l2 : leq l1 l2 ->
+                                         secure_expr l1 e -> secure_expr l2 e.
+Proof.
+  intros Hl He observer. specialize (He observer).
+  inv He.
+  - case_leq l2 observer.
+    + left; auto.
+    + right; auto. apply expr_only_ret.
+  - case_leq l2 observer.
+    + exfalso. eapply H. eapply leq_trans_lat; eauto.
+    + right; auto.
+Qed.
+
+Lemma state_secure_eutt_equiv_ret_aux:
+  forall R RR t1 t2 (observer : label) (r1 r2 : R),
+    Equivalence RR ->
+    RR r1 r2 ->
+    (forall σ1 σ2 : map,
+        labelled_equiv Γ observer σ1 σ2 ->
+        eqit_secure _ (priv_exc_io Labels) (product_rel (labelled_equiv Γ observer) RR) true
+                    true observer (interp_imp t1 σ1) (Ret(σ2,r1))) ->
+    (forall σ1 σ2 : map,
+        labelled_equiv Γ observer σ1 σ2 ->
+        eqit_secure _ (priv_exc_io Labels) (product_rel (labelled_equiv Γ observer) RR) true
+                    true observer (interp_imp t2 σ1) (Ret(σ2,r2))) ->
+    forall σ1 σ2 : map,
+      labelled_equiv Γ observer σ1 σ2 ->
+      eqit_secure _ (priv_exc_io Labels) (product_rel (labelled_equiv Γ observer) RR) true
+                  true observer (interp_state (handle_imp _) t1 σ1)
+                  (interp_state (handle_imp _) t2 σ2).
+Proof.
+  intros R RR t1 t2 observer r1 r2 HRR Hr12 Hr1 Hr2 s1 s2 Hs12.
+  set ((product_rel (labelled_equiv Γ observer) RR)) as Rst.
+  apply eqit_secure_RR_imp with (RR1 := rcompose Rst Rst).
+  { intros [? ?] [? ?] [? ?]. destruct r3. cbn in *. unfold Rst in *.
+    split. 2 : cbv; auto. destruct REL1 as [REL1 _]. destruct REL2 as [REL2 _].
+    cbn in *. etransitivity; eauto. destruct REL1. destruct REL2.  cbn in *. etransitivity; eauto. }
+  eapply eqit_secure_trans; eauto. eapply eqit_secure_sym.
+  apply eqit_secure_RR_imp with (RR1 := Rst).
+  { intros. split. 2 : cbv; auto. unfold Rst in PR. destruct PR.
+    symmetry. auto. destruct x0. destruct x1. unfold Rst in *. destruct PR. symmetry. auto. }
+  assert (eqit_secure _ (priv_exc_io Labels) Rst true true observer (Ret (s2, r2) ) (Ret (s2,r1))).
+  { apply secure_eqit_ret. unfold Rst in *. split; auto; cbv; auto. symmetry. auto. }
+  apply eqit_secure_RR_imp with (RR1 := rcompose Rst Rst).
+  { intros [? ?] [? ?] [? ?]. destruct r3. cbn in *. unfold Rst in *.
+    split. 2 : cbv; auto. destruct REL1 as [REL1 _]. destruct REL2 as [REL2 _].
+    cbn in *. etransitivity; eauto. destruct REL1. destruct REL2. etransitivity; eauto. }
+  eapply eqit_secure_trans; try apply Hr2; eauto. reflexivity.
+Qed.
+
+Lemma state_secure_eutt_throw_ret_aux:
+  forall t1 t2  (observer : label),
+    label_state_sec_eutt Γ observer
+                         (fun (sum : unit + label) (_ : unit) =>
+                            is_inl sum) (interp_state (handle_imp _) (throw_prefix t1))
+                         (ret tt) ->
+    label_state_sec_eutt Γ observer
+                         (fun (sum : unit + label) (_ : unit) =>
+                            is_inl sum) (interp_state (handle_imp _) (throw_prefix t2))
+                         (ret tt) ->
+    forall σ3 σ4 : map,
+      labelled_equiv Γ observer σ3 σ4 ->
+      eqit_secure _ (priv_exc_io Labels)
+                  (product_rel (labelled_equiv Γ observer)
+                               (sum_rel eq
+                                        (fun l1 l2 : label =>
+                                           eqlat l1 bot /\ eqlat l2 bot))) true
+                  true observer
+                  (interp_state (handle_imp _)
+                                (throw_prefix t1) σ3)
+                  (interp_state (handle_imp _)
+                                (throw_prefix t2) σ4).
+Proof.
+  intros t1 t2 observer Ht1 Ht2 σ3 σ4 Hσ.
+  do 2 red in Ht1, Ht2. cbn in *. set (product_rel
+             (labelled_equiv Γ observer)
+             (fun (sum : unit + label)
+                (_ : unit) => is_inl sum)) as Rst.
+  set (product_rel (labelled_equiv Γ observer) (fun (sum1 sum2 : unit + label) => is_inl sum1 /\ is_inl sum2)  ) as Rst'.
+  eapply eqit_secure_RR_imp with (RR1 := Rst').
+  { unfold Rst'. intros [σ1 [ [] | l1] ] [σ2 [ [] | l2] ] [Hσ' [Hr1 Hr2] ]; inv Hr1; inv Hr2.
+    split; auto. constructor. auto. }
+  eapply eqit_secure_RR_imp with (RR1 := rcompose Rst (rcompose eq (fun x1 x2 => Rst x2 x1)) ).
+  { unfold Rst. intros [σ1  r1 ] [σ2 r2 ] Hr. inv Hr. inv REL2. destruct REL1. destruct REL3.
+    inv H0. inv H2. unfold Rst'. destruct r3. cbn in *. subst. split; try split; try (constructor; auto).
+    cbn. symmetry in H1. etransitivity; eauto. }
+  eapply eqit_secure_trans; try eapply Ht1; eauto. eapply eqit_secure_trans with (t2 := (Ret (σ4, tt) ) ).
+  apply secure_eqit_ret. auto. apply eqit_secure_sym. eapply Ht2. reflexivity.
+Qed.
+
+
+Lemma state_secure_eutt_ret_aux:
+  forall R t1 t2 (observer : label) (r1 r2 : R),
+    (forall σ1 σ2 : map,
+        labelled_equiv Γ observer σ1 σ2 ->
+        eqit_secure _ (priv_exc_io Labels) (product_rel (labelled_equiv Γ observer) (@top2 R R)) true
+                    true observer (interp_imp t1 σ1) (Ret(σ2,r1))) ->
+    (forall σ1 σ2 : map,
+        labelled_equiv Γ observer σ1 σ2 ->
+        eqit_secure _ (priv_exc_io Labels) (product_rel (labelled_equiv Γ observer) (@top2 R R)) true
+                    true observer (interp_imp t2 σ1) (Ret(σ2,r2))) ->
+    forall σ1 σ2 : map,
+      labelled_equiv Γ observer σ1 σ2 ->
+      eqit_secure _ (priv_exc_io Labels) (product_rel (labelled_equiv Γ observer) top2) true
+                  true observer (interp_state (handle_imp _) t1 σ1)
+                  (interp_state (handle_imp _) t2 σ2).
+Proof.
+  intros R t1 t2 observer r1 r2 Hr1 Hr2 s1 s2 Hs12.
+  eapply state_secure_eutt_equiv_ret_aux; eauto. 2: cbv; auto.
+  constructor; constructor.
+Qed.
+
+Lemma update_labelled_equiv_invisible:
+  forall (x : var) (observer : label) Γ,
+    ~ leq (Γ x) observer ->
+    forall (σ1 : map) (v : value) (σ2 : map),
+      labelled_equiv Γ observer σ1 σ2 -> labelled_equiv Γ observer (update x v σ1) (σ2).
+Proof.
+  intros x observer Γ' H σ1 v σ2 H2.
+  red. red in H2. intros.
+  unfold update. destruct (x =? x0) eqn : Heq; auto.
+  exfalso. apply H. apply eqb_eq in Heq. subst; auto.
+Qed.
+
+Lemma update_labelled_equiv_visible:
+  forall (x : var) (observer : label) Γ,
+    leq (Γ x) observer ->
+    forall (σ1 : map) (v : value) (σ2 : map),
+      labelled_equiv Γ observer σ1 σ2 -> labelled_equiv Γ observer (update x v σ1) (update x v σ2).
+Proof.
+  intros x observer Γ' H σ1 v σ2 H2.
+  red. red in H2. intros. unfold update.
+  destruct (x =? x0) eqn : Heq; auto.
+Qed.
+
+Lemma assign_well_typed_correct x e pc l : secure_expr l e -> leq (join l pc) (Γ x) -> secure_stmt pc (Assign x e).
+Proof.
+  intros Hle Hx.
+  assert (Hpc : leq pc (Γ x) ).
+  { eapply leq_trans_lat; eauto. apply leq_join_r; auto. }
+  assert (Hl : leq l (Γ x) ).
+  { eapply leq_trans_lat; try apply Hx; auto. apply leq_join_l; eauto. }
+  assert (He : secure_expr (Γ x) e ).
+  { eapply secure_expr_upward_close with (l2:= Γ x); eauto. }
+  intros observer.
+  specialize ( He observer). inv He.
+  - left. eapply leq_trans_lat; eauto.
+    do 2 red in H0. do 2 red. intros. unfold sem_stmt.
+    cbn. unfold interp_imp. setoid_rewrite interp_state_bind.
+    eapply secure_eqit_bind; eauto. intros [? ?] [? ?] [? ?].
+    cbn in H2, H3. subst. eapply proper_eutt_secure_eutt; try apply interp_state_trigger.
+    cbn. apply secure_eqit_ret; split; auto. cbn. cbn in *; subst; apply update_labelled_equiv_visible; auto.
+  - case_leq pc observer.
+    + left; auto.
+      destruct H0 as [n Hn]. unfold sem_stmt.
+      cbn. unfold interp_imp. do 2 red. intros. setoid_rewrite interp_state_bind.
+      do 2 red in Hn.
+      eapply secure_eqit_bind with (RR := product_rel (labelled_equiv Γ observer) top2 ); eauto.
+      2 : { eapply state_secure_eutt_ret_aux; try apply Hn; auto. }
+      intros [? ?] [? ?] [? ?]. cbn in H1. cbn.
+      eapply proper_eutt_secure_eutt; try apply interp_state_trigger.
+      cbn. apply secure_eqit_ret. split. 2 : cbv; auto. cbn.
+      apply update_labelled_equiv_invisible; auto. symmetry.
+      apply update_labelled_equiv_invisible;  auto.
+      symmetry; auto.
+    + right; auto.
+      destruct H0 as [n Hn]. unfold sem_stmt. cbn.
+      do 2 red in Hn. do 2 red. intros. unfold sem_stmt. cbn.
+      setoid_rewrite interp_state_bind.
+      match goal with |- eqit_secure _ _ _ _ _ _ _ ?t =>
+                      assert (t ≈ (ITree.bind (Ret (σ2, n)) (fun st => Ret (fst st, tt) ))) end.
+      rewrite bind_ret_l. reflexivity.
+      eapply proper_eutt_secure_eutt; try apply H1; try reflexivity.
+      eapply secure_eqit_bind; try apply Hn; eauto.
+      intros [? ?] [? ?] [? ?]. cbn in H3.
+      eapply proper_eutt_secure_eutt; try apply interp_state_trigger; try reflexivity.
+      cbn.
+      apply secure_eqit_ret; split; auto.
+      cbn. apply update_labelled_equiv_invisible; auto.
+Qed.
+
+Lemma throw_prefix_denote_expr e : throw_prefix (denote_expr e) ≈ (ITree.bind (denote_expr e) (fun v => Ret (inl v))).
+Proof.
+  induction e; cbn.
+  - setoid_rewrite bind_trigger. setoid_rewrite throw_prefix_ev.
+    apply eqit_Vis. setoid_rewrite throw_prefix_ret. intros. rewrite tau_eutt. reflexivity.
+  - rewrite throw_prefix_ret, bind_ret_l. reflexivity.
+  - setoid_rewrite throw_prefix_bind. setoid_rewrite IHe1. repeat rewrite bind_bind.
+    eapply eqit_bind'; try reflexivity. intros; subst. rewrite bind_ret_l. rewrite throw_prefix_bind.
+    rewrite IHe2. repeat rewrite bind_bind. eapply eqit_bind'; try reflexivity. intros; subst. repeat rewrite bind_ret_l.
+    rewrite throw_prefix_ret. reflexivity.
+  - setoid_rewrite throw_prefix_bind. setoid_rewrite IHe1. repeat rewrite bind_bind.
+    eapply eqit_bind'; try reflexivity. intros; subst. rewrite bind_ret_l. rewrite throw_prefix_bind.
+    rewrite IHe2. repeat rewrite bind_bind. eapply eqit_bind'; try reflexivity. intros; subst. repeat rewrite bind_ret_l.
+    rewrite throw_prefix_ret. reflexivity.
+  - setoid_rewrite throw_prefix_bind. setoid_rewrite IHe1. repeat rewrite bind_bind.
+    eapply eqit_bind'; try reflexivity. intros; subst. rewrite bind_ret_l. rewrite throw_prefix_bind.
+    rewrite IHe2. repeat rewrite bind_bind. eapply eqit_bind'; try reflexivity. intros; subst. repeat rewrite bind_ret_l.
+    rewrite throw_prefix_ret. reflexivity.
+Qed.
+
+Lemma expr_only_ret' e s : exists n, sem_expr e s ≈ Ret(s, n).
+Proof.
+  unfold sem_expr, interp_imp. cbn.
+  induction e.
+  - cbn. setoid_rewrite interp_state_trigger. cbn. repeat setoid_rewrite bind_ret_l.
+    cbn. eexists; reflexivity.
+  - cbn. setoid_rewrite interp_state_ret.
+    eexists; reflexivity.
+  - destruct IHe1 as [n1 IHn1]. destruct IHe2 as [n2 IHn2].
+    cbn. setoid_rewrite interp_state_bind. setoid_rewrite IHn1.
+    setoid_rewrite bind_ret_l. setoid_rewrite interp_state_bind. setoid_rewrite IHn2.
+    setoid_rewrite bind_ret_l. setoid_rewrite interp_state_ret.
+    eexists; reflexivity.
+  - destruct IHe1 as [n1 IHn1]. destruct IHe2 as [n2 IHn2].
+    cbn. setoid_rewrite interp_state_bind. setoid_rewrite IHn1.
+    setoid_rewrite bind_ret_l. setoid_rewrite interp_state_bind. setoid_rewrite IHn2.
+    setoid_rewrite bind_ret_l. setoid_rewrite interp_state_ret.
+    eexists; reflexivity.
+  - destruct IHe1 as [n1 IHn1]. destruct IHe2 as [n2 IHn2].
+    cbn. setoid_rewrite interp_state_bind. setoid_rewrite IHn1.
+    setoid_rewrite bind_ret_l. setoid_rewrite interp_state_bind. setoid_rewrite IHn2.
+    setoid_rewrite bind_ret_l. setoid_rewrite interp_state_ret.
+    eexists; reflexivity.
+Qed.
+
+Lemma assign_well_typed_correct' x e pc l : secure_expr l e -> leq (join l pc) (Γ x) -> secure_throw_stmt pc (Assign x e).
+Proof.
+  intros Hle Hx.
+  assert (Hpc : leq pc (Γ x) ).
+  { eapply leq_trans_lat; eauto. apply leq_join_r; auto. }
+  assert (Hl : leq l (Γ x) ).
+  { eapply leq_trans_lat; try apply Hx; auto. apply leq_join_l; eauto. }
+  assert (He : secure_expr (Γ x) e ).
+  { eapply secure_expr_upward_close with (l2:= Γ x); eauto. }
+  intros observer.
+  specialize ( He observer). inv He.
+  - left. eapply leq_trans_lat; eauto.
+    do 2 red in H0. do 2 red. intros. unfold sem_throw_stmt.
+    cbn. setoid_rewrite throw_prefix_bind. unfold interp_imp. setoid_rewrite interp_state_bind.
+    eapply secure_eqit_bind with (RR := product_rel (labelled_equiv Γ observer) (fun sum1 sum2 => sum1 = sum2 /\ is_inl sum1) ).
+    + intros [σ3 [v1 | l1] ] [σ4 [v2 | l2] ] [Hσ Hr]; inv Hr; try inv H3; try discriminate.
+      cbn. setoid_rewrite throw_prefix_ev. setoid_rewrite interp_state_vis. cbn.
+      repeat rewrite bind_ret_l. setoid_rewrite throw_prefix_ret. setoid_rewrite interp_state_tau. setoid_rewrite interp_state_ret.
+      cbn. eapply proper_eutt_secure_eutt; repeat rewrite tau_eutt; try reflexivity. apply secure_eqit_ret.
+      split; cbn; auto. injection H2; intros; subst. apply update_labelled_equiv_visible; auto.
+    + eapply proper_eutt_secure_eutt; try rewrite throw_prefix_denote_expr; try reflexivity.
+      setoid_rewrite interp_state_bind.
+      eapply secure_eqit_bind; eauto. intros [σ3 v1] [σ4 v2] [Hσ Hr]. cbn in Hr; subst. setoid_rewrite interp_state_ret. apply secure_eqit_ret.
+      split; auto. cbn. split; auto. constructor.
+  - case_leq pc observer.
+    + left; auto.
+      destruct H0 as [n Hn]. unfold sem_throw_stmt.
+      cbn. unfold interp_imp. do 2 red. intros. setoid_rewrite throw_prefix_bind. setoid_rewrite interp_state_bind.
+      eapply proper_eutt_secure_eutt; try setoid_rewrite throw_prefix_denote_expr; try reflexivity.
+      setoid_rewrite interp_state_bind. repeat rewrite bind_bind.
+      assert (label_state_sec_eutt Γ observer top2
+         (sem_expr e) (sem_expr e)).
+      { do 2 red. intros. eapply state_secure_eutt_ret_aux; eauto; apply Hn. }
+      eapply secure_eqit_bind; try apply H1; auto. intros [σ3 v1] [σ4 v2] [Hσ Hv].
+      setoid_rewrite interp_state_ret. cbn. setoid_rewrite bind_ret_l. cbn. setoid_rewrite throw_prefix_ev.
+      setoid_rewrite interp_state_vis. cbn. setoid_rewrite bind_ret_l. setoid_rewrite interp_state_tau.
+      eapply proper_eutt_secure_eutt; repeat rewrite tau_eutt; try reflexivity.
+      setoid_rewrite throw_prefix_ret. setoid_rewrite interp_state_ret. cbn. apply secure_eqit_ret.
+      split; cbn; try constructor; auto.
+      apply update_labelled_equiv_invisible; auto. symmetry.
+      apply update_labelled_equiv_invisible;  auto. symmetry. auto.
+    + right; auto.
+      destruct H0 as [n Hn]. unfold sem_throw_stmt. cbn.
+      assert (label_state_sec_eutt Γ observer top2
+         (sem_expr e) (sem_expr e)).
+      { do 2 red. intros. eapply state_secure_eutt_ret_aux; eauto; apply Hn. }
+      do 2 red. intros.
+      setoid_rewrite throw_prefix_bind. unfold interp_imp. setoid_rewrite interp_state_bind.
+      eapply proper_eutt_secure_eutt; try setoid_rewrite throw_prefix_denote_expr; try reflexivity.
+      specialize (expr_only_ret' e σ1) as [n' Hn'].
+      setoid_rewrite interp_state_bind.
+      eapply proper_eutt_secure_eutt; try setoid_rewrite Hn'; try reflexivity. rewrite bind_bind.
+      rewrite bind_ret_l. setoid_rewrite interp_state_ret. rewrite bind_ret_l. cbn.
+      setoid_rewrite throw_prefix_ev. setoid_rewrite interp_state_vis. cbn. rewrite bind_ret_l.
+      rewrite interp_state_tau. eapply proper_eutt_secure_eutt; repeat rewrite tau_eutt; try reflexivity.
+      setoid_rewrite throw_prefix_ret. setoid_rewrite interp_state_ret. cbn. apply secure_eqit_ret.
+      split; try constructor; auto. cbn. apply update_labelled_equiv_invisible; auto.
+Qed.
+
+
+
+Lemma assign_only_ret e x σ : exists σ', sem_stmt (Assign x e) σ ≈ Ret (σ', tt).
+Proof.
+  unfold sem_stmt, interp_imp. cbn.
+  setoid_rewrite interp_state_bind. specialize (expr_only_ret' e σ) as He.
+  destruct He as [n Hn]. setoid_rewrite Hn. setoid_rewrite bind_ret_l.
+  setoid_rewrite interp_state_trigger. cbn. eexists; reflexivity.
+Qed.
+
+Lemma output_well_typed_correct l1 le pc e :
+  secure_expr le e -> leq (join le pc) l1 ->
+  secure_stmt pc (Output l1 e).
+Proof.
+  intros He0 Hle1.
+  assert (Hle : leq le l1).
+  { eapply leq_trans_lat; eauto. apply leq_join_l; auto. }
+  assert (Hpc : leq pc l1).
+  { eapply leq_trans_lat; try apply Hle1; auto. apply leq_join_r; eauto.  }
+  assert (He : secure_expr l1 e ).
+  { eapply secure_expr_upward_close with (l1 := le); eauto. }
+  intros observer. specialize (He observer).
+  inv He.
+  - assert (Hobs : leq pc observer). eapply leq_trans_lat; eauto.
+    left; auto.
+    do 2 red in H0. do 2 red. intros. unfold sem_stmt. cbn.
+    unfold interp_imp. setoid_rewrite interp_state_bind.
+    eapply secure_eqit_bind; eauto. intros [? ?] [? ?] [? ?].
+    cbn in H2, H3. subst. cbn. eapply proper_eutt_secure_eutt; try apply interp_state_trigger.
+    cbn. setoid_rewrite bind_trigger. cbn.
+    apply eqit_secure_public_Vis; try apply H.
+    intros []. apply secure_eqit_ret; auto. split; auto.
+  - case_leq pc observer.
+    + left; auto. destruct H0 as [n Hn]. do 2 red in Hn. cbn in Hn.
+      unfold sem_stmt. cbn. unfold interp_imp. do 2 red.
+      intros. setoid_rewrite interp_state_bind.
+      eapply secure_eqit_bind with (RR := product_rel (labelled_equiv Γ observer) top2 ); eauto.
+      2 : { eapply state_secure_eutt_ret_aux; try apply Hn; auto. }
+      intros [? ?] [? ?] [? ?]. cbn in H1. cbn.
+      eapply proper_eutt_secure_eutt; try apply interp_state_trigger.
+      cbn. setoid_rewrite bind_trigger. apply eqit_secure_private_VisLR; auto.
+      constructor; apply tt. constructor; apply tt. intros [] [].
+      apply secure_eqit_ret. split; auto.
+    + right; auto. destruct H0 as [n Hn]. do 2 red in Hn.
+      do 2 red. intros. unfold sem_stmt. cbn.
+      unfold interp_imp. setoid_rewrite interp_state_bind.
+      match goal with |- eqit_secure _ _ _ _ _ _ _ ?t =>
+                      assert (t ≈ (ITree.bind (Ret (σ2, n)) (fun st => Ret (fst st, tt) ))) end.
+      rewrite bind_ret_l. reflexivity.
+      eapply proper_eutt_secure_eutt; try apply H1; try reflexivity.
+      eapply secure_eqit_bind; try apply Hn; eauto.
+      intros [? ?] [? ?] [? ?]. cbn.
+      eapply proper_eutt_secure_eutt; try apply interp_state_trigger; try reflexivity.
+      cbn. setoid_rewrite bind_trigger. cbn.
+      apply eqit_secure_private_VisL; auto. constructor; apply tt.
+      intros []. apply secure_eqit_ret; auto. split; auto.
+Qed.
+
+Lemma throw_prefix_output l1 e :  throw_prefix (denote_stmt Labels (Output l1 e) ) ≈
+        v <- denote_expr e;; trigger (LabelledPrint Labels l1 v);; Ret (inl tt).
+Proof.
+  cbn. rewrite throw_prefix_bind. rewrite throw_prefix_denote_expr. rewrite bind_bind.
+  eapply eqit_bind'; try reflexivity. intros; subst. rewrite bind_ret_l. setoid_rewrite throw_prefix_ev.
+  rewrite bind_trigger. apply eqit_Vis. intros []. rewrite tau_eutt. rewrite throw_prefix_ret. reflexivity.
+Qed.
+
+Lemma output_well_typed_correct' l1 le pc e :
+  secure_expr le e -> leq (join le pc) l1 ->
+  secure_throw_stmt pc (Output l1 e).
+Proof.
+  intros He0 Hle1.
+  assert (Hle : leq le l1).
+  { eapply leq_trans_lat; eauto. apply leq_join_l; auto. }
+  assert (Hpc : leq pc l1).
+  { eapply leq_trans_lat; try apply Hle1; auto. apply leq_join_r; eauto.  }
+  assert (He : secure_expr l1 e ).
+  { eapply secure_expr_upward_close with (l1 := le); eauto. }
+  intros observer. specialize (He observer).
+  inv He.
+  - assert (Hobs : leq pc observer). eapply leq_trans_lat; eauto.
+    left; auto.
+    do 2 red in H0. do 2 red. intros. unfold sem_throw_stmt.
+    eapply proper_eutt_secure_eutt; try rewrite throw_prefix_output; try reflexivity. unfold interp_imp.
+    setoid_rewrite interp_state_bind.
+    eapply secure_eqit_bind; eauto.
+    intros [? ?] [? ?] [? ?].
+    cbn in H2, H3. subst. cbn. eapply proper_eutt_secure_eutt; try rewrite interp_state_bind, interp_state_trigger; try reflexivity.
+    cbn. setoid_rewrite bind_trigger. setoid_rewrite bind_vis.
+    apply eqit_secure_public_Vis; try apply H.
+    intros []. setoid_rewrite bind_ret_l. setoid_rewrite interp_state_ret. apply secure_eqit_ret; auto.
+    cbn. split; auto. constructor. auto.
+  - case_leq pc observer.
+    + left; auto. destruct H0 as [n Hn]. do 2 red in Hn. cbn in Hn.
+      unfold sem_throw_stmt. do 2 red. intros.
+      eapply proper_eutt_secure_eutt; try rewrite throw_prefix_output; try reflexivity.
+      cbn. unfold interp_imp.
+      setoid_rewrite interp_state_bind.
+      eapply secure_eqit_bind with (RR := product_rel (labelled_equiv Γ observer) top2 ); eauto.
+      2 : { eapply state_secure_eutt_ret_aux; try apply Hn; auto. }
+      intros [? ?] [? ?] [? ?]. cbn in H2.
+      setoid_rewrite interp_state_bind.
+      eapply proper_eutt_secure_eutt; try setoid_rewrite interp_state_trigger; try reflexivity. cbn.
+      setoid_rewrite bind_bind. setoid_rewrite bind_trigger. apply eqit_secure_private_VisLR; auto.
+      all : try (constructor; apply tt; fail). intros [] []. setoid_rewrite bind_ret_l.
+      setoid_rewrite interp_state_ret. apply secure_eqit_ret. split; try constructor; auto.
+    + right; auto. destruct H0 as [n Hn]. do 2 red in Hn.
+      do 2 red. intros. unfold sem_throw_stmt.
+      eapply proper_eutt_secure_eutt; try rewrite throw_prefix_output; try reflexivity.
+      unfold interp_imp.
+      setoid_rewrite interp_state_bind.
+      match goal with |- eqit_secure _ _ _ _ _ _ _ ?t =>
+                      assert (t ≈ (ITree.bind (Ret (σ2, n)) (fun st => Ret (fst st, tt) ))) end.
+      rewrite bind_ret_l. reflexivity.
+      eapply proper_eutt_secure_eutt; try apply H1; try reflexivity.
+      eapply secure_eqit_bind; try apply Hn; eauto.
+      intros [? ?] [? ?] [? ?]. cbn. setoid_rewrite interp_state_bind.
+      eapply proper_eutt_secure_eutt; try rewrite interp_state_trigger; try reflexivity. cbn.
+      rewrite bind_bind, bind_trigger. apply eqit_secure_private_VisL; auto. constructor; constructor.
+      intros []. rewrite bind_ret_l. rewrite interp_state_ret.
+      apply secure_eqit_ret; auto. split; auto. constructor.
+Qed.
+
+Lemma seq_well_typed_correct pc s1 s2 :
+  secure_stmt pc s1 -> secure_stmt pc s2 ->
+  secure_stmt pc (Seq s1 s2).
+Proof.
+  intros Hc1 Hc2. red. intros.
+  specialize (Hc1 observer) as Hc1obs. specialize (Hc2 observer) as Hc2obs.
+  inv Hc1obs.
+  - do 2 red in H0. left; auto. unfold sem_stmt.
+    cbn. unfold interp_imp. do 2 red. intros. setoid_rewrite interp_state_bind.
+    eapply secure_eqit_bind; eauto. intros [? [] ] [? [] ] [? ?].
+    clear H3. cbn in H2. cbn.
+    inv Hc2obs; try apply H4; auto.
+    do 2 red in H4.
+    eapply eqit_secure_RR_imp with (RR1 := product_rel (labelled_equiv Γ observer) top2 ).
+    { intros [ ? [] ] [? [] ] [? ?] . split; auto. }
+    eapply state_secure_eutt_ret_aux; try apply H4; eauto.
+    (* I think this ends up being fine*)
+  - right; auto. unfold sem_stmt, interp_imp. cbn. do 2 red. intros.
+    setoid_rewrite interp_state_bind.
+    inv Hc2obs.
+    { exfalso. apply H. auto. }
+    match goal with |- eqit_secure _ _ _ _ _ _ _ ?t =>
+                      assert (t ≈ (ITree.bind (Ret (σ2, tt)) (fun st => Ret (fst st, tt) ))) end.
+    rewrite bind_ret_l. reflexivity.
+    eapply proper_eutt_secure_eutt; try apply H4; try reflexivity.
+    eapply secure_eqit_bind; try eapply H0; auto.
+    intros [? ?] [? ?] [? ?]. apply H3; auto.
+Qed.
+
+Lemma seq_well_typed_correct' pc s1 s2 :
+  secure_throw_stmt pc s1 -> secure_throw_stmt pc s2 ->
+  secure_throw_stmt pc (Seq s1 s2).
+Proof.
+  intros Hc1 Hc2. red. intros.
+  specialize (Hc1 observer) as Hc1obs. specialize (Hc2 observer) as Hc2obs.
+  inv Hc1obs.
+  - do 2 red in H0. left; auto. unfold sem_throw_stmt.
+    cbn. unfold interp_imp. do 2 red. intros. setoid_rewrite throw_prefix_bind. setoid_rewrite interp_state_bind.
+    eapply secure_eqit_bind; eauto.
+    intros [σ3 [ [] | ?] ] [σ4 [ [] | ?]] [Hσ Hr] ; inv Hr.
+    + cbn. inv Hc2obs; try contradiction. eapply H3; eauto.
+    + destruct H4; subst; cbn. setoid_rewrite interp_state_ret. apply secure_eqit_ret. split; try constructor; auto.
+  - right; auto. unfold sem_throw_stmt, interp_imp. cbn. do 2 red. intros.
+    setoid_rewrite throw_prefix_bind. setoid_rewrite interp_state_bind.
+    inv Hc2obs; try contradiction.
+    match goal with |- eqit_secure _ _ _ _ _ _ _ ?t =>
+                      assert (t ≈ (ITree.bind (Ret (σ2, tt)) (fun st => Ret (fst st, tt) ))) end.
+    rewrite bind_ret_l. reflexivity.
+    eapply proper_eutt_secure_eutt; try apply H4; try reflexivity.
+    eapply secure_eqit_bind; try eapply H0; auto.
+    intros [σ3 [ [] | ?] ] [σ4 [] ] [Hσ Hr] ; inv Hr.
+    cbn. eapply H3; eauto.
+Qed.
+
+Lemma if_well_typed_correct pc le e s1 s2 :
+  secure_expr le e -> secure_stmt (join pc le) s1 -> secure_stmt (join pc le) s2 ->
+  secure_stmt pc (If e s1 s2).
+Proof.
+  intros He Hc1 Hc2. red. intros.
+  specialize (Hc1 observer) as Hc1obs. specialize (Hc2 observer) as Hc2obs.
+  specialize (He observer).
+  inv Hc1obs; inv Hc2obs; try contradiction.
+  - left. eapply leq_trans_lat; eauto. apply leq_join_l; auto.
+    inv He. 2 : { exfalso. apply H3. eapply leq_trans_lat; eauto. apply leq_join_r; auto. }
+    unfold sem_stmt, interp_imp.
+    cbn. do 2 red. intros. setoid_rewrite interp_state_bind. eapply secure_eqit_bind; try apply H4; auto.
+    intros [? ?] [? ?] [? ?]. cbn in H6, H7. subst. cbn. destruct v0; eauto.
+  - case_leq pc observer.
+    + left; auto. unfold sem_stmt, interp_imp. cbn. do 2 red. intros.
+      setoid_rewrite interp_state_bind.
+      inv He; try contradiction.
+      * eapply secure_eqit_bind; try apply H5; eauto.
+        intros [? ?] [? ?] [? ?]. cbn in H7, H6. cbn. subst. do 2 red in H0, H2.
+        eapply eqit_secure_RR_imp with (RR1 := product_rel (labelled_equiv Γ observer) top2 ).
+        { intros [? [] ] [? [] ] [? ?]. split; auto. }
+        destruct v0; try eapply  state_secure_eutt_ret_aux; cbn in *; eauto.
+      * destruct H5 as [n Hn]. do 2 red in Hn.
+        eapply secure_eqit_bind; try eapply  state_secure_eutt_ret_aux; cbn in Hn; eauto.
+        intros [? ?] [? ?] [? ?]. cbn. cbn in H6.
+        eapply eqit_secure_RR_imp with (RR1 := product_rel (labelled_equiv Γ observer) top2 ).
+        { intros [? [] ] [? [] ] [? ?]. split; auto. }
+        destruct v; destruct v0;
+        try eapply state_secure_eutt_ret_aux; try apply H0; try apply H2; eauto.
+     + right; auto. do 2 red. intros. unfold sem_stmt, interp_imp. cbn.
+       setoid_rewrite interp_state_bind.
+       match goal with |- eqit_secure _ _ _ _ _ _ _ ?t =>
+                      assert (t ≈ (ITree.bind (Ret (σ2, 0)) (fun st => Ret (fst st, tt) ))) end.
+       rewrite bind_ret_l. reflexivity.
+       eapply proper_eutt_secure_eutt; try apply H4; try reflexivity.
+       inv He.
+       * eapply secure_eqit_bind with (RR := product_rel (labelled_equiv Γ observer) top2) .
+         2 : { apply expr_only_ret_aux1; auto. }
+         intros [? ?] [? ?] [? ?]. cbn. destruct v; cbn in *; eauto.
+       * destruct H6. eapply secure_eqit_bind; try apply expr_only_ret_aux1; auto.
+
+         intros [? ?] [? ?] [? ?]. cbn. destruct v; cbn in *; eauto.
+Qed.
+
+Lemma if_well_typed_correct' pc le e s1 s2 :
+  secure_expr le e -> secure_throw_stmt (join pc le) s1 -> secure_throw_stmt (join pc le) s2 ->
+  secure_throw_stmt pc (If e s1 s2).
+Proof.
+  intros He Hc1 Hc2. red. intros.
+  specialize (Hc1 observer) as Hc1obs. specialize (Hc2 observer) as Hc2obs.
+  specialize (He observer).
+  inv Hc1obs; inv Hc2obs; try contradiction.
+  - left. eapply leq_trans_lat; eauto. apply leq_join_l; auto.
+    inv He. 2 : { exfalso. apply H3. eapply leq_trans_lat; eauto. apply leq_join_r; auto. }
+    unfold sem_throw_stmt, interp_imp.
+    cbn. do 2 red. intros. setoid_rewrite throw_prefix_bind.
+    eapply proper_eutt_secure_eutt; try setoid_rewrite throw_prefix_denote_expr; try reflexivity.
+    rewrite bind_bind. setoid_rewrite interp_state_bind; setoid_rewrite bind_ret_l.
+    eapply secure_eqit_bind; try apply H4; auto.
+    intros [? ?] [? ?] [? ?]. cbn in H6, H7. subst. cbn. destruct v0; eauto.
+  - (* ~ leq (join pc le) observer  *)
+    case_leq pc observer.
+    + (* leq pc observer *)
+      left; auto. unfold sem_throw_stmt, interp_imp. cbn. do 2 red. intros.
+      setoid_rewrite throw_prefix_bind.
+      setoid_rewrite interp_state_bind.
+      inv He; try contradiction.
+      * (* leq le observer *)
+        eapply proper_eutt_secure_eutt; try setoid_rewrite throw_prefix_denote_expr; try reflexivity.
+        setoid_rewrite interp_state_bind. repeat rewrite bind_bind.
+        eapply secure_eqit_bind; try eapply H6; eauto.
+        setoid_rewrite interp_state_ret. setoid_rewrite bind_ret_l; cbn.
+        intros [σ3 v1 ] [σ4 v2 ] [Hσ Hv]; cbn in Hv; subst. destruct v2; cbn; eauto;
+        try eapply state_secure_eutt_throw_ret_aux; eauto.
+      * eapply proper_eutt_secure_eutt; try setoid_rewrite throw_prefix_denote_expr; try reflexivity.
+        setoid_rewrite interp_state_bind. setoid_rewrite bind_bind.
+        destruct H5 as [n Hn].
+        eapply secure_eqit_bind; try eapply state_secure_eutt_ret_aux; try eapply Hn; eauto.
+        intros [σ3 v1] [σ4 v2] [Hσ _ ]. setoid_rewrite interp_state_ret. cbn.
+        setoid_rewrite bind_ret_l. cbn. destruct v1; destruct v2; try eapply state_secure_eutt_throw_ret_aux; eauto.
+   + (* ~ leq pc observer *)
+     right; auto. unfold sem_throw_stmt, interp_imp. cbn. do 2 red. intros. setoid_rewrite throw_prefix_bind.
+     setoid_rewrite interp_state_bind.
+     match goal with |- eqit_secure _ _ _ _ _ _ _ ?t =>
+                      assert (t ≈ (ITree.bind (Ret (σ2, 0)) (fun st => Ret (fst st, tt) ))) end.
+     rewrite bind_ret_l. reflexivity.
+     eapply proper_eutt_secure_eutt; try apply H5; try reflexivity.
+     inv He.
+     * eapply proper_eutt_secure_eutt; try setoid_rewrite throw_prefix_denote_expr; try reflexivity.
+       eapply proper_eutt_secure_eutt; try apply H4; try reflexivity.
+       setoid_rewrite interp_state_bind. rewrite bind_bind.
+       eapply secure_eqit_bind; try eapply expr_only_ret_aux1; eauto.
+       intros [σ3 v1] [σ4 v2] [Hσ _ ]. setoid_rewrite interp_state_ret. setoid_rewrite bind_ret_l.
+       cbn. destruct v1; cbn in *; eauto.
+     * destruct H6 as [n Hn]. eapply proper_eutt_secure_eutt; try setoid_rewrite throw_prefix_denote_expr; try apply H4; try reflexivity.
+       setoid_rewrite interp_state_bind. rewrite bind_bind.
+       eapply secure_eqit_bind; try eapply expr_only_ret_aux1; eauto.
+       setoid_rewrite interp_state_ret. setoid_rewrite bind_ret_l. cbn.
+       intros [σ3 v1] [σ4 v2] [Hσ _ ]. destruct v1; cbn in *; eauto.
+Qed.
+
+Lemma while_well_typed_correct e s :
+  secure_expr bot e -> secure_stmt bot s ->
+  secure_stmt bot (While e s).
+Proof.
+  intros He Hc. red. intros.
+  assert (leq bot observer).
+  { cbn. destruct LabelLattice.
+    setoid_rewrite <- join_comm. rewrite <- join_unit. reflexivity. }
+  specialize (He observer).
+  specialize (Hc observer).
+  inv He; inv Hc; try contradiction.
+  left; auto. unfold sem_stmt, interp_imp. cbn. unfold while.
+  specialize @interp_state_iter' as Hisi. red in Hisi. do 2 red. intros.
+  setoid_rewrite Hisi. eapply secure_eqit_iter with (RA := product_rel (labelled_equiv Γ observer) eq).
+  { split; auto. }
+  intros [? [] ] [? [] ] [? ?]. cbn.
+  setoid_rewrite interp_state_bind. setoid_rewrite bind_bind.
+  eapply secure_eqit_bind; try apply H1; auto.
+  intros [? ?] [? ?] [? ?]. cbn. cbn in H7, H8; subst. destruct v0.
+  - setoid_rewrite interp_state_ret. setoid_rewrite bind_ret_l. cbn.
+    apply secure_eqit_ret. constructor. split; auto.
+  - setoid_rewrite interp_state_bind. setoid_rewrite bind_bind.
+    eapply secure_eqit_bind; try apply H3; auto.
+    intros [? [] ] [? [] ] [? ?]. cbn. cbn in H8.
+    setoid_rewrite interp_state_ret. setoid_rewrite bind_ret_l. cbn.
+    apply secure_eqit_ret. constructor. split; auto.
+Qed.
+
+Lemma while_well_typed_correct' e s :
+  secure_expr bot e -> secure_throw_stmt bot s ->
+  secure_throw_stmt bot (While e s).
+Proof.
+  intros He Hc. red. intros.
+  assert (leq bot observer).
+  { cbn. destruct LabelLattice.
+    setoid_rewrite <- join_comm. rewrite <- join_unit. reflexivity. }
+  specialize (He observer).
+  specialize (Hc observer).
+  inv He; inv Hc; try contradiction.
+  left; auto. unfold sem_throw_stmt in *.
+  cbn. do 2 red. intros. setoid_rewrite throw_prefix_iter.
+  unfold interp_imp in *.
+  specialize @interp_state_iter' as Hisi. red in Hisi.
+  setoid_rewrite Hisi. cbn.
+  eapply secure_eqit_iter with (RA := product_rel (labelled_equiv Γ observer) eq ).
+  split; auto. intros [σ3 [] ] [σ4 [] ] [Hσ _]. cbn.
+  setoid_rewrite throw_prefix_bind. repeat setoid_rewrite interp_state_bind.
+  repeat rewrite bind_bind.
+  eapply proper_eutt_secure_eutt;
+    try setoid_rewrite throw_prefix_denote_expr; try reflexivity.
+  setoid_rewrite interp_state_bind. setoid_rewrite bind_bind.
+  eapply secure_eqit_bind; try eapply H1; eauto.
+  intros [σ5 v1] [σ6 v2] [Hσ' Heq]; cbn in Heq; subst. cbn.
+  setoid_rewrite interp_state_ret. setoid_rewrite bind_ret_l. cbn.
+  destruct v2.
+  - cbn. setoid_rewrite throw_prefix_ret. setoid_rewrite interp_state_ret.
+    setoid_rewrite bind_ret_l. cbn. setoid_rewrite interp_state_ret.
+    setoid_rewrite bind_ret_l. cbn. apply secure_eqit_ret. constructor. split; auto.
+    constructor. auto.
+  - setoid_rewrite throw_prefix_bind. setoid_rewrite interp_state_bind.
+    setoid_rewrite bind_bind. eapply secure_eqit_bind; try eapply H3; eauto.
+    intros [σ7 [ [] | l1] ] [σ8 [ [] | l2] ] [Hσ'' Hsum]; inv Hsum.
+    + cbn. setoid_rewrite throw_prefix_ret. setoid_rewrite interp_state_ret.
+      setoid_rewrite bind_ret_l. cbn. setoid_rewrite interp_state_ret.
+      setoid_rewrite bind_ret_l. cbn. apply secure_eqit_ret.
+      constructor. split; auto.
+    + cbn. setoid_rewrite interp_state_ret. setoid_rewrite bind_ret_l.
+      cbn. setoid_rewrite interp_state_ret. setoid_rewrite bind_ret_l.
+      cbn. apply secure_eqit_ret. destruct H7; subst. constructor.
+      split; auto. constructor. auto.
+Qed.
+
+Lemma well_typed_raise : secure_stmt bot (Raise bot).
+Proof.
+  red. intros. left.
+  destruct LabelLattice. cbn.
+  setoid_rewrite <- join_comm. rewrite <- join_unit. reflexivity.
+  red. red. intros. unfold sem_stmt, interp_imp.
+  cbn. setoid_rewrite interp_state_bind. eapply secure_eqit_bind with (RR := eq).
+  intros [ _ [] ].
+  eapply proper_eutt_secure_eutt; try apply interp_state_trigger; try reflexivity.
+  cbn. setoid_rewrite bind_trigger. apply eqit_secure_public_Vis.
+  cbn. destruct LabelLattice.
+  setoid_rewrite <- join_comm. rewrite <- join_unit. reflexivity. intros [].
+Qed.
+
+Lemma well_typed_raise' : secure_throw_stmt bot (Raise bot).
+Proof.
+  red. intros. left. apply leq_bot; auto.
+  red. red. intros. unfold sem_throw_stmt, interp_imp. cbn.
+  setoid_rewrite throw_prefix_bind. setoid_rewrite interp_state_bind.
+  eapply secure_eqit_bind with (RR := product_rel (labelled_equiv Γ observer)  (fun r1 r2 => r1 = inr bot /\ r2 = inr bot) ).
+  - intros [σ3 [ [] | l1 ] ] [σ4 [ [] | l2 ] ] Heq; subst. cbn. destruct Heq. cbn in *. subst.
+    destruct H1. injection H1; injection H2; intros; subst.
+    setoid_rewrite interp_state_ret. apply secure_eqit_ret.
+    split; auto. constructor. split; destruct LabelLattice; reflexivity.
+  - setoid_rewrite throw_prefix_exc. setoid_rewrite interp_state_ret. apply secure_eqit_ret.
+    split; auto.
+Qed.
+
+
+Lemma try_catch_public_exc R RR (t1 t2 catch1 catch2 : itree _ R ) observer :
+  label_state_sec_eutt Γ observer (sum_rel RR (fun l1 l2 => eqlat l1 bot /\ eqlat l2 bot) )
+                       (interp_imp (throw_prefix t1) ) (interp_imp (throw_prefix t2) )  ->
+  label_state_sec_eutt Γ observer RR (interp_imp t1) (interp_imp t2) ->
+  label_state_sec_eutt Γ observer RR (interp_imp catch1) (interp_imp catch2) ->
+  label_state_sec_eutt Γ observer RR
+              (interp_imp (try_catch t1 (fun _ => catch1))) (interp_imp (try_catch t2 (fun _ => catch2))).
+Proof.
+  unfold interp_imp. intros Hthrow Hsect Hsecc σ1 σ2 Hσ.
+  (* try_catch_to_throw_prefix *)
+  eapply proper_eutt_secure_eutt; try setoid_rewrite try_catch_to_throw_prefix;
+    try setoid_rewrite interp_state_bind; try reflexivity.
+  eapply secure_eqit_bind; eauto.
+  intros [σ3 [r1 | l1] ] [σ4 [r2 | l2] ] Htry; destruct Htry as [ Hσ34 Hsum];
+    inv Hsum.
+  - cbn. repeat rewrite interp_state_ret. apply secure_eqit_ret.
+    split; auto.
+  - destruct H1; subst. cbn. apply Hsecc. auto.
+Qed.
+
+Lemma try_catch_throw_secure_stmt pc s catch :
+  secure_stmt pc s -> secure_throw_stmt pc s -> secure_stmt pc catch ->
+  secure_stmt pc (TryCatch s catch).
+Proof.
+  intros Hs Hthrows Hcatch. intros observer.
+  specialize (Hs observer). specialize (Hthrows observer). specialize (Hcatch observer).
+  inv Hs; inv Hthrows; inv Hcatch; try contradiction.
+  - left; auto. unfold sem_stmt. cbn. eapply try_catch_public_exc; eauto.
+  - right; auto. unfold sem_stmt. cbn. cbn in H2. unfold sem_throw_stmt in H2.
+    do 2 red. intros. apply H0 in H5 as H6. cbn in H6. unfold interp_imp.
+    eapply proper_eutt_secure_eutt; try setoid_rewrite try_catch_to_throw_prefix; try reflexivity.
+    setoid_rewrite <- bind_ret_r at 6.
+    setoid_rewrite interp_state_bind.
+    eapply secure_eqit_bind; eauto.
+    intros [σ3 [ [] | l] ] [σ4 []] [Hσ Hsum]; inv Hsum. cbn.
+    setoid_rewrite interp_state_ret. apply secure_eqit_ret; split; cbv; auto.
+Qed.
+
+Lemma try_catch_throw_secure_stmt' pc s catch :
+  secure_stmt pc s -> secure_throw_stmt pc s -> secure_throw_stmt pc catch ->
+  secure_throw_stmt pc (TryCatch s catch).
+Proof.
+  intros Hs1 Hs2 Hcatch observer.
+  specialize (Hs1 observer). specialize (Hs2 observer). specialize (Hcatch observer).
+  inv Hs1; inv Hs2; inv Hcatch; try contradiction.
+  - left; auto. unfold sem_throw_stmt in *. cbn.
+    do 2 red. intros.
+    eapply proper_eutt_secure_eutt; try setoid_rewrite throw_prefix_of_try_catch;
+       try setoid_rewrite try_catch_to_throw_prefix; try reflexivity.
+    unfold interp_imp in *. setoid_rewrite interp_state_bind.
+    setoid_rewrite throw_prefix_bind. setoid_rewrite interp_state_bind.
+    setoid_rewrite bind_bind. clear H0.
+    eapply secure_eqit_bind; try eapply H2; eauto.
+    try reflexivity.
+    intros [σ3 [ [] | l1] ] [σ4 [ [] | l2] ] [Hσ Hsum]; inv Hsum; cbn.
+    + setoid_rewrite throw_prefix_ret. setoid_rewrite interp_state_ret.
+      setoid_rewrite bind_ret_l. cbn. setoid_rewrite interp_state_ret.
+      apply secure_eqit_ret. split; auto. constructor. auto.
+    + setoid_rewrite interp_state_ret. setoid_rewrite bind_ret_l.
+      destruct H7; subst. cbn. eauto.
+  - right; auto. unfold sem_throw_stmt in *. cbn.
+    do 2 red. intros.
+    eapply proper_eutt_secure_eutt; try setoid_rewrite throw_prefix_of_try_catch;
+       try setoid_rewrite try_catch_to_throw_prefix; try reflexivity.
+    setoid_rewrite throw_prefix_bind. rewrite bind_bind.
+    match goal with |- eqit_secure _ _ _ _ _ _ _ ?t =>
+                      assert (t ≈ (ITree.bind (Ret (σ2, tt)) (fun st => Ret (fst st, tt) ))) end.
+     rewrite bind_ret_l. reflexivity.
+     eapply proper_eutt_secure_eutt; try rewrite H6; try reflexivity.
+     unfold interp_imp. setoid_rewrite interp_state_bind.
+     eapply secure_eqit_bind; try eapply H2; eauto.
+     intros [σ3 [[] | l] ] [σ4 [] ] [Hσ Hsum]; inv Hsum.
+     cbn. rewrite throw_prefix_ret, bind_ret_l. rewrite interp_state_ret.
+     apply secure_eqit_ret. split; auto. constructor; auto.
+Qed.
+
+Lemma well_typed_skip pc : secure_stmt pc Skip.
+Proof.
+  intro observer. case_leq pc observer.
+  - left; auto. unfold sem_stmt, interp_imp. do 2 red. intros.
+    cbn. setoid_rewrite interp_state_ret. apply secure_eqit_ret; auto.
+    split; auto.
+  - right; auto. unfold sem_stmt, interp_imp. do 2 red. intros.
+    cbn. setoid_rewrite interp_state_ret. apply secure_eqit_ret; auto.
+    split; auto. cbv. auto.
+Qed.
+
+Lemma well_typed_skip' pc : secure_throw_stmt pc Skip.
+Proof.
+  intro observer. case_leq pc observer.
+  - left; auto. unfold sem_throw_stmt, interp_imp. do 2 red. intros.
+    cbn. setoid_rewrite throw_prefix_ret.
+    setoid_rewrite interp_state_ret. apply secure_eqit_ret; auto.
+    split; auto. constructor. auto.
+  - right; auto. unfold sem_throw_stmt, interp_imp. do 2 red. intros.
+    cbn. setoid_rewrite throw_prefix_ret.
+    setoid_rewrite interp_state_ret. apply secure_eqit_ret; auto.
+    split; auto. constructor.
+Qed.
+
+Inductive well_typed_expr : label -> expr -> Prop :=
+  | wte_lit l n : well_typed_expr l (Lit n)
+  | wte_var x l : leq (Γ x) l -> well_typed_expr l (Var x)
+  | wte_plus l1 l2 l3 e1 e2 : well_typed_expr l1 e1 -> well_typed_expr l2 e2 ->
+                              eqlat (join l1 l2) l3 ->
+                              well_typed_expr l3 (Plus e1 e2)
+  | wte_min l1 l2 l3 e1 e2 : well_typed_expr l1 e1 -> well_typed_expr l2 e2 ->
+                             eqlat (join l1 l2) l3 ->
+                             well_typed_expr l3 (Minus e1 e2)
+  | wte_mult l1 l2 l3 e1 e2 : well_typed_expr l1 e1 -> well_typed_expr l2 e2 ->
+                              eqlat (join l1 l2) l3 ->
+                              well_typed_expr l3 (Mult e1 e2)
+.
+
+
+(* rework this definition to have only public exceptions*)
+Inductive well_typed_stmt : label -> stmt Labels -> Prop :=
+  | wts_manual pc s : secure_stmt pc s /\ secure_throw_stmt pc s -> well_typed_stmt pc s
+  | wts_skip pc : well_typed_stmt pc Skip
+  | wts_seq pc s1 s2 : well_typed_stmt pc s1 -> well_typed_stmt pc s2 ->
+                                   well_typed_stmt pc  (Seq s1 s2)
+  | wts_assign pc l x e : well_typed_expr l e -> leq (join l pc) (Γ x) ->
+                          well_typed_stmt pc (Assign x e)
+  | wts_print pc le lp e : well_typed_expr le e -> leq (join le pc) lp ->
+                           well_typed_stmt pc (Output lp e)
+  | wts_if pc le e s1 s2 : well_typed_expr le e -> well_typed_stmt (join pc le) s1 -> well_typed_stmt (join pc le) s2 ->
+                                       well_typed_stmt pc (If e s1 s2)
+  | wts_while e s : well_typed_expr bot e -> well_typed_stmt bot s ->
+                         well_typed_stmt bot (While e s)
+  | wts_raise : well_typed_stmt bot (Raise bot)
+  | wts_try pc s1 s2 : well_typed_stmt pc s1 -> well_typed_stmt pc s2 ->
+                                   well_typed_stmt pc (TryCatch s1 s2)
+.
+
+Instance proper_eqlat_expr : Proper (eqlat ==> eq ==> Basics.flip Basics.impl) well_typed_expr.
+Proof.
+  intros l1 l2 Hl e1 e2 He. subst. intro Htype.
+  generalize dependent l1. induction Htype.
+  - intros. constructor.
+  - intros. constructor. destruct LabelLattice. rewrite Hl. auto.
+  - intros. destruct LabelLattice. rewrite <- H in Hl.
+    econstructor; eauto. rewrite Hl. reflexivity.
+  - intros. destruct LabelLattice.
+    econstructor; eauto. rewrite Hl. auto.
+  - intros. destruct LabelLattice. rewrite <- H in Hl.
+    econstructor; eauto. rewrite Hl. reflexivity.
+Qed.
+
+Instance proper_eqlat_expr' : Proper (eqlat ==> eq ==> Basics.impl) well_typed_expr.
+Proof.
+  intros l1 l2 Hl e1 e2 He. subst. intro Htype.
+  generalize dependent l2. induction Htype.
+  - intros. constructor.
+  - intros. constructor. destruct LabelLattice. rewrite <- Hl. auto.
+  - intros. destruct LabelLattice. rewrite Hl in H.
+    econstructor; eauto.
+  - intros. destruct LabelLattice. rewrite Hl in H.
+    econstructor; eauto.
+  - intros. destruct LabelLattice. rewrite Hl in H.
+    econstructor; eauto.
+Qed.
+
+Lemma well_typed_expr_upward_close l1 l2 e : leq l1 l2 -> well_typed_expr l1 e -> well_typed_expr l2 e.
+Proof.
+  revert l1 l2.
+  induction e; intros; try inv H0.
+  - constructor. eapply leq_trans_lat; eauto.
+  - constructor.
+  - cbn in H. setoid_rewrite <- H. destruct LabelLattice.
+    econstructor; try reflexivity; eauto. eapply IHe1; eauto.
+    apply leq_trans_lat with (l2 := join l0 l3); auto.
+    apply leq_join_l; auto. rewrite H6. cbn. apply join_idempot; auto.
+    eapply IHe2; eauto.
+    apply leq_trans_lat with (l2 := join l0 l3); auto.
+    apply leq_join_r; auto. rewrite H6. auto.
+  - cbn in H. setoid_rewrite <- H. destruct LabelLattice.
+    econstructor; try reflexivity; eauto. eapply IHe1; eauto.
+    apply leq_trans_lat with (l2 := join l0 l3); auto.
+    apply leq_join_l; auto. rewrite H6. cbn. apply join_idempot; auto.
+    eapply IHe2; eauto.
+    apply leq_trans_lat with (l2 := join l0 l3); auto.
+    apply leq_join_r; auto. rewrite H6. auto.
+  - cbn in H. setoid_rewrite <- H. destruct LabelLattice.
+    econstructor; try reflexivity; eauto. eapply IHe1; eauto.
+    apply leq_trans_lat with (l2 := join l0 l3); auto.
+    apply leq_join_l; auto. rewrite H6. cbn. apply join_idempot; auto.
+    eapply IHe2; eauto.
+    apply leq_trans_lat with (l2 := join l0 l3); auto.
+    apply leq_join_r; auto. rewrite H6. auto.
+Qed.
+
+Lemma well_typed_expr_correct l e : well_typed_expr l e -> secure_expr l e.
+Proof.
+  revert l. red. induction e; intros l Htype observer.
+  - inv Htype. case_leq l observer.
+    + left; auto. unfold sem_expr. cbn. unfold interp_imp.
+      do 2 red. intros. eapply proper_eutt_secure_eutt; try apply interp_state_trigger.
+      cbn.
+      unfold get. apply secure_eqit_ret; split; auto. cbn.
+      red in H. apply H. eapply leq_trans_lat; eauto.
+    + right; auto. apply expr_only_ret.
+  - case_leq l observer.
+    + left; auto. unfold sem_expr. cbn. unfold interp_imp. do 2 red.
+      intros. setoid_rewrite interp_state_ret. apply secure_eqit_ret.
+      split; auto.
+    + right; auto. exists 0. unfold sem_expr. cbn. unfold interp_imp. do 2 red.
+      intros. setoid_rewrite interp_state_ret. apply secure_eqit_ret. split; auto.
+      cbv. auto.
+  - inv Htype.
+    assert (well_typed_expr l e1 ). eapply well_typed_expr_upward_close; eauto.
+    eapply leq_trans_lat with (l2 := join l1 l2); auto. apply leq_join_l; auto.
+    cbn. destruct LabelLattice. rewrite H4. apply join_idempot; auto.
+    assert (well_typed_expr l e2 ). eapply well_typed_expr_upward_close; eauto.
+    apply leq_trans_lat with (l2 := join l1 l2); auto. apply leq_join_r; auto.
+    cbn. destruct LabelLattice. rewrite H4. apply join_idempot; auto.
+    apply IHe1 with (observer := observer) in H.
+    apply IHe2 with (observer := observer) in H0. inv H; inv H0; try contradiction.
+    + left; auto.
+      unfold sem_expr. cbn. unfold interp_imp. do 2 red. intros.
+      repeat setoid_rewrite interp_state_bind.
+      eapply secure_eqit_bind. 2 : eapply H5; eauto.
+      intros [s3 r1] [s4 r2] Hprod. destruct Hprod. cbn in *. subst.
+      eapply secure_eqit_bind. 2 : eapply H6; eauto.
+      intros [? ?] [? ?] [? ?]. cbn in *. subst. setoid_rewrite interp_state_ret.
+      apply secure_eqit_ret. split; auto.
+    + right; auto. apply expr_only_ret.
+  - inv Htype.
+    assert (well_typed_expr l e1 ). eapply well_typed_expr_upward_close; eauto.
+    eapply leq_trans_lat with (l2 := join l1 l2); auto. apply leq_join_l; auto.
+    cbn. destruct LabelLattice. rewrite H4. apply join_idempot; auto.
+    assert (well_typed_expr l e2 ). eapply well_typed_expr_upward_close; eauto.
+    apply leq_trans_lat with (l2 := join l1 l2); auto. apply leq_join_r; auto.
+    cbn. destruct LabelLattice. rewrite H4. apply join_idempot; auto.
+    apply IHe1 with (observer := observer) in H.
+    apply IHe2 with (observer := observer) in H0. inv H; inv H0; try contradiction.
+    + left; auto.
+      unfold sem_expr. cbn. unfold interp_imp. do 2 red. intros.
+      repeat setoid_rewrite interp_state_bind.
+      eapply secure_eqit_bind. 2 : eapply H5; eauto.
+      intros [s3 r1] [s4 r2] Hprod. destruct Hprod. cbn in *. subst.
+      eapply secure_eqit_bind. 2 : eapply H6; eauto.
+      intros [? ?] [? ?] [? ?]. cbn in *. subst. setoid_rewrite interp_state_ret.
+      apply secure_eqit_ret. split; auto.
+    + right; auto. apply expr_only_ret.
+  - inv Htype.
+    assert (well_typed_expr l e1 ). eapply well_typed_expr_upward_close; eauto.
+    eapply leq_trans_lat with (l2 := join l1 l2); auto. apply leq_join_l; auto.
+    cbn. destruct LabelLattice. rewrite H4. apply join_idempot; auto.
+    assert (well_typed_expr l e2 ). eapply well_typed_expr_upward_close; eauto.
+    apply leq_trans_lat with (l2 := join l1 l2); auto. apply leq_join_r; auto.
+    cbn. destruct LabelLattice. rewrite H4. apply join_idempot; auto.
+    apply IHe1 with (observer := observer) in H.
+    apply IHe2 with (observer := observer) in H0. inv H; inv H0; try contradiction.
+    + left; auto.
+      unfold sem_expr. cbn. unfold interp_imp. do 2 red. intros.
+      repeat setoid_rewrite interp_state_bind.
+      eapply secure_eqit_bind. 2 : eapply H5; eauto.
+      intros [s3 r1] [s4 r2] Hprod. destruct Hprod. cbn in *. subst.
+      eapply secure_eqit_bind. 2 : eapply H6; eauto.
+      intros [? ?] [? ?] [? ?]. cbn in *. subst. setoid_rewrite interp_state_ret.
+      apply secure_eqit_ret. split; auto.
+    + right; auto. apply expr_only_ret.
+Qed.
+
+Lemma well_typed_stmt_sound s pc : well_typed_stmt s pc -> secure_stmt s pc.
+Proof.
+  intros Htype. enough (secure_stmt s pc /\ secure_throw_stmt s pc); try tauto.
+  induction Htype; eauto.
+  - (* Skip *) split; try apply well_typed_skip; try apply well_typed_skip'.
+  - (* Seq *)
+    split; try apply seq_well_typed_correct; try apply seq_well_typed_correct'; tauto.
+  - (* Assign *)
+    split; try eapply assign_well_typed_correct; try eapply assign_well_typed_correct';
+      try apply well_typed_expr_correct; eauto.
+  - (* Output *)
+    split; try eapply output_well_typed_correct; try eapply output_well_typed_correct';
+      try apply well_typed_expr_correct; eauto.
+  - (* If *)
+    apply well_typed_expr_correct in H.
+    split; try eapply if_well_typed_correct; try eapply if_well_typed_correct'; eauto; try tauto.
+  - (* While *)
+    destruct IHHtype. apply well_typed_expr_correct in H.
+    split; try eapply while_well_typed_correct; try eapply while_well_typed_correct'; eauto.
+  - (* Raise *)
+    split; try eapply well_typed_raise; try eapply well_typed_raise'; eauto.
+  - (* TryCatch *)
+    destruct IHHtype1. destruct IHHtype2.
+    split; try eapply try_catch_throw_secure_stmt; try eapply try_catch_throw_secure_stmt'; eauto.
+Qed.
+
+Lemma secure_stmt_lower_pc:
+  forall (pc2 : label) (s : stmt Labels),
+    secure_stmt pc2 s -> forall pc1 : L, leq pc1 pc2 -> secure_stmt pc1 s.
+Proof.
+  intros pc2 s H pc1 Hpc observer.
+  specialize (H observer). inv H.
+  - left. eapply leq_trans_lat; eauto. auto.
+  - case_leq pc1 observer.
+    + left; auto. cbn in H1. intros σ1 σ2 Hσ.
+      eapply eqit_secure_RR_imp with (RR1 := product_rel (labelled_equiv Γ observer) top2 ).
+        { intros [? [] ] [? [] ] [? ?]. split; auto. }
+      eapply state_secure_eutt_equiv_ret_aux; eauto.
+      constructor. all : try cbv; tauto.
+    + right; auto.
+Qed.
+
+Lemma secure_throw_stmt_lower_pc:
+  forall (pc : label) (s : stmt Labels),
+    secure_throw_stmt pc s -> forall pc1 : L, leq pc1 pc -> secure_throw_stmt pc1 s.
+Proof.
+  intros pc s H pc1 Hpc observer.
+  specialize (H observer). inv H.
+  - left. eapply leq_trans_lat; eauto. auto.
+  - case_leq pc1 observer.
+    + left; auto. cbn in H1. intros σ1 σ2 Hσ.
+      eapply state_secure_eutt_throw_ret_aux; eauto.
+    + right; auto.
+Qed.
+(* would need to slightly refactor well_typed_stmt to be true will this formulation
+Lemma lower_pc_sound s pc1 pc2 :
+  leq pc1 pc2 -> well_typed_stmt pc2 s -> well_typed_stmt pc1 s.
+Proof.
+  intros Hpc Hs. generalize dependent pc1. induction Hs; intros.
+  - constructor. destruct H. split. eapply secure_stmt_lower_pc; eauto.
+    eapply secure_throw_stmt_lower_pc; eauto.
+  - apply wts_skip.
+  - apply wts_seq; eauto.
+  - eapply wts_assign; eauto. eapply leq_trans_lat; eauto.
+    destruct l; destruct pc; destruct pc1; cbv; auto; contradiction.
+  - eapply wts_print; eauto. eapply leq_trans_lat; eauto.
+    destruct le; destruct pc; destruct pc1; cbv; auto; contradiction.
+  - eapply wts_if; eauto. eapply IHHs1. 2: eapply IHHs2.
+    all :  destruct le; destruct pc; destruct pc1; cbv; auto; contradiction.
+  - destruct pc1; try contradiction. eapply wts_while; eauto.
+  - apply wts_raise. eapply leq_trans_lat; eauto.
+  - apply wts_try; eauto.
+Qed.
+*)
+
+End LabelledImpTypes.
+
+
+(*
+Require Import Coq.Logic.FunctionalExtensionality.
+Require Import Coq.micromega.Lia.
+
+Section Examples.
+
+  Context (X : var).
+
+  Definition sdec_body :=
+    (If (Var X)
+                 (Assign X (Minus (Var X) (Lit 1) ) )
+                 (Raise Private)
+             ).
+
+  Definition sdec : stmt :=
+   TryCatch
+     ( While (Lit 1) sdec_body)
+     Skip.
+
+  Definition sdec_opt : stmt :=
+    Assign X (Lit 0).
+
+  Lemma sdec_body_eq σ : (sem_stmt sdec_body σ ≈ if (Nat.eqb (σ X) 0)
+                                               then v <- trigger (inl1 (Throw sensitivity Private));; match (v : void) with end
+                                               else Ret (update X (σ X - 1) σ, tt))%itree.
+  Proof.
+    unfold sem_stmt, interp_imp. cbn. setoid_rewrite interp_state_bind.
+    setoid_rewrite interp_state_trigger. cbn. rewrite bind_ret_l. cbn. unfold get.
+    destruct (σ X) eqn : Heq.
+    - rewrite <- EqNat.beq_nat_refl. cbn. rewrite interp_state_bind. cbn.
+      setoid_rewrite interp_state_trigger. cbn. repeat rewrite bind_bind. repeat rewrite bind_trigger. cbn.
+      apply eqit_Vis. intros [].
+    - specialize (Nat.eqb_neq) as Hn. assert (S v <> 0). intro. discriminate.
+      apply Hn in H. rewrite H. setoid_rewrite bind_trigger. rewrite bind_vis. rewrite interp_state_vis.
+      cbn. repeat rewrite bind_ret_l. cbn. rewrite interp_state_trigger.
+      tau_steps. setoid_rewrite Heq. cbn. reflexivity.
+  Qed.
+
+  Lemma throw_sdec_body_eq σ : (sem_throw_stmt sdec_body σ ≈ if (Nat.eqb (σ X) 0)
+                                               then Ret (σ, inr Private)
+                                               else Ret (update X (σ X - 1) σ, inl tt))%itree.
+  Proof.
+    unfold sem_throw_stmt, interp_imp. cbn. setoid_rewrite bind_trigger.
+    setoid_rewrite throw_prefix_ev. setoid_rewrite interp_state_vis. cbn.
+    rewrite bind_ret_l. repeat setoid_rewrite tau_eutt. cbn.
+    unfold get. destruct (σ X) eqn : Heq.
+    - cbn. rewrite throw_prefix_bind. setoid_rewrite throw_prefix_exc. rewrite bind_ret_l.
+      setoid_rewrite interp_state_ret. reflexivity.
+    - specialize (Nat.eqb_neq) as Hn. assert (S v <> 0). intro. discriminate.
+      apply Hn in H. rewrite H. repeat setoid_rewrite bind_trigger. rewrite throw_prefix_bind.
+      rewrite interp_state_bind. setoid_rewrite throw_prefix_ev. rewrite interp_state_vis.
+      repeat rewrite bind_bind. cbn. rewrite bind_ret_l. tau_steps.
+      setoid_rewrite Heq. reflexivity.
+  Qed.
+
+
+  Lemma while_sdec_body_eq σ0 : sem_stmt (While (Lit 1) sdec_body ) σ0 ≈
+                                        ITree.iter (fun '(σ, u) =>
+                                                      if (Nat.eqb (σ X) 0)
+                                                      then v <- trigger (inl1 (Throw sensitivity Private));;
+                                                           match (v : void) with end
+                                                      else Ret (inl (update X (σ X - 1) σ, tt)))
+                                        (σ0, tt).
+  Proof.
+    unfold sem_stmt, interp_imp. unfold denote_stmt. fold denote_stmt. unfold while.
+    specialize @interp_state_iter' as Hisi. red in Hisi.
+    setoid_rewrite Hisi.
+    eapply eutt_iter' with (RI := product_rel eq eq); try (split; auto; fail).
+    intros [σ1 [] ] [σ2 [] ] [ Hσ _ ]. cbn in Hσ. rewrite Hσ.
+    remember sdec_body as s. cbn.
+    setoid_rewrite interp_state_bind. setoid_rewrite interp_state_ret.
+    rewrite bind_bind. repeat rewrite bind_ret_l. cbn.
+    setoid_rewrite interp_state_bind. rewrite bind_bind.
+    rewrite Heqs. setoid_rewrite sdec_body_eq.
+    destruct (σ2 X =? 0)%nat.
+    - setoid_rewrite bind_bind. setoid_rewrite bind_trigger.
+      apply eqit_Vis. intros [].
+    - setoid_rewrite interp_state_ret. repeat rewrite bind_ret_l. cbn.
+      apply eqit_Ret. constructor. split; auto.
+   Qed.
+
+  Lemma while_sdec_body_eq' σ0 : sem_throw_stmt (While (Lit 1) sdec_body ) σ0 ≈
+                                         ITree.iter (fun '(σ, u) =>
+                                                       if (Nat.eqb (σ X) 0)
+                                                       then Ret (inr (σ, inr Private))
+                                                      else Ret (inl (update X (σ X - 1) σ, tt)))
+                                        (σ0, tt).
+  Proof.
+    unfold sem_throw_stmt, interp_imp. unfold denote_stmt. fold denote_stmt. unfold while.
+    specialize @interp_state_iter' as Hisi. red in Hisi. setoid_rewrite throw_prefix_iter.
+    setoid_rewrite Hisi.
+    eapply eutt_iter' with (RI := eq); auto.
+    intros [σ1 [] ] [σ2 [] ] Heq. injection Heq; intros; subst. remember (sdec_body) as s.
+    cbn. setoid_rewrite interp_state_bind. setoid_rewrite bind_ret_l.
+    repeat rewrite bind_bind. rewrite Heqs.
+    setoid_rewrite throw_prefix_bind. setoid_rewrite interp_state_bind.
+    setoid_rewrite throw_sdec_body_eq. destruct (σ2 X =? 0)%nat.
+    - rewrite bind_bind, bind_ret_l. cbn. rewrite interp_state_ret. rewrite bind_ret_l. setoid_rewrite interp_state_ret.
+      rewrite bind_ret_l. cbn. apply eqit_Ret. constructor; auto.
+    - rewrite bind_bind, bind_ret_l. cbn. rewrite throw_prefix_ret. rewrite interp_state_ret. rewrite bind_ret_l.
+      setoid_rewrite interp_state_ret.
+      rewrite bind_ret_l. cbn. apply eqit_Ret. constructor. auto.
+  Qed.
+
+
+
+  Lemma sdec_eq σ0 : sem_stmt sdec σ0 ≈ Ret (update X 0 σ0 ,tt).
+  Proof.
+    unfold sdec. remember (While (Lit 1) sdec_body ) as s.
+    unfold sem_stmt, interp_imp. cbn.
+    setoid_rewrite try_catch_to_throw_prefix.
+    setoid_rewrite interp_state_bind.  rewrite Heqs. clear Heqs s. setoid_rewrite while_sdec_body_eq'.
+    remember (σ0 X) as X0. generalize dependent σ0. induction X0; intros.
+    - setoid_rewrite unfold_iter. rewrite <- HeqX0. cbn. rewrite bind_bind.
+      repeat rewrite bind_ret_l. cbn. repeat rewrite bind_bind, bind_ret_l. rewrite bind_ret_l.
+      cbn. enough (σ0 = update X 0 σ0). rewrite H at 1. reflexivity.
+      apply functional_extensionality. intros Y. unfold update.
+      destruct (X =? Y) eqn : Heq; auto. apply eqb_eq in Heq. subst. auto.
+    - rewrite unfold_iter. rewrite <- HeqX0. cbn. rewrite bind_bind. rewrite bind_ret_l.
+      rewrite tau_eutt. assert (X0 - 0 = X0). lia. rewrite H.
+      rewrite IHX0. 2 : { unfold update. rewrite eqb_refl. auto. }
+      enough (update X 0 (update X X0 σ0) = update X 0 σ0). rewrite H0. reflexivity.
+      unfold update. apply functional_extensionality. intros Y.
+      destruct (X =? Y) eqn : Heq; auto.
+  Qed.
+
+  Lemma sdec_sdec_opt σ : sem_stmt sdec σ ≈ sem_stmt sdec_opt σ.
+  Proof.
+    unfold sdec_opt. unfold sem_stmt at 2. unfold interp_imp. cbn.
+    setoid_rewrite bind_ret_l. setoid_rewrite interp_state_trigger. cbn.
+    apply sdec_eq.
+  Qed.
+
+End Examples.
+
+*)

--- a/secure_example/LabelledImpTypesProgInsens.v
+++ b/secure_example/LabelledImpTypesProgInsens.v
@@ -1,0 +1,1071 @@
+From Coq Require Import Morphisms.
+
+From ITree Require Import
+     ITree
+     ITreeFacts
+     HeterogeneousRelations
+     Events.State
+     Events.StateFacts
+     Events.Exception
+     Events.ExceptionFacts
+     Secure.SecureEqHalt
+     Secure.SecureEqProgInsens
+     Secure.SecureEqProgInsensFacts
+.
+
+From SecureExample Require Import
+     Lattice
+     LabelledImp
+     LabelledImpHandler
+     LabelledImpTypes.
+
+Import Monads.
+Import MonadNotation.
+Local Open Scope monad_scope.
+
+
+Section LabelledImpTypesProgInsens.
+
+Context (Labels : Lattice).
+Context (HLat : LatticeLaws Labels).
+
+Notation label := (@T Labels).
+
+Definition labelled_equiv  :=
+  LabelledImpTypes.labelled_equiv Labels.
+
+Arguments denote_expr {Labels}.
+Arguments denote_stmt {Labels}.
+Arguments interp_imp {Labels} {R}.
+
+Ltac case_leq l1 l2 := destruct (leq_dec Labels l1 l2) as [?Hleq | ?Hnleq].
+
+Instance labelled_equit_equiv {Γ l} : Equivalence (labelled_equiv Γ l).
+Proof.
+  constructor; unfold labelled_equiv.
+  - red. red. intros; auto.
+  - do 2 red. intros. symmetry; auto.
+  - do 2 red. intros. rewrite H; auto.
+Qed.
+
+Definition label_pi_eqit_secure_impstate  (b1 b2 : bool) (Γ : privacy_map Labels) (l : label) {R1 R2 : Type} (RR : R1 -> R2 -> Prop )
+           (m1 : stateT map (itree ((impExcE Labels) +' (IOE Labels))) R1) (m2 : stateT map (itree ((impExcE Labels) +' (IOE Labels))) R2) : Prop :=
+  forall σ1 σ2, labelled_equiv Γ l σ1 σ2 -> pi_eqit_secure _ (priv_exc_io Labels) (product_rel (labelled_equiv Γ l) RR) b1 b2 l (m1 σ1) (m2 σ2).
+
+Definition label_state_pi_sec_eutt {R1 R2} priv l (RR : R1 -> R2 -> Prop) m1 m2 :=
+  label_pi_eqit_secure_impstate true true  priv l RR m1 m2.
+
+Definition sem_stmt (s : stmt Labels) := interp_imp (denote_stmt s).
+
+Definition sem_throw_stmt (s : stmt Labels) := interp_imp (throw_prefix (denote_stmt s) ).
+
+Definition sem_expr (e : expr) := LabelledImpTypes.sem_expr Labels e.
+
+Definition state_equiv {E R} (m1 m2 : stateT map (itree E) R) := forall (σ : map), m1 σ ≈ m2 σ.
+
+Global Instance proper_eutt_pi_secure_eutt  {E R1 R2 RR Label priv l} : Proper (@eutt E R1 R1 eq ==> @eutt E R2 R2 eq ==> Basics.flip Basics.impl)
+                                                               (pi_eqit_secure Label priv RR true true l).
+Proof.
+  eapply pi_eqit_secure_eq_itree_proper. all : apply true.
+Qed.
+
+Global Instance proper_eq_itree_secure_eutt  {E R1 R2 RR Label priv l} : Proper (@eq_itree E R1 R1 eq ==> @eq_itree E R2 R2 eq ==> Basics.flip Basics.impl)
+                                                               (pi_eqit_secure Label priv RR true true l).
+Proof.
+  repeat intro. assert (x ≈ y). rewrite H. reflexivity.
+  assert (x0 ≈ y0). rewrite H0. reflexivity. setoid_rewrite H3. rewrite H2. auto.
+Qed.
+
+Global Instance proper_state_equiv_label_state_sec_eutt {R1 R2 RR priv l} : Proper (@state_equiv _ R1 ==> @state_equiv _ R2 ==> iff) (@label_state_pi_sec_eutt R1 R2 priv l RR).
+Proof.
+  repeat intro. split.
+  - intros. do 2 red in H1. do 2 red. intros. red in H0. specialize (H0 σ2). red in H.
+    specialize (H σ1). eapply proper_eutt_pi_secure_eutt; eauto. symmetry. auto. symmetry. auto.
+  - intros. intros. do 2 red in H1. do 2 red. intros. red in H0. specialize (H0 σ2). red in H.
+    specialize (H σ1).  eapply proper_eutt_pi_secure_eutt; eauto.
+Qed.
+
+Context (Γ : privacy_map Labels).
+
+Variant secure_stmt_at_label (observer pc lexn : label) (s : stmt Labels) : Prop :=
+  | ssal_leq : (leq pc observer) -> label_state_pi_sec_eutt Γ observer eq (sem_stmt s) (sem_stmt s) -> secure_stmt_at_label observer pc lexn s
+  | ssal_nleq : (~ leq pc observer) -> label_state_pi_sec_eutt Γ observer top2 (sem_stmt s) (ret tt) -> secure_stmt_at_label observer pc lexn s.
+
+
+
+Variant secure_expr_at_label (observer protection: label ) (e : expr) : Prop :=
+  | seal_leq : (leq protection observer) -> label_state_pi_sec_eutt Γ observer eq (sem_expr e) (sem_expr e) ->
+               secure_expr_at_label observer protection e
+  | seal_nleq : (~leq protection observer) -> (exists n:value, label_state_pi_sec_eutt Γ observer top2 (sem_expr e) (ret n)) ->
+                secure_expr_at_label observer protection e
+.
+
+Definition secure_expr l e := forall observer, secure_expr_at_label observer l e.
+
+Definition secure_stmt pc lexn s := forall observer, secure_stmt_at_label observer pc lexn s.
+
+Variant is_inl {A B : Type} : A + B -> Prop :=
+  | is_inl_ev (a : A) : is_inl (inl a).
+
+
+(* I need cases like rsense_termlexcr so for when public observers look at private
+   exceptions throw the sum type lense *)
+Variant Rsense (observer lexn : label) : unit + label -> unit + label -> Prop :=
+  | rsense_termlr : Rsense observer lexn (inl tt) (inl tt)
+  | rsense_exclr l1 l2 : leq l1 lexn -> leq l2 lexn -> Rsense observer lexn (inr l1) (inr l2)
+  | rsense_termlexcr lpriv : leq lpriv lexn -> ~ leq lpriv observer -> Rsense observer lexn (inl tt) (inr lpriv)
+  | rsense_excltermr lpriv : leq lpriv lexn -> ~ leq lpriv observer -> Rsense observer lexn (inr lpriv) (inl tt)
+.
+
+Instance sym_rsense {observer lexn} : Symmetric (Rsense observer lexn).
+Proof.
+  red. intros. inv H; constructor; auto.
+Qed.
+
+Variant Rsense_unpriv (observer lexn : label) : unit + label -> Prop :=
+  | rup_inl : Rsense_unpriv observer lexn (inl tt)
+  | rup_priv_exc lpriv : ~ leq lpriv observer -> leq lpriv lexn -> Rsense_unpriv observer lexn (inr lpriv).
+
+Variant secure_throw_stmt_at_label (observer pc lexn : label) (s : stmt Labels) : Prop :=
+  | stsal_leq : leq pc observer -> label_state_pi_sec_eutt Γ observer (Rsense observer lexn )
+                                                       (sem_throw_stmt s) (sem_throw_stmt s) -> secure_throw_stmt_at_label observer pc lexn s
+  | stsal_nleq : (~ leq pc observer) -> label_state_pi_sec_eutt Γ observer (fun sum _ => Rsense_unpriv observer lexn sum )
+                                                            (sem_throw_stmt s) (ret tt ) ->  secure_throw_stmt_at_label observer pc lexn s
+  .
+
+Definition secure_throw_stmt pc lexn s := forall observer, secure_throw_stmt_at_label observer pc lexn s.
+
+Lemma pi_sem_stmt_ret_aux:
+  forall (s1 s2 : stmt Labels) (observer : label) (σ3 σ4 : map),
+    (forall σ1 σ2 : map,
+        labelled_equiv Γ observer σ1 σ2 ->
+        pi_eqit_secure _ (priv_exc_io Labels) (product_rel (labelled_equiv Γ observer) top2)
+                       true true observer (sem_stmt s1 σ1) (Ret (σ2, tt))) ->
+    (forall σ1 σ2 : map,
+        labelled_equiv Γ observer σ1 σ2 ->
+        pi_eqit_secure _ (priv_exc_io Labels) (product_rel (labelled_equiv Γ observer) top2)
+                       true true observer (sem_stmt s2 σ1) (Ret (σ2, tt))) ->
+    labelled_equiv Γ observer σ3 σ4 ->
+    pi_eqit_secure _ (priv_exc_io Labels) (product_rel (labelled_equiv Γ observer) eq) true
+                   true observer (interp_state (handle_imp Labels) (denote_stmt s1) σ3)
+                   (interp_state (handle_imp Labels) (denote_stmt s2) σ4).
+Proof.
+  intros s1 s2 observer σ3 σ4 Hσ Hs1 Hs2.
+  eapply pi_eqit_secure_RR_imp with (RR1 := rcompose  (product_rel (labelled_equiv Γ observer) (@top2 unit unit)) (Basics.flip (product_rel (labelled_equiv Γ observer) top2))).
+  { intros [σ5 [] ] [σ6 [] ] Hr. inv Hr. inv REL1. inv REL2. split; auto.
+    destruct r2 as [σ7 [] ]. etransitivity; eauto. symmetry. auto.
+  }
+  eapply pi_eqit_secure_trans_ret; eauto.
+  apply pi_eqit_secure_sym. eapply Hs1. reflexivity.
+Qed.
+
+Lemma pi_sem_throw_stmt_ret_aux:
+  forall (lexn: label) (s1 s2 : stmt Labels) (observer : label) (σ3 σ4 : map),
+    (forall σ1 σ2 : map,
+        labelled_equiv Γ observer σ1 σ2 ->
+        pi_eqit_secure _ (priv_exc_io Labels)
+                       (product_rel (labelled_equiv Γ observer)
+                                    (fun (sum : unit + label) (_ : unit) => Rsense_unpriv observer lexn sum)) true true observer
+                       (sem_throw_stmt s1 σ1) (Ret (σ2, tt))) ->
+    (forall σ1 σ2 : map,
+        labelled_equiv Γ observer σ1 σ2 ->
+        pi_eqit_secure _ (priv_exc_io Labels)
+                       (product_rel (labelled_equiv Γ observer)
+                                    (fun (sum : unit + label) (_ : unit) => Rsense_unpriv observer lexn sum)) true true observer
+                       (sem_throw_stmt s2 σ1) (Ret (σ2, tt))) ->
+    labelled_equiv Γ observer σ3 σ4 ->
+    pi_eqit_secure _ (priv_exc_io Labels)
+                   (product_rel (labelled_equiv Γ observer) (Rsense observer lexn)) true true
+                   observer (interp_state (handle_imp Labels) (throw_prefix (denote_stmt s1)) σ3)
+                   (interp_state (handle_imp Labels) (throw_prefix (denote_stmt s2)) σ4).
+Proof.
+  intros lexn s1 s2 observer σ3 σ4 Hs1 Hs2 Hσ.
+  set (product_rel (labelled_equiv Γ observer) (fun (sum : unit + label) ( _ : unit) => Rsense_unpriv observer lexn sum ) ) as HR.
+  eapply pi_eqit_secure_RR_imp with (RR1 := rcompose HR (Basics.flip HR) ).
+  { unfold HR. intros [σ5 r1] [σ6 r2] Hr. inv Hr. inv REL1. inv REL2.
+    inv H0. inv H2. cbn in H3. cbn in H0. subst.
+    destruct r0 as [σ7 [] ]. split. etransitivity; eauto. symmetry. auto.
+    constructor. cbn in H5. subst. destruct r0 as [σ7 [] ]. split. etransitivity; eauto. symmetry. auto.
+    cbn in H3. subst. constructor; auto. cbn in H5. cbn in H2.
+    subst. destruct r0. split. etransitivity; eauto. symmetry. auto.
+    cbn. inv H2. constructor; auto. constructor; auto.
+  }
+  eapply pi_eqit_secure_trans_ret; eauto. apply pi_eqit_secure_sym.
+  eapply Hs2. reflexivity.
+Qed.
+
+Lemma lower_lexn_sound lexn1 lexn2 t1 t2 observer :
+  leq lexn1 lexn2 ->
+  pi_eqit_secure _ (priv_exc_io Labels)
+                 (product_rel (labelled_equiv Γ observer) (Rsense observer lexn1)) true true
+                 observer t1 t2 ->
+  pi_eqit_secure _ (priv_exc_io Labels)
+                 (product_rel (labelled_equiv Γ observer) (Rsense observer lexn2)) true true
+                 observer t1 t2.
+Proof.
+  intros. eapply pi_eqit_secure_RR_imp; try apply H0.
+  intros [σ1 r1] [σ2 r2] [Hσ Hr]. inv Hr.
+  all : split; auto.
+  - cbn in *; subst; constructor.
+  - cbn in H3; cbn in H4; subst. constructor; auto.
+    all : eapply leq_trans_lat; eauto.
+  - cbn in H3; cbn in H4; subst. constructor; auto.
+    eapply leq_trans_lat; eauto.
+  - cbn in H3; cbn in H4; subst. constructor; auto.
+    eapply leq_trans_lat; eauto.
+Qed.
+
+Lemma lower_lexn_sound' lexn1 lexn2 t1 t2 observer :
+  leq lexn1 lexn2 ->
+  pi_eqit_secure _ (priv_exc_io Labels)
+                 (product_rel (labelled_equiv Γ observer) (fun (sum : unit + label) (_ : unit) => Rsense_unpriv observer lexn1 sum)) true true
+                 observer t1 t2 ->
+  pi_eqit_secure _ (priv_exc_io Labels)
+                 (product_rel (labelled_equiv Γ observer) (fun (sum : unit + label) (_ : unit) => Rsense_unpriv observer lexn2 sum)) true true
+                 observer t1 t2.
+Proof.
+  intros. eapply pi_eqit_secure_RR_imp; try apply H0.
+  intros [σ1 r1] [σ2 [] ] [Hσ Hr]; inv Hr.
+  - cbn in H1; subst. split; auto. constructor.
+  - cbn in H3. subst. split; auto.
+    constructor; auto. eapply leq_trans_lat; eauto.
+Qed.
+
+
+
+Lemma seq_well_typed_correct pc lexn1 lexn2 s1 s2 :
+  secure_stmt pc lexn1 s1 -> secure_stmt (join pc lexn1) lexn2 s2 ->
+  secure_stmt pc (join lexn1 lexn2) (Seq s1 s2).
+Proof.
+  intros Hs1 Hs2 observer.
+  specialize (Hs1 observer). inv Hs1.
+  - left; auto. unfold sem_stmt, interp_imp.
+    cbn. do 2 red. intros σ1 σ2 Hσ. setoid_rewrite interp_state_bind.
+    eapply pi_eqit_secure_bind; eauto. intros [σ3 [] ] [σ4 [] ] [Hσ' _ ].
+    specialize (Hs2 observer). inv Hs2; eauto. cbn. do 2 red in H2. cbn in H2.
+    eapply pi_sem_stmt_ret_aux; eauto.
+  - right; auto. cbn in H0. unfold sem_stmt, interp_imp. cbn.
+    do 2 red. intros σ1 σ2 Hσ.
+    setoid_rewrite <- bind_ret_r with (s := Ret (σ2, tt) ).
+    setoid_rewrite interp_state_bind.
+    eapply pi_eqit_secure_bind; eauto.
+    intros [σ3 [] ] [σ4 [] ] [Hσ' _ ].
+    specialize (Hs2 observer). inv Hs2; eauto.
+    + exfalso. apply H. eapply leq_trans_lat; eauto.
+      apply leq_join_l; auto.
+    + cbn in H2. eauto.
+Qed.
+
+Lemma seq_well_typed_correct' pc lexn1 lexn2 s1 s2 :
+  secure_throw_stmt pc lexn1 s1 -> secure_throw_stmt (join pc lexn1) lexn2 s2 ->
+  secure_throw_stmt pc (join lexn1 lexn2) (Seq s1 s2).
+Proof.
+  intros Hs1 Hs2 observer.
+  specialize (Hs1 observer). inv Hs1.
+  - left; auto. unfold sem_throw_stmt, interp_imp. cbn. do 2 red.
+    intros σ1 σ2 Hσ. setoid_rewrite throw_prefix_bind.
+    setoid_rewrite interp_state_bind.
+    eapply pi_eqit_secure_bind; eauto.
+    intros [σ3 r1] [σ4 r2] [Hσ' Hr]. inv Hr.
+    + specialize (Hs2 observer). inv Hs2; eauto.
+      * cbn.
+        eapply pi_eqit_secure_RR_imp; try eapply H4; eauto.
+        intros. destruct H5. split; auto. inv H6; constructor; auto;
+        try eapply leq_trans_lat; eauto; apply leq_join_r; auto.
+      * cbn in H4. cbn.
+        do 2 red in H4. cbn in Hσ'.
+        eapply lower_lexn_sound. apply leq_join_r; auto.
+        eapply pi_sem_throw_stmt_ret_aux; eauto.
+    + setoid_rewrite interp_state_ret. apply pi_eqit_secure_ret.
+      split; auto; constructor; eapply leq_trans_lat; eauto.
+      all : apply leq_join_l; auto.
+    + specialize (Hs2 observer). inv Hs2; eauto.
+      * exfalso. apply H2. eapply leq_trans_lat; eauto.
+        eapply leq_trans_lat; eauto. apply leq_join_r; auto.
+      * setoid_rewrite interp_state_ret. cbn.
+        cbn in H6. do 2 red in H6.
+        match goal with
+      |- pi_eqit_secure _ _ _ _ _ _ _ ?t => assert (t ≈ ITree.bind (Ret (σ4,tt) ) (fun '(σ',x) => Ret (σ', inr lpriv) )) end.
+        rewrite bind_ret_l. reflexivity.
+        rewrite H7. rewrite <- bind_ret_r.
+        eapply pi_eqit_secure_bind; eauto.
+        intros [σ5 r3] [σ6 r4] [Hσ'' Hr']; inv Hr'.
+        -- cbn in H8. subst. apply pi_eqit_secure_ret. split; auto.
+           constructor; auto. eapply leq_trans_lat; eauto. apply leq_join_l; auto.
+        -- cbn in H10. subst. apply pi_eqit_secure_ret. split; auto.
+           constructor; auto. eapply leq_trans_lat; eauto. apply leq_join_r; auto.
+           eapply leq_trans_lat; eauto. apply leq_join_l; auto.
+    + specialize (Hs2 observer). inv Hs2; eauto.
+      * exfalso. apply H2. eapply leq_trans_lat; eauto.
+        eapply leq_trans_lat; eauto. apply leq_join_r; auto.
+      * setoid_rewrite interp_state_ret. cbn.
+        cbn in H6.
+        match goal with
+        |- pi_eqit_secure _ _ _ _ _ _ ?t _ => assert (t ≈ ITree.bind (Ret (σ3,tt) ) (fun '(σ',x) => Ret (σ', inr lpriv) )) end.
+        rewrite bind_ret_l. reflexivity. rewrite H7.
+        setoid_rewrite <- bind_ret_r at 4.
+        apply pi_eqit_secure_sym. symmetry in Hσ'. eapply pi_eqit_secure_bind; eauto.
+        intros [σ5 r3] [σ6 [] ] [Hσ'' Hr']; inv Hr'.
+        -- cbn in H8. subst. apply pi_eqit_secure_ret. split; auto. symmetry. auto.
+           constructor; auto. eapply leq_trans_lat; eauto. apply leq_join_l; auto.
+        -- cbn in H10. subst. apply pi_eqit_secure_ret. split; auto. symmetry. auto.
+           constructor. eapply leq_trans_lat; eauto. apply leq_join_l; auto.
+           eapply leq_trans_lat; eauto. apply leq_join_r; auto.
+  - right; auto. intros σ1 σ2 Hσ. unfold sem_throw_stmt, interp_imp.
+    cbn. setoid_rewrite throw_prefix_bind. setoid_rewrite interp_state_bind.
+    cbn in H0. rewrite <- bind_ret_r with (s := Ret (σ2, tt) ).
+    eapply pi_eqit_secure_bind; eauto. intros [σ3 r1] [σ4 [] ] [Hσ' Hr]. inv Hr.
+    -- cbn in H1. subst. cbn. specialize (Hs2 observer). inv Hs2.
+       ++ exfalso. apply H. eapply leq_trans_lat; eauto. apply leq_join_l; auto.
+       ++ cbn in H2. eapply lower_lexn_sound'; eauto. apply leq_join_r; auto.
+    -- cbn in H3. subst. cbn.  setoid_rewrite interp_state_ret.
+       apply pi_eqit_secure_ret. split; auto. constructor; auto.
+       eapply leq_trans_lat; eauto. apply leq_join_l; auto.
+Qed.
+
+Lemma try_catch_well_typed_correct pc lexn1 lexn2 s1 s2 :
+  secure_stmt pc lexn1 s1 -> secure_throw_stmt pc lexn1 s1 ->
+  secure_stmt (join pc lexn1) lexn2 s2 ->
+  secure_stmt pc lexn2 (TryCatch s1 s2).
+Proof.
+  intros Hs1 Hs1t Hs2 observer.
+  specialize (Hs1 observer). specialize (Hs1t observer).
+  inv Hs1; inv Hs1t; try contradiction.
+  - left; auto. unfold sem_stmt, interp_imp. do 2 red. intros σ1 σ2 Hσ.
+    cbn. setoid_rewrite try_catch_to_throw_prefix.
+    setoid_rewrite interp_state_bind. eapply pi_eqit_secure_bind; eauto.
+    intros [σ3 r1 ] [σ4 r2 ] [Hσ' Hr] ; inv Hr; cbn.
+    + setoid_rewrite interp_state_ret. apply pi_eqit_secure_ret. split; auto.
+    + specialize (Hs2 observer). inv Hs2; eauto. do 2 red in H8.
+      cbn in H8. eapply pi_sem_stmt_ret_aux; eauto.
+    + specialize (Hs2 observer). inv Hs2.
+      * exfalso. apply H4. eapply leq_trans_lat; eauto.
+        eapply leq_trans_lat; auto. apply leq_join_r; auto. eauto.
+      * apply pi_eqit_secure_sym. do 2 red in H8.
+        apply pi_eqit_secure_RR_imp with (RR1 := product_rel (labelled_equiv Γ observer) top2).
+        { intros [? [] ] [? [] ] ? . inv H9. split; auto. symmetry. auto. }
+        cbn in H8. setoid_rewrite interp_state_ret. eapply H8. symmetry. auto.
+    + specialize (Hs2 observer). inv Hs2.
+      * exfalso. apply H4. eapply leq_trans_lat; eauto.
+        eapply leq_trans_lat; auto. apply leq_join_r; auto. eauto.
+      * do 2 red in H8.
+        apply pi_eqit_secure_RR_imp with (RR1 := product_rel (labelled_equiv Γ observer) top2).
+        { intros [? [] ] [? [] ] ? . inv H9. split; auto. }
+        cbn in H8. setoid_rewrite interp_state_ret. eapply H8. auto.
+  - right; auto. unfold sem_stmt, interp_imp. do 2 red. intros σ1 σ2 Hσ.
+    cbn. setoid_rewrite try_catch_to_throw_prefix.
+    (* rewrite the ret into a trivial bind *)
+    match goal with
+      |- pi_eqit_secure _ _ _ _ _ _ _ ?t => assert (t ≈ ITree.bind (Ret (σ2,tt) ) (fun x => Ret x)) end.
+    rewrite bind_ret_r. reflexivity. rewrite H3.
+    setoid_rewrite interp_state_bind. cbn in H2.
+    eapply pi_eqit_secure_bind; eauto.
+    intros [σ3 r1] [σ4 [] ] [Hσ' Hr]; inv Hr.
+    + tau_steps. apply pi_eqit_secure_ret. split; auto. cbv. auto.
+    + specialize (Hs2 observer). inv Hs2; eauto.
+      * exfalso. apply H. eapply leq_trans_lat; eauto. apply leq_join_l; auto.
+      * cbn in H8. eauto.
+Qed.
+
+Lemma try_catch_well_typed_correct' pc lexn1 lexn2 s1 s2 :
+  secure_stmt pc lexn1 s1 -> secure_throw_stmt pc lexn1 s1 ->
+  secure_throw_stmt (join pc lexn1) lexn2 s2 ->
+  secure_throw_stmt pc lexn2 (TryCatch s1 s2).
+Proof.
+  intros Hs1 Hs1t Hs2 observer. specialize (Hs1 observer).
+  specialize (Hs1t observer). inv Hs1; inv Hs1t; try contradiction.
+  - left; auto. unfold sem_throw_stmt, interp_imp. cbn. do 2 red.
+    intros σ1 σ2 Hσ. rewrite throw_prefix_of_try_catch.
+    setoid_rewrite try_catch_to_throw_prefix.
+    setoid_rewrite throw_prefix_bind.
+    repeat setoid_rewrite interp_state_bind. setoid_rewrite bind_bind.
+    eapply pi_eqit_secure_bind; eauto.
+    intros [σ3 r1] [σ4 r2] [Hσ' Hr]; inv Hr; cbn;
+      try setoid_rewrite throw_prefix_ret; try setoid_rewrite interp_state_ret;
+        try setoid_rewrite bind_ret_l; cbn.
+    + setoid_rewrite interp_state_ret. apply pi_eqit_secure_ret.
+      split; auto. constructor.
+    + specialize (Hs2 observer). inv Hs2; eauto.
+      eapply pi_sem_throw_stmt_ret_aux; eauto.
+    + specialize (Hs2 observer). inv Hs2; eauto.
+      * exfalso. apply H4. eapply leq_trans_lat; eauto.
+        eapply leq_trans_lat; eauto. apply leq_join_r; auto.
+      * apply pi_eqit_secure_sym. cbn in H8. do 2 red in H8.
+        setoid_rewrite interp_state_ret.
+        match goal with
+        |- pi_eqit_secure _ _ _ _ _ _ _ ?t => assert (t ≈ ITree.bind (Ret (σ3, tt) ) (fun '(σ, x) => Ret (σ, inl x) ) ) end.
+        rewrite bind_ret_l. reflexivity. rewrite H9.
+        rewrite <- bind_ret_r. symmetry in Hσ'. eapply pi_eqit_secure_bind; eauto.
+        intros [σ5 r] [σ6 [] ] Hr. inv Hr. inv H11.
+        -- apply pi_eqit_secure_ret. split. symmetry. auto. cbn in H12. subst.
+           constructor.
+        -- cbn in H14. subst. apply pi_eqit_secure_ret. split. symmetry. auto.
+           constructor; auto.
+    + specialize (Hs2 observer). inv Hs2; eauto.
+      * exfalso. apply H4. eapply leq_trans_lat; eauto.
+        eapply leq_trans_lat; eauto. apply leq_join_r; auto.
+      * setoid_rewrite interp_state_ret.
+         match goal with
+        |- pi_eqit_secure _ _ _ _ _ _ _ ?t => assert (t ≈ ITree.bind (Ret (σ4, tt) ) (fun '(σ, x) => Ret (σ, inl x) ) ) end.
+        rewrite bind_ret_l. reflexivity. rewrite H9. cbn in H8.
+        rewrite <- bind_ret_r. eapply pi_eqit_secure_bind; eauto.
+        intros [σ5 r] [σ6 [] ] Hr. inv Hr. inv H11.
+        -- cbn in H12. subst. apply pi_eqit_secure_ret. constructor.
+           auto. constructor.
+        -- cbn in H14. subst. apply pi_eqit_secure_ret. split; auto.
+           constructor; auto.
+  - right; auto. unfold sem_throw_stmt, interp_imp. cbn. do 2 red.
+    intros σ1 σ2 Hσ. rewrite throw_prefix_of_try_catch.
+    rewrite try_catch_to_throw_prefix.
+    rewrite throw_prefix_bind. repeat rewrite interp_state_bind.
+    rewrite bind_bind.
+    setoid_rewrite <- bind_ret_r with (s := Ret (σ2, tt) ).
+    cbn in H2.
+    eapply pi_eqit_secure_bind; eauto.
+    intros [σ3 r1] [σ4 r2] [Hσ' Hr]; inv Hr.
+    + rewrite throw_prefix_ret, interp_state_ret, bind_ret_l. cbn.
+      rewrite interp_state_ret. apply pi_eqit_secure_ret. split; auto.
+      constructor.
+    + specialize (Hs2 observer). inv Hs2; eauto.
+      * exfalso. apply H. eapply leq_trans_lat; eauto. apply leq_join_l; auto.
+      * cbn in H7. setoid_rewrite interp_state_ret. rewrite bind_ret_l.
+        cbn. destruct r2. eauto.
+Qed.
+
+Lemma pi_eqit_secure_while_ret_aux:
+  forall (e : expr) (s : stmt Labels) (observer : label),
+    label_state_pi_sec_eutt Γ observer top2 (sem_stmt s) (ret tt) ->
+    forall σ1 σ2 : map,
+      labelled_equiv Γ observer σ1 σ2 ->
+      pi_eqit_secure _ (priv_exc_io Labels)
+                     (product_rel (labelled_equiv Γ observer) top2) true true
+                     observer (sem_stmt (While e s) σ1) (Ret (σ2, tt)).
+Proof.
+  intros e s observer H0 σ1 σ2 H3.
+  unfold sem_stmt, interp_imp.
+  cbn. specialize (@interp_state_iter') as Hisi. red in Hisi. setoid_rewrite Hisi.
+  eapply pi_eqit_secure_iter_ret with (Rinv := product_rel (labelled_equiv Γ observer) eq ).
+  2 : split; auto.
+  intros [σ3 [] ] [Hσ3 _ ]. cbn.
+  setoid_rewrite interp_state_bind. rewrite bind_bind.
+  specialize (expr_only_ret' Labels e σ3) as [n Hn]. setoid_rewrite Hn.
+  rewrite bind_ret_l. destruct n.
+  + cbn. rewrite interp_state_ret, bind_ret_l. cbn. apply pi_eqit_secure_ret.
+    constructor. split; auto. cbv. auto.
+  + cbn. rewrite interp_state_bind. rewrite bind_bind.
+    rewrite <- (bind_ret_r (Ret (σ2, tt))).
+    cbn in H0.
+    eapply pi_eqit_secure_bind; eauto.
+    intros [σ4 [] ] [σ5 [] ] [Hσ' _ ]. rewrite interp_state_ret, bind_ret_l. cbn.
+    apply pi_eqit_secure_ret. constructor. split; auto.
+Qed.
+
+Lemma pi_eqit_secure_while_ret_throw_aux:
+  forall (e : expr) (s : stmt Labels) (observer lexn : label),
+    label_state_pi_sec_eutt Γ observer (fun (sum : unit + label) (_ : unit) => Rsense_unpriv observer lexn sum)
+                            (sem_throw_stmt s) (ret tt) ->
+    forall σ1 σ2 : map,
+      labelled_equiv Γ observer σ1 σ2 ->
+      pi_eqit_secure _ (priv_exc_io Labels)
+                     (product_rel (labelled_equiv Γ observer)
+                                  (fun (sum : unit + label) (_ : unit) => Rsense_unpriv observer lexn sum)) true true observer
+                     (sem_throw_stmt (While e s) σ1) (Ret (σ2, tt)).
+Proof.
+  intros e s observer lexn H0 σ1 σ2 Hσ.
+  unfold sem_throw_stmt, interp_imp.
+  cbn. setoid_rewrite throw_prefix_iter.
+  specialize (@interp_state_iter') as Hisi. red in Hisi. setoid_rewrite Hisi.
+  apply pi_eqit_secure_iter_ret with (Rinv := product_rel (labelled_equiv Γ observer) eq).
+  2 : split; auto.
+  intros [σ3 [] ] [Hσ3 _ ]. cbn. cbn in Hσ3. setoid_rewrite throw_prefix_bind.
+  repeat setoid_rewrite interp_state_bind. repeat rewrite bind_bind.
+  rewrite throw_prefix_denote_expr. rewrite interp_state_bind, bind_bind.
+  specialize (expr_only_ret' Labels e σ3) as [n Hn]. setoid_rewrite Hn.
+  rewrite bind_ret_l, interp_state_ret, bind_ret_l. cbn.
+  destruct n.
+  + rewrite throw_prefix_ret, interp_state_ret, bind_ret_l. cbn.
+    rewrite interp_state_ret. rewrite bind_ret_l. cbn.
+    apply pi_eqit_secure_ret. constructor. split; auto.
+    constructor.
+  + rewrite throw_prefix_bind. rewrite interp_state_bind. rewrite bind_bind.
+    rewrite <- (bind_ret_r (Ret (σ2, tt))).
+    cbn in H0.
+    eapply pi_eqit_secure_bind; eauto.
+    intros [σ4 r1] [σ5 r2] [Hσ' Hr]; inv Hr.
+    * cbn in H. subst. tau_steps. apply pi_eqit_secure_ret.
+      constructor; auto. split; auto. destruct r2. auto.
+    * cbn in H2. subst. tau_steps.
+      apply pi_eqit_secure_ret. constructor. split; auto. constructor; auto.
+Qed.
+
+Lemma while_well_typed_correct e le pc lexn s :
+  secure_expr le e -> secure_stmt (join pc (join le lexn)) lexn s -> secure_stmt pc lexn (While e s).
+Proof.
+  intros He Hs observer.
+  specialize (He observer). specialize (Hs observer).
+  inv Hs; inv He.
+  - left. eapply leq_trans_lat; try apply H; auto. apply leq_join_l; auto.
+    do 2 red. intros σ1 σ2 Hσ. unfold sem_stmt, interp_imp. cbn.
+    specialize (@interp_state_iter') as Hisi. red in Hisi. setoid_rewrite Hisi.
+    apply secure_eqit_iter with (RA := product_rel (labelled_equiv Γ observer) eq );
+      auto.
+    clear σ1 σ2 Hσ. intros [σ1 [] ] [σ2 [] ] [Hσ _ ].
+    cbn. setoid_rewrite interp_state_bind. repeat rewrite bind_bind.
+    eapply pi_eqit_secure_bind; eauto.
+    intros [σ3 v1] [σ4 v2] [Hσ' Hv]; cbn in Hv; subst. cbn.
+    destruct v2.
+    + setoid_rewrite interp_state_ret. setoid_rewrite bind_ret_l.
+      cbn. apply pi_eqit_secure_ret. constructor. split; auto.
+    + setoid_rewrite interp_state_bind. setoid_rewrite bind_bind.
+      eapply pi_eqit_secure_bind; eauto.
+      intros [σ5 [] ] [σ6 [] ] [Hσ'' _ ]. setoid_rewrite interp_state_ret.
+      setoid_rewrite bind_ret_l. cbn. apply pi_eqit_secure_ret.
+      constructor; split; auto.
+    + split; auto.
+  - exfalso. apply H1.
+    eapply leq_trans_lat with (l2 := join le lexn); eauto.
+    apply leq_join_l; auto.
+    eapply leq_trans_lat; try apply leq_join_r; auto. eauto.
+  - case_leq pc observer.
+    + left; auto. intros σ1 σ2 Hσ.
+      specialize (pi_eqit_secure_while_ret_aux e s observer H0) as Hwhile.
+      eapply pi_sem_stmt_ret_aux; eauto.
+    + right; auto. cbn. do 2 red. intros. eapply pi_eqit_secure_while_ret_aux; eauto.
+  - case_leq pc observer.
+    + left; auto. intros σ1 σ2 Hσ.
+      specialize (pi_eqit_secure_while_ret_aux e s observer H0) as Hwhile.
+      eapply pi_sem_stmt_ret_aux; eauto.
+    + right; auto. cbn. do 2 red. intros. eapply pi_eqit_secure_while_ret_aux; eauto.
+Qed.
+
+
+
+Lemma while_well_typed_correct' e le pc lexn s :
+  secure_expr le e -> secure_throw_stmt (join pc (join le lexn)) lexn s -> secure_throw_stmt pc lexn (While e s).
+Proof.
+  intros He Hs observer.
+  specialize (He observer). specialize (Hs observer).
+  inv Hs; inv He.
+  - left. eapply leq_trans_lat; try apply H; auto. apply leq_join_l; auto.
+    do 2 red. intros σ1 σ2 Hσ. unfold sem_throw_stmt, interp_imp. cbn.
+    setoid_rewrite throw_prefix_iter.
+    specialize (@interp_state_iter') as Hisi. red in Hisi. setoid_rewrite Hisi.
+    eapply secure_eqit_iter with (RA := product_rel (labelled_equiv Γ observer) eq ); auto.
+    intros [σ3 [] ] [σ4 [] ] [Hσ' _ ]. cbn. setoid_rewrite throw_prefix_bind.
+    repeat setoid_rewrite interp_state_bind. repeat rewrite bind_bind.
+    setoid_rewrite throw_prefix_denote_expr. setoid_rewrite interp_state_bind.
+    setoid_rewrite bind_bind.
+    eapply pi_eqit_secure_bind; eauto. intros [σ5 v1] [σ6 v2] [Hσ'' Hv]; cbn in Hv; subst.
+    setoid_rewrite interp_state_ret. setoid_rewrite bind_ret_l. cbn.
+    destruct v2; cbn.
+    + setoid_rewrite throw_prefix_ret. tau_steps.
+      apply pi_eqit_secure_ret. constructor. split; auto. constructor.
+    + setoid_rewrite throw_prefix_bind. setoid_rewrite interp_state_bind.
+      setoid_rewrite bind_bind.
+      eapply pi_eqit_secure_bind; eauto.
+      intros [σ7 r1] [σ8 r2] [Hσ''' Hr]. cbn in Hr. inv Hr.
+      * setoid_rewrite throw_prefix_ret. tau_steps.
+        apply pi_eqit_secure_ret. constructor. split; auto.
+      * tau_steps. apply pi_eqit_secure_ret. constructor. split; auto.
+        constructor; auto.
+      * exfalso. apply H4.
+        eapply leq_trans_lat; eauto.
+        eapply leq_trans_lat; try apply H; auto.
+        eapply leq_trans_lat with (l2 := join le lexn); eauto.
+        apply leq_join_r; auto. apply leq_join_r; auto.
+      * exfalso.  apply H4.
+        eapply leq_trans_lat; eauto.
+        eapply leq_trans_lat; try apply H; auto.
+        eapply leq_trans_lat with (l2 := join le lexn); eauto.
+        apply leq_join_r; auto. apply leq_join_r; auto.
+    + split; auto.
+  - exfalso. apply H1. eapply leq_trans_lat; eauto.
+    eapply leq_trans_lat with (l2 := join le lexn); auto.
+    apply leq_join_l; auto. apply leq_join_r; auto.
+  - case_leq pc observer.
+    + left; auto. intros σ1 σ2 Hσ.
+      specialize (pi_eqit_secure_while_ret_throw_aux e s observer) as Hwhile.
+      eapply pi_sem_throw_stmt_ret_aux; eauto.
+    + right; auto. cbn. intros σ1 σ2 Hσ.
+      eapply pi_eqit_secure_while_ret_throw_aux; eauto.
+  - case_leq pc observer.
+    + left; auto. intros σ1 σ2 Hσ.
+      specialize (pi_eqit_secure_while_ret_throw_aux e s observer) as Hwhile.
+      eapply pi_sem_throw_stmt_ret_aux; eauto.
+    + right; auto. cbn. intros σ1 σ2 Hσ.
+      eapply pi_eqit_secure_while_ret_throw_aux; eauto.
+Qed.
+
+Lemma if_well_typed_correct e le pc lexn1 lexn2 s1 s2 :
+  secure_expr le e -> secure_stmt (join pc le) lexn1 s1 ->
+  secure_stmt (join pc le) lexn2 s2 ->
+  secure_stmt pc (join lexn1 lexn2) (If e s1 s2).
+Proof.
+  intros He Hs1 Hs2 observer.
+  specialize (Hs1 observer). specialize (Hs2 observer).
+  specialize (He observer).
+  inv Hs1; inv Hs2; inv He; try contradiction.
+  - left; auto. eapply leq_trans_lat with (l2 := join pc le);  eauto.
+    apply leq_join_l; auto.
+    intros σ1 σ2 Hσ. unfold sem_stmt, interp_imp.
+    cbn. setoid_rewrite interp_state_bind.
+    eapply pi_eqit_secure_bind; eauto.
+    intros [σ3 v1] [σ4 v2] [Hσ' Hv]; cbn in Hv; subst.
+    destruct v2; cbn; eauto.
+  - exfalso. apply H3. eapply leq_trans_lat; eauto.
+    apply leq_join_r; auto.
+  - right. intro. apply H. apply leq_join_lub; auto.
+    intros σ1 σ2 Hσ. unfold sem_stmt, interp_imp. cbn.
+    setoid_rewrite interp_state_bind.
+    specialize (expr_only_ret' Labels e σ1) as [n Hn]. setoid_rewrite Hn.
+    rewrite bind_ret_l. destruct n; cbn in *; eauto.
+  - case_leq pc observer.
+    + left; auto. intros σ1 σ2 Hσ. unfold sem_stmt, interp_imp. cbn.
+      setoid_rewrite interp_state_bind.
+      specialize (expr_only_ret' Labels e σ1) as [n1 Hn1]. setoid_rewrite Hn1.
+      specialize (expr_only_ret' Labels e σ2) as [n2 Hn2]. setoid_rewrite Hn2.
+      setoid_rewrite bind_ret_l.
+      destruct n1; destruct n2; cbn;
+        eapply pi_sem_stmt_ret_aux; eauto.
+    + right; auto.
+      intros σ1 σ2 Hσ. unfold sem_stmt, interp_imp. cbn.
+      setoid_rewrite interp_state_bind.
+      specialize (expr_only_ret' Labels e σ1) as [n1 Hn1]. setoid_rewrite Hn1.
+      rewrite bind_ret_l. destruct n1; cbn in *; eauto.
+Qed.
+
+Lemma if_well_typed_correct' e le pc lexn1 lexn2 s1 s2 :
+  secure_expr le e -> secure_throw_stmt (join pc le) lexn1 s1 ->
+  secure_throw_stmt (join pc le) lexn2 s2 ->
+  secure_throw_stmt pc (join lexn1 lexn2) (If e s1 s2).
+Proof.
+  intros He Hs1 Hs2 observer.
+  specialize (Hs1 observer). specialize (Hs2 observer).
+  specialize (He observer).
+  inv Hs1; inv Hs2; inv He; try contradiction.
+  - left; auto. eapply leq_trans_lat with (l2 := join pc le);  eauto.
+    apply leq_join_l; auto.
+    unfold sem_throw_stmt, interp_imp. intros σ1 σ2 Hσ.
+    cbn. setoid_rewrite throw_prefix_bind.
+    rewrite throw_prefix_denote_expr.
+    repeat setoid_rewrite interp_state_bind.
+    repeat setoid_rewrite bind_bind.
+    eapply pi_eqit_secure_bind; eauto.
+    intros [σ3 v1] [σ4 v2] [Hσ' Hv]; cbn in Hv; subst.
+    setoid_rewrite interp_state_ret. setoid_rewrite bind_ret_l.
+    cbn. destruct v2; eauto.
+    eapply lower_lexn_sound; eauto. apply leq_join_r; auto.
+    eapply lower_lexn_sound; eauto. apply leq_join_l; auto.
+  - exfalso. apply H3. eapply leq_trans_lat; eauto. apply leq_join_r; auto.
+  - right. intro. apply H.
+    apply leq_join_lub; auto.
+    intros σ1 σ2 Hσ. unfold sem_throw_stmt, interp_imp.
+    cbn. setoid_rewrite throw_prefix_bind.
+    setoid_rewrite throw_prefix_denote_expr.
+    repeat rewrite interp_state_bind. repeat rewrite bind_bind.
+    specialize (expr_only_ret' Labels e σ1) as [n1 Hn1]. setoid_rewrite Hn1.
+    rewrite bind_ret_l. rewrite interp_state_ret, bind_ret_l.
+    cbn.
+    destruct n1; cbn in *; eapply lower_lexn_sound'; eauto.
+    apply leq_join_r; auto. apply leq_join_l; auto.
+  - case_leq pc observer.
+    + left; auto. intros σ1 σ2 Hσ. unfold sem_throw_stmt, interp_imp.
+      cbn. setoid_rewrite throw_prefix_bind. setoid_rewrite interp_state_bind.
+      setoid_rewrite throw_prefix_denote_expr. setoid_rewrite interp_state_bind.
+      repeat rewrite bind_bind.
+      specialize (expr_only_ret' Labels e σ1) as [n1 Hn1]. setoid_rewrite Hn1.
+      specialize (expr_only_ret' Labels e σ2) as [n2 Hn2]. setoid_rewrite Hn2.
+      setoid_rewrite bind_ret_l. setoid_rewrite interp_state_ret.
+      setoid_rewrite bind_ret_l. cbn.
+      assert (label_state_pi_sec_eutt Γ observer
+         (fun (sum : unit + label) (_ : unit) => Rsense_unpriv observer (join lexn1 lexn2) sum)
+         (sem_throw_stmt s1) (ret tt)).
+      { do 2 red. intros. eapply lower_lexn_sound'; eauto. apply leq_join_l; auto. }
+      assert (label_state_pi_sec_eutt Γ observer
+         (fun (sum : unit + label) (_ : unit) => Rsense_unpriv observer (join lexn1 lexn2) sum)
+         (sem_throw_stmt s2) (ret tt)).
+      { do 2 red. intros. eapply lower_lexn_sound'; eauto. apply leq_join_r; auto. }
+      destruct n1; destruct n2; cbn in *; try eapply pi_sem_throw_stmt_ret_aux; eauto.
+   + right; auto.
+     intros σ1 σ2 Hσ. unfold sem_throw_stmt, interp_imp. cbn.
+     setoid_rewrite throw_prefix_bind. setoid_rewrite throw_prefix_denote_expr.
+     repeat rewrite interp_state_bind. repeat rewrite bind_bind.
+     specialize (expr_only_ret' Labels e σ1) as [n1 Hn1]. setoid_rewrite Hn1.
+     rewrite bind_ret_l. rewrite interp_state_ret, bind_ret_l. cbn.
+     destruct n1; try eapply lower_lexn_sound'; cbn in *; eauto.
+     apply leq_join_r; auto. apply leq_join_l; auto.
+Qed.
+
+Lemma secure_expr_upward_close
+     : forall (e : expr) (l1 l2 : L),
+       leq l1 l2 -> secure_expr l1 e -> secure_expr l2 e.
+Proof.
+  intros e l1 l2 Hl He observer.
+  specialize (He observer). inv He.
+  - case_leq l2 observer.
+    + left; auto.
+    + right; auto.
+      exists 0. do 2 red. intros. cbn.
+      specialize (expr_only_ret' Labels e σ1) as [n Hn]. rewrite Hn.
+      apply pi_eqit_secure_ret. split; auto. cbv. auto.
+  - case_leq l2 observer.
+    + left; auto. exfalso. apply H. eapply leq_trans_lat; eauto.
+    + right; auto.
+Qed.
+
+Lemma assign_well_typed_correct e le pc x :
+  secure_expr le e -> leq (join le pc) (Γ x) ->
+  secure_stmt pc bot (Assign x e).
+Proof.
+  intros Hle Hx.
+  assert (Hpc : leq pc (Γ x) ).
+  { eapply leq_trans_lat; eauto. apply leq_join_r; auto. }
+  assert (Hl : leq le (Γ x) ).
+  { eapply leq_trans_lat; try apply H5; auto. apply leq_join_l; auto. eauto. }
+  assert (He : secure_expr (Γ x) e ).
+  { eapply secure_expr_upward_close with (l2:= Γ x); eauto. }
+  intros observer.
+  specialize ( He observer). inv He.
+  - left. eapply leq_trans_lat; eauto.
+    do 2 red in H0. do 2 red. intros. unfold sem_stmt.
+    cbn. unfold interp_imp.
+    setoid_rewrite interp_state_bind. eapply pi_eqit_secure_bind; eauto.
+    intros [σ3 v1] [σ4 v2] [Hσ Hv]; cbn in Hv; subst.
+    setoid_rewrite interp_state_trigger. cbn. apply pi_eqit_secure_ret.
+    split; auto. cbn. eapply update_labelled_equiv_visible; auto.
+  - case_leq pc observer.
+    + left; auto.
+      destruct H0 as [n Hn]. unfold sem_stmt.
+      cbn. unfold interp_imp. do 2 red. intros. setoid_rewrite interp_state_bind.
+      specialize (expr_only_ret' Labels e σ1) as [n1 Hn1]. setoid_rewrite Hn1.
+      specialize (expr_only_ret' Labels e σ2) as [n2 Hn2]. setoid_rewrite Hn2.
+      setoid_rewrite bind_ret_l. cbn. setoid_rewrite interp_state_trigger.
+      cbn. apply pi_eqit_secure_ret. split; auto.
+      cbn. apply update_labelled_equiv_invisible; auto. symmetry.
+      apply update_labelled_equiv_invisible; auto. symmetry; auto.
+    + right; auto.
+      unfold sem_stmt, interp_imp. cbn. intros σ1 σ2 Hσ.
+      setoid_rewrite interp_state_bind.
+      specialize (expr_only_ret' Labels e σ1) as [n1 Hn1]. setoid_rewrite Hn1.
+      rewrite bind_ret_l. setoid_rewrite interp_state_trigger.
+      cbn. apply pi_eqit_secure_ret.
+      split. 2 : cbv; auto. cbn. apply update_labelled_equiv_invisible; auto.
+Qed.
+
+Lemma assign_well_typed_correct' e le pc x :
+  secure_expr le e -> leq (join le pc) (Γ x) ->
+  secure_throw_stmt pc bot (Assign x e).
+Proof.
+  intros Hle Hx.
+  assert (Hpc : leq pc (Γ x) ).
+  { eapply leq_trans_lat; eauto. apply leq_join_r; auto. }
+  assert (Hl : leq le (Γ x) ).
+  { eapply leq_trans_lat; try apply H5; auto. apply leq_join_l; auto. eauto. }
+  assert (He : secure_expr (Γ x) e ).
+  { eapply secure_expr_upward_close with (l2:= Γ x); eauto. }
+  intros observer.
+  specialize ( He observer). inv He.
+  - left. eapply leq_trans_lat; eauto.
+    do 2 red in H0. do 2 red. intros. unfold sem_throw_stmt.
+    cbn. unfold interp_imp. setoid_rewrite throw_prefix_bind.
+    setoid_rewrite throw_prefix_denote_expr.
+    setoid_rewrite interp_state_bind.
+    setoid_rewrite interp_state_bind. repeat rewrite bind_bind.
+    eapply pi_eqit_secure_bind; eauto.
+    intros [σ3 v1] [σ4 v2] [Hσ Hv]; cbn in Hv; subst.
+    setoid_rewrite interp_state_ret. setoid_rewrite bind_ret_l. cbn.
+    setoid_rewrite throw_prefix_ev.
+    setoid_rewrite interp_state_vis. cbn.
+    setoid_rewrite bind_ret_l. tau_steps.
+    apply pi_eqit_secure_ret.
+    split; auto. cbn. eapply update_labelled_equiv_visible; auto.
+    constructor.
+  - case_leq pc observer.
+    + left; auto.
+      destruct H0 as [n Hn]. unfold sem_throw_stmt.
+      cbn. unfold interp_imp. do 2 red. intros.
+      setoid_rewrite throw_prefix_bind. setoid_rewrite throw_prefix_denote_expr.
+      repeat setoid_rewrite interp_state_bind.
+      specialize (expr_only_ret' Labels e σ1) as [n1 Hn1]. setoid_rewrite Hn1.
+      specialize (expr_only_ret' Labels e σ2) as [n2 Hn2]. setoid_rewrite Hn2.
+      repeat rewrite bind_ret_l. tau_steps.
+      apply pi_eqit_secure_ret. split; auto.
+      cbn. apply update_labelled_equiv_invisible; auto. symmetry.
+      apply update_labelled_equiv_invisible; auto. symmetry; auto.
+      constructor.
+    + right; auto.
+      unfold sem_throw_stmt, interp_imp. cbn. intros σ1 σ2 Hσ.
+      setoid_rewrite throw_prefix_bind.
+      setoid_rewrite interp_state_bind. rewrite throw_prefix_denote_expr.
+      setoid_rewrite interp_state_bind.
+      specialize (expr_only_ret' Labels e σ1) as [n1 Hn1]. setoid_rewrite Hn1.
+      tau_steps.
+      apply pi_eqit_secure_ret.
+      split. 2 : constructor. cbn. apply update_labelled_equiv_invisible; auto.
+Qed.
+
+Lemma print_well_typed_correct pc le lp e :
+  secure_expr le e -> leq (join le pc) lp ->
+  secure_stmt pc bot (Output lp e).
+Proof.
+  intros He0 Hle1.
+  assert (Hle : leq le lp).
+  { eapply leq_trans_lat; eauto. apply leq_join_l; auto. }
+  assert (Hpc : leq pc lp).
+  { eapply leq_trans_lat; try apply H5; auto. apply leq_join_r; eauto. eauto.  }
+  assert (He : secure_expr lp e ).
+  { eapply secure_expr_upward_close with (l1 := le); eauto. }
+  intros observer. specialize (He observer).
+  inv He.
+  - left. eapply leq_trans_lat; eauto.
+    unfold sem_stmt, interp_imp. intros σ1 σ2 Hσ.
+    cbn. setoid_rewrite interp_state_bind.
+    eapply pi_eqit_secure_bind; eauto.
+    intros [σ3 v1] [σ4 v4] [Hσ' Hv]; cbn in Hv; subst.
+    cbn. setoid_rewrite interp_state_trigger. cbn.
+    setoid_rewrite bind_trigger. apply pi_eqit_secure_pub_vis.
+    auto. intros []. apply pi_eqit_secure_ret. split; auto.
+  - case_leq pc observer.
+    + left; auto. unfold sem_stmt, interp_imp. intros σ1 σ2 Hσ.
+      cbn. setoid_rewrite interp_state_bind.
+      specialize (expr_only_ret' Labels e σ1) as [n1 Hn1]. setoid_rewrite Hn1.
+      specialize (expr_only_ret' Labels e σ2) as [n2 Hn2]. setoid_rewrite Hn2.
+      setoid_rewrite bind_ret_l. setoid_rewrite interp_state_trigger.
+      cbn. setoid_rewrite bind_trigger. apply pi_eqit_secure_priv_vislr; auto.
+      intros [] []. apply pi_eqit_secure_ret. split; auto.
+    + right; auto. unfold sem_stmt, interp_imp. intros σ1 σ2 Hσ.
+      cbn. setoid_rewrite interp_state_bind.
+      specialize (expr_only_ret' Labels e σ1) as [n1 Hn1]. setoid_rewrite Hn1.
+      rewrite bind_ret_l. rewrite interp_state_trigger. cbn. rewrite bind_trigger.
+      apply pi_eqit_secure_priv_visl; auto. intros [].
+      apply pi_eqit_secure_ret. split; auto. cbv. auto.
+Qed.
+
+Lemma print_well_typed_correct' pc le lp e :
+  secure_expr le e -> leq (join le pc) lp ->
+  secure_throw_stmt pc bot (Output lp e).
+Proof.
+  intros He0 Hle1.
+  assert (Hle : leq le lp).
+  { eapply leq_trans_lat; eauto. apply leq_join_l; auto. }
+  assert (Hpc : leq pc lp).
+  { eapply leq_trans_lat; try apply H5; auto. apply leq_join_r; eauto. eauto.  }
+  assert (He : secure_expr lp e ).
+  { eapply secure_expr_upward_close with (l1 := le); eauto. }
+  intros observer. specialize (He observer).
+  inv He.
+  - left. eapply leq_trans_lat; eauto.
+    unfold sem_throw_stmt, interp_imp. intros σ1 σ2 Hσ.
+    cbn. setoid_rewrite throw_prefix_bind. setoid_rewrite interp_state_bind.
+    setoid_rewrite throw_prefix_denote_expr. setoid_rewrite interp_state_bind.
+    repeat rewrite bind_bind.
+    eapply pi_eqit_secure_bind; eauto.
+    intros [σ3 v1] [σ4 v4] [Hσ' Hv]; cbn in Hv; subst.
+    setoid_rewrite interp_state_ret. setoid_rewrite bind_ret_l.
+    cbn. setoid_rewrite throw_prefix_ev. setoid_rewrite interp_state_vis.
+    cbn. setoid_rewrite bind_trigger. setoid_rewrite bind_vis.
+    apply pi_eqit_secure_pub_vis; auto. intros [].
+    setoid_rewrite bind_ret_l. setoid_rewrite throw_prefix_ret.
+    tau_steps. apply pi_eqit_secure_ret. split; auto; constructor.
+  - case_leq pc observer.
+    + left; auto. unfold sem_throw_stmt, interp_imp. intros σ1 σ2 Hσ.
+      cbn. setoid_rewrite throw_prefix_bind.
+      setoid_rewrite throw_prefix_denote_expr.
+      repeat setoid_rewrite interp_state_bind.
+      repeat rewrite bind_bind.
+      specialize (expr_only_ret' Labels e σ1) as [n1 Hn1]. setoid_rewrite Hn1.
+      specialize (expr_only_ret' Labels e σ2) as [n2 Hn2]. setoid_rewrite Hn2.
+      setoid_rewrite bind_ret_l.
+      setoid_rewrite interp_state_ret. setoid_rewrite bind_ret_l. cbn.
+      setoid_rewrite throw_prefix_ev.
+      setoid_rewrite interp_state_vis.
+      cbn. setoid_rewrite bind_trigger.
+      setoid_rewrite bind_vis.
+      apply pi_eqit_secure_priv_vislr; auto.
+      intros [] []. tau_steps. apply pi_eqit_secure_ret. split; auto. constructor.
+    + right; auto. unfold sem_throw_stmt, interp_imp. intros σ1 σ2 Hσ.
+      cbn.
+      setoid_rewrite throw_prefix_bind. setoid_rewrite interp_state_bind.
+      setoid_rewrite throw_prefix_denote_expr.
+      setoid_rewrite interp_state_bind.
+      specialize (expr_only_ret' Labels e σ1) as [n1 Hn1]. setoid_rewrite Hn1.
+      repeat rewrite bind_ret_l.
+      rewrite interp_state_ret. rewrite bind_ret_l. cbn.
+      setoid_rewrite throw_prefix_ev.
+      rewrite interp_state_vis. cbn. rewrite bind_trigger.
+      rewrite bind_vis.
+      apply pi_eqit_secure_priv_visl; auto. intros [].
+      tau_steps.
+      apply pi_eqit_secure_ret. split; auto. cbv. constructor.
+Qed.
+
+Lemma skip_well_typed_correct pc :
+  secure_stmt pc bot Skip.
+Proof.
+  intros observer. case_leq pc observer.
+  - left; auto. do 2 red. unfold sem_stmt. intros σ1 σ2 Hσ.
+    cbn. setoid_rewrite interp_state_ret. apply pi_eqit_secure_ret.
+    split; auto.
+  - right; auto. do 2 red. unfold sem_stmt. intros σ1 σ2 Hσ.
+    cbn. setoid_rewrite interp_state_ret. apply pi_eqit_secure_ret.
+    split; auto. cbv. auto.
+Qed.
+
+Lemma skip_well_typed_correct' pc :
+  secure_throw_stmt pc bot Skip.
+Proof.
+  intros observer. case_leq pc observer.
+  - left; auto. do 2 red. unfold sem_throw_stmt. intros σ1 σ2 Hσ.
+    cbn. setoid_rewrite throw_prefix_ret.
+    setoid_rewrite interp_state_ret. apply pi_eqit_secure_ret.
+    split; auto. constructor.
+  - right; auto. do 2 red. unfold sem_throw_stmt. intros σ1 σ2 Hσ.
+    cbn. setoid_rewrite throw_prefix_ret.
+    setoid_rewrite interp_state_ret. apply pi_eqit_secure_ret.
+    split; auto. constructor.
+Qed.
+
+Lemma raise_well_typed pc lexn :
+  leq pc lexn -> secure_stmt pc lexn (Raise lexn).
+Proof.
+  intros Hpc observer. case_leq pc observer.
+  - left; auto. unfold sem_stmt, interp_imp. do 2 red. intros.
+    cbn. setoid_rewrite bind_trigger. setoid_rewrite interp_state_vis.
+    cbn. setoid_rewrite bind_trigger. setoid_rewrite bind_vis.
+    case_leq lexn observer.
+    + apply pi_eqit_secure_pub_vis. auto. intros [].
+    + apply pi_eqit_secure_priv_vislr; auto. intros [].
+  - right; auto. unfold sem_stmt, interp_imp. do 2 red. intros.
+    cbn. setoid_rewrite bind_trigger. setoid_rewrite interp_state_vis.
+    cbn. setoid_rewrite bind_trigger. setoid_rewrite bind_vis.
+    apply pi_eqit_secure_priv_visl. 2 : intros []. intro.
+    apply Hnleq. eapply leq_trans_lat; eauto.
+Qed.
+
+Lemma raise_well_typed' pc lexn :
+  leq pc lexn -> secure_throw_stmt pc lexn (Raise lexn).
+Proof.
+  intros Hpc observer. case_leq pc observer.
+  - left; auto. unfold sem_throw_stmt, interp_imp.
+    cbn. do 2 red. intros. setoid_rewrite bind_trigger.
+    setoid_rewrite throw_prefix_exc. setoid_rewrite interp_state_ret.
+    apply pi_eqit_secure_ret; auto. split; auto. constructor.
+    all : apply leq_refl_lat; auto.
+  - right; auto. do 2 red. intros. unfold sem_throw_stmt, interp_imp.
+    cbn. setoid_rewrite bind_trigger.
+    setoid_rewrite throw_prefix_exc. setoid_rewrite interp_state_ret.
+    apply pi_eqit_secure_ret. split; auto.
+    constructor. 2 : apply leq_refl_lat; auto.
+    intro.
+    apply Hnleq. eapply leq_trans_lat; eauto.
+Qed.
+
+Definition well_typed_expr := LabelledImpTypes.well_typed_expr Labels Γ.
+
+
+(* rework this definition to have only public exceptions*)
+Inductive well_typed_stmt : label -> label -> stmt Labels -> Prop :=
+  | wts_manual pc lexn s : secure_stmt pc lexn s /\ secure_throw_stmt pc lexn s -> well_typed_stmt pc lexn s
+  | wts_skip pc : well_typed_stmt pc bot Skip
+  | wts_seq pc lexn1 lexn2 s1 s2 : well_typed_stmt pc lexn1 s1 -> well_typed_stmt (join pc lexn1) lexn2 s2 ->
+                                   well_typed_stmt pc (join lexn1 lexn2) (Seq s1 s2)
+  | wts_assign pc l x e : well_typed_expr l e -> leq (join l pc) (Γ x) ->
+                          well_typed_stmt pc bot (Assign x e)
+  | wts_print pc le lp e : well_typed_expr le e -> leq (join le pc) lp ->
+                           well_typed_stmt pc bot (Output lp e)
+  | wts_if pc le e lexn1 lexn2 s1 s2 : well_typed_expr le e -> well_typed_stmt (join pc le) lexn1 s1 -> well_typed_stmt (join pc le) lexn2 s2 ->
+                                       well_typed_stmt pc (join lexn1 lexn2) (If e s1 s2)
+  | wts_while e le pc lexn s : well_typed_expr le e -> well_typed_stmt (join pc (join le lexn)) lexn s ->
+                         well_typed_stmt pc lexn (While e s)
+  | wts_raise pc lexn : leq pc lexn -> well_typed_stmt pc lexn (Raise lexn)
+  | wts_try pc lexn1 lexn2 s1 s2 : well_typed_stmt pc lexn1 s1 -> well_typed_stmt (join pc lexn1) lexn2 s2 ->
+                                   well_typed_stmt pc lexn2 (TryCatch s1 s2)
+.
+
+Lemma well_typed_expr_correct e l :
+  well_typed_expr l e -> secure_expr l e.
+Proof.
+  intros He observer.
+  apply well_typed_expr_correct in He; auto.
+  specialize (He observer). inv He.
+  - left; auto. do 2 red. intros. eapply eqit_secure_imp_pi_eqit_scure; eauto.
+  - right; auto. destruct H0 as [n Hn]. exists n.
+    do 2 red. intros. eapply eqit_secure_imp_pi_eqit_scure; eauto.
+Qed.
+
+
+Lemma well_typed_stmt_sound s pc lexn : well_typed_stmt s pc lexn -> secure_stmt s pc lexn.
+Proof.
+  intros Htype. enough (secure_stmt s pc lexn /\ secure_throw_stmt s pc lexn); try tauto.
+  induction Htype; eauto.
+  - (* Skip *) split; try apply skip_well_typed_correct; try apply skip_well_typed_correct'.
+  - (* Seq *)
+    split; try apply seq_well_typed_correct; try apply seq_well_typed_correct'; tauto.
+  - (* Assign *)
+    split; try eapply assign_well_typed_correct; try eapply assign_well_typed_correct';
+      try apply well_typed_expr_correct; eauto.
+  - (* Output *)
+    split; try eapply print_well_typed_correct; try eapply print_well_typed_correct';
+      try apply well_typed_expr_correct; eauto.
+  - (* If *)
+    apply well_typed_expr_correct in H.
+    split; try eapply if_well_typed_correct; try eapply if_well_typed_correct'; eauto; try tauto.
+  - (* While *)
+    destruct IHHtype. apply well_typed_expr_correct in H.
+    split; try eapply while_well_typed_correct; try eapply while_well_typed_correct'; eauto.
+  - (* Raise *)
+    split; try eapply raise_well_typed; try eapply raise_well_typed'; eauto.
+  - (* TryCatch *)
+    destruct IHHtype1. destruct IHHtype2.
+    split; try eapply try_catch_well_typed_correct; try eapply try_catch_well_typed_correct'; eauto.
+Qed.
+
+Lemma secure_stmt_lower_pc:
+  forall (pc2 : label) lexn (s : stmt Labels),
+    secure_stmt pc2 lexn s -> forall pc1 : L, leq pc1 pc2 -> secure_stmt pc1 lexn s.
+Proof.
+  intros pc2 lexn s H pc1 Hpc observer.
+  specialize (H observer). inv H.
+  - left. eapply leq_trans_lat; eauto. auto.
+  - case_leq pc1 observer.
+    + left; auto. cbn in H1. intros σ1 σ2 Hσ.
+      eapply pi_sem_stmt_ret_aux; eauto.
+    + right; auto.
+Qed.
+
+Lemma secure_throw_stmt_lower_pc:
+  forall (pc lexn : label) (s : stmt Labels),
+    secure_throw_stmt pc lexn s -> forall pc1 : L, leq pc1 pc -> secure_throw_stmt pc1 lexn s.
+Proof.
+  intros pc lexn s H pc1 Hpc observer.
+  specialize (H observer). inv H.
+  - left. eapply leq_trans_lat; eauto. auto.
+  - case_leq pc1 observer.
+    + left; auto. cbn in H1. intros σ1 σ2 Hσ.
+      eapply pi_sem_throw_stmt_ret_aux; eauto.
+    + right; auto.
+Qed.
+(* Would need to make annoying changes to type system for this to technically hold
+Lemma lower_pc_sound s lexn pc1 pc2 :
+  leq pc1 pc2 -> well_typed_stmt pc2 lexn s -> well_typed_stmt pc1 lexn s.
+Proof.
+  intros Hpc Hs. generalize dependent pc1. induction Hs; intros.
+  - constructor. destruct H. split. eapply secure_stmt_lower_pc; eauto.
+    eapply secure_throw_stmt_lower_pc; eauto.
+  - apply wts_skip.
+  - apply wts_seq; eauto. eapply IHHs2.
+    destruct pc1; destruct pc; destruct lexn1; cbv; auto; try contradiction.
+  - eapply wts_assign; eauto. eapply leq_trans_lat; eauto.
+    destruct l; destruct pc; destruct pc1; cbv; auto; contradiction.
+  - eapply wts_print; eauto. eapply leq_trans_lat; eauto.
+    destruct le; destruct pc; destruct pc1; cbv; auto; contradiction.
+  - eapply wts_if; eauto. eapply IHHs1. 2: eapply IHHs2.
+    all :  destruct le; destruct pc; destruct pc1; cbv; auto; contradiction.
+  - eapply wts_while; eauto. eapply IHHs.
+    destruct le; destruct pc; destruct pc1; destruct lexn; cbv; auto; contradiction.
+  - apply wts_raise. eapply leq_trans_lat; eauto.
+  - eapply wts_try; eauto. eapply IHHs2.
+    destruct pc; destruct pc1; destruct lexn1; cbv; auto; contradiction.
+Qed.
+*)
+End LabelledImpTypesProgInsens.

--- a/secure_example/Lattice.v
+++ b/secure_example/Lattice.v
@@ -1,0 +1,126 @@
+From Coq Require Import Morphisms.
+
+From ITree Require Import Secure.SecureEqHalt.
+
+Class Lattice := {
+  T : Type;
+  join : T -> T -> T;
+  meet : T -> T -> T;
+  eqlat : T -> T -> Prop;
+  top : T;
+  bot : T;
+
+}.
+
+Class LatticeLaws (Lat : Lattice) := {
+  eq_equiv : Equivalence eqlat;
+  join_proper : Proper (eqlat ==> eqlat ==> eqlat) join;
+  meet_proper : Proper (eqlat ==> eqlat ==> eqlat) meet;
+  eqlat_dec : forall l1 l2, {eqlat l1 l2} + {~ eqlat l1 l2};
+  join_comm : forall l1 l2, eqlat (join l1 l2) (join l2 l1);
+  join_assoc : forall l1 l2 l3, eqlat (join l1 (join l2 l3)) (join (join l1 l2) l3 );
+  meet_comm : forall l1 l2, eqlat (meet l1 l2) (meet l2 l1);
+  meet_assoc : forall l1 l2 l3, eqlat (meet l1 (meet l2 l3) ) (meet (meet l1 l2) l3 );
+  join_unit : forall l, eqlat l (join l bot);
+  meet_unit : forall l, eqlat l (meet l top);
+  absorb1 : forall l1 l2, eqlat (join l1 (meet l1 l2) ) l1;
+  absorb2 : forall l1 l2, eqlat (meet l1 (join l1 l2) ) l1;
+}.
+
+
+#[global] Instance PreOrderOfLattice (Lat : Lattice)  : Preorder :=
+  {|
+  L := T;
+  leq := fun l1 l2 => eqlat (join l1 l2) l2;
+  |}.
+
+Lemma join_idempot (Lat : Lattice) {HLat : LatticeLaws Lat} (l : L) :
+  eqlat (join l l) l.
+Proof.
+  destruct HLat. setoid_rewrite meet_unit0 at 3. apply absorb3.
+Qed.
+
+Lemma meet_idempot (Lat : Lattice) {HLat : LatticeLaws Lat} (l : L) :
+  eqlat (meet l l) l.
+Proof.
+  destruct HLat. setoid_rewrite join_unit0 at 3. apply absorb4.
+Qed.
+
+Lemma leq_trans_lat (Lat : Lattice) {HLat : LatticeLaws Lat}  (l1 l2 l3 : L) :
+  leq l1 l2 -> leq l2 l3 -> leq l1 l3.
+Proof.
+  cbn. intros H12 H23. destruct HLat. setoid_rewrite <- H23.
+  rewrite join_assoc0. rewrite H12. reflexivity.
+Qed.
+
+Lemma leq_join_l (Lat : Lattice) {HLat : LatticeLaws Lat}  (l1 l2 : L) :
+  leq l1 (join l1 l2).
+Proof.
+  cbn. assert (LatticeLaws Lat). auto. destruct HLat. rewrite join_assoc0. rewrite join_idempot; auto.
+  reflexivity.
+Qed.
+
+Lemma leq_join_r (Lat : Lattice) {HLat : LatticeLaws Lat}  (l1 l2 : L) :
+  leq l2 (join l1 l2).
+Proof.
+  cbn. assert (LatticeLaws Lat). auto. destruct HLat. rewrite join_comm0. rewrite <- join_assoc0.
+  rewrite join_idempot; auto. reflexivity.
+Qed.
+
+Lemma leq_refl_lat (Lat : Lattice) {HLat : LatticeLaws Lat} l :
+  leq l l.
+Proof.
+  cbn. apply join_idempot; auto.
+Qed.
+
+Lemma leq_join_and (Lat : Lattice) {HLat : LatticeLaws Lat} (l1 l2 l3 : L) :
+  leq (join l1 l2) l3 -> leq l1 l3 /\ leq l2 l3.
+Proof.
+  intros. split.
+  eapply leq_trans_lat; eauto. apply leq_join_l; auto.
+  eapply leq_trans_lat; eauto. apply leq_join_r; auto.
+Qed.
+
+Lemma leqlat_join_or (Lat : Lattice) {HLat : LatticeLaws Lat} (l1 l2 l3 : L) :
+  ~ (leq (join l1 l2) l3) -> ~ leq l1 l3 \/ ~ leq l2 l3.
+Proof.
+  intros. cbn. destruct HLat. destruct (eqlat_dec0 (join l1 l3) l3); eauto.
+  right. intro. cbn in H. rewrite <- join_assoc0 in H.
+  rewrite H0 in H. contradiction.
+Qed.
+
+Lemma leq_dec (Lat : Lattice) {HLat : LatticeLaws Lat} (l1 l2 : L) :
+  {leq l1 l2} + {~ leq l1 l2}.
+Proof.
+  cbn. destruct HLat. auto.
+Qed.
+
+Lemma leq_bot (Lat : Lattice) {HLat : LatticeLaws Lat} l :
+  leq bot l.
+Proof.
+  cbn. destruct HLat. rewrite join_comm0. rewrite <- join_unit0.
+  reflexivity.
+Qed.
+
+Lemma leq_top  (Lat : Lattice) {HLat : LatticeLaws Lat} l :
+  leq l top.
+Proof.
+  cbn. destruct HLat. rewrite join_comm0. rewrite (meet_unit0 l).
+  rewrite meet_comm0. rewrite absorb3. reflexivity.
+Qed.
+
+Lemma leq_join_lub (Lat : Lattice) {HLat : LatticeLaws Lat} l1 l2 l3 :
+  leq l1 l3 -> leq l2 l3 -> leq (join l1 l2) l3.
+Proof.
+  cbn. intros. destruct HLat. rewrite <- join_assoc0. rewrite H0. auto.
+Qed.
+
+#[global] Instance proper_leq1 (Lat : Lattice) {HLat : LatticeLaws Lat} : Proper (eqlat ==> eqlat ==> Basics.flip Basics.impl) leq.
+Proof.
+  cbn. repeat intro. destruct HLat. rewrite H, H0. auto.
+Qed.
+
+#[global] Instance proper_leq2 (Lat : Lattice) {HLat : LatticeLaws Lat} : Proper (eqlat ==> eqlat ==> Basics.impl) leq.
+Proof.
+  cbn. repeat intro. destruct HLat. rewrite <- H. rewrite <- H0. auto.
+Qed.

--- a/secure_example/Makefile
+++ b/secure_example/Makefile
@@ -1,0 +1,7 @@
+.PHONY: secure
+
+secure: coq
+
+include ../common.mk
+
+clean: clean-coq

--- a/secure_example/Utils_tutorial.v
+++ b/secure_example/Utils_tutorial.v
@@ -1,0 +1,640 @@
+(** * Utilities for the compiler tutorial *)
+
+(** This file should not be required to be read for
+    understanding the remaining of the tutorial.
+    It however contains no hidden black magic. Its
+    main content is the following:
+    - a few simple generic tactics;
+    - a collection of facts about ExtLib's association
+    lists [alist] that should probably be moved over ExtLib;
+    - a function converting [nat] to their decimal representation
+    as [string], and an unreasonably painful proof of the injectivity
+    of this function.
+    - a [traverse_] function.
+*)
+
+(* begin hide *)
+From Coq Require Import Lia Arith ZArith Ascii String List.
+
+From ExtLib Require Import
+     Structures.Monad
+     Core.RelDec
+     Data.Map.FMapAList.
+
+Import MonadNotation.
+(* end hide *)
+
+Ltac flatten_goal :=
+  match goal with
+  | |- context[match ?x with | _ => _ end] => let Heq := fresh "Heq" in destruct x eqn:Heq
+  end.
+
+Ltac flatten_hyp h :=
+  match type of h with
+  | context[match ?x with | _ => _ end] => let Heq := fresh "Heq" in destruct x eqn:Heq
+  end.
+
+Ltac flatten_all :=
+  match goal with
+  | h: context[match ?x with | _ => _ end] |- _ => let Heq := fresh "Heq" in destruct x eqn:Heq
+  | |- context[match ?x with | _ => _ end] => let Heq := fresh "Heq" in destruct x eqn:Heq
+  end.
+
+Ltac inv h := inversion h; subst; clear h.
+
+Section alistFacts.
+  (* Generic facts about alists. To eventually move to ExtLib. *)
+
+  Arguments alist_find {_ _ _ _}.
+
+  Definition alist_In {K R RD V} k m v := @alist_find K R RD V k m = Some v.
+
+  Arguments alist_add {_ _ _ _}.
+  Arguments alist_find {_ _ _ _}.
+  Arguments alist_remove {_ _ _ _}.
+
+  Context {K V: Type}.
+  Context {RR : @RelDec K (@eq K)}.
+  Context {RRC : @RelDec_Correct K (@eq K) RR}.
+
+  Lemma In_add_eq:
+    forall k v (m: alist K V),
+      alist_In k (alist_add k v m) v.
+  Proof.
+    intros; unfold alist_add, alist_In; simpl; flatten_goal; [reflexivity | rewrite <- neg_rel_dec_correct in Heq; tauto].
+  Qed.
+
+  (* A removed key is not contained in the resulting map *)
+  Lemma not_In_remove:
+    forall (m : alist K V) (k : K) (v: V),
+      ~ alist_In k (alist_remove k m) v.
+  Proof.
+    induction m as [| [k1 v1] m IH]; intros.
+    - simpl; intros abs; inv abs.
+    - simpl; flatten_goal.
+      + unfold alist_In; simpl.
+        rewrite Bool.negb_true_iff in Heq; rewrite Heq.
+        intros abs; eapply IH; eassumption.
+      + rewrite Bool.negb_false_iff, rel_dec_correct in Heq; subst.
+        intros abs; eapply IH; eauto.
+  Qed.
+
+  (* Removing a key does not alter other keys *)
+  Lemma In_In_remove_ineq:
+    forall (m : alist K V) (k : K) (v : V) (k' : K),
+      k <> k' ->
+      alist_In k m v ->
+      alist_In k (alist_remove k' m) v.
+  Proof.
+    induction m as [| [? ?] m IH]; intros ?k ?v ?k' ineq IN; [inversion IN |].
+    simpl.
+    flatten_goal.
+    - unfold alist_In in *; simpl in *.
+      rewrite Bool.negb_true_iff, <- neg_rel_dec_correct in Heq.
+      flatten_goal; auto.
+    - unfold alist_In in *; simpl in *.
+      rewrite Bool.negb_false_iff, rel_dec_correct in Heq; subst.
+      flatten_hyp IN; [rewrite rel_dec_correct in Heq; subst; tauto | eapply IH; eauto].
+  Qed.
+
+  Lemma In_remove_In_ineq:
+    forall (m : alist K V) (k : K) (v : V) (k' : K),
+      alist_In k (alist_remove k' m) v ->
+      alist_In k m v.
+  Proof.
+    induction m as [| [? ?] m IH]; intros ?k ?v ?k' IN; [inversion IN |].
+    simpl in IN; flatten_hyp IN.
+    - unfold alist_In in *; simpl in *.
+      flatten_all; auto.
+      eapply IH; eauto.
+    -rewrite Bool.negb_false_iff, rel_dec_correct in Heq; subst.
+     unfold alist_In; simpl.
+     flatten_goal; [rewrite rel_dec_correct in Heq; subst |].
+     exfalso; eapply not_In_remove; eauto.
+     eapply IH; eauto.
+  Qed.
+
+  Lemma In_remove_In_ineq_iff:
+    forall (m : alist K V) (k : K) (v : V) (k' : K),
+      k <> k' ->
+      alist_In k (alist_remove k' m) v <->
+      alist_In k m v.
+  Proof.
+    intros; split; eauto using In_In_remove_ineq, In_remove_In_ineq.
+  Qed.
+
+  (* Adding a value to a key does not alter other keys *)
+  Lemma In_In_add_ineq:
+    forall k v k' v' (m: alist K V),
+      k <> k' ->
+      alist_In k m v ->
+      alist_In k (alist_add k' v' m) v.
+  Proof.
+    intros.
+    unfold alist_In; simpl; flatten_goal; [rewrite rel_dec_correct in Heq; subst; tauto |].
+    apply In_In_remove_ineq; auto.
+  Qed.
+
+  Lemma In_add_In_ineq:
+    forall k v k' v' (m: alist K V),
+      k <> k' ->
+      alist_In k (alist_add k' v' m) v ->
+      alist_In k m v.
+  Proof.
+    intros k v k' v' m ineq IN.
+    unfold alist_In in IN; simpl in IN; flatten_hyp IN; [rewrite rel_dec_correct in Heq; subst; tauto |].
+    eapply In_remove_In_ineq; eauto.
+  Qed.
+
+  Lemma In_add_ineq_iff:
+    forall m (v v' : V) (k k' : K),
+      k <> k' ->
+      alist_In k m v <-> alist_In k (alist_add k' v' m) v.
+  Proof.
+    intros; split; eauto using In_In_add_ineq, In_add_In_ineq.
+  Qed.
+
+  (* alist_find fails iff no value is associated to the key in the map *)
+  Lemma alist_find_None:
+    forall k (m: alist K V),
+      (forall v, ~ In (k,v) m) <-> alist_find k m = None.
+  Proof.
+    induction m as [| [k1 v1] m IH]; [simpl; easy |].
+    simpl; split; intros H.
+    - flatten_goal; [rewrite rel_dec_correct in Heq; subst; exfalso | rewrite <- neg_rel_dec_correct in Heq].
+      apply (H v1); left; reflexivity.
+      apply IH; intros v abs; apply (H v); right; assumption.
+    - intros v; flatten_hyp H; [inv H | rewrite <- IH in H].
+      intros [EQ | abs]; [inv EQ; rewrite <- neg_rel_dec_correct in Heq; tauto | apply (H v); assumption].
+  Qed.
+
+  Lemma alist_In_add_eq : forall m (k:K) (v n:V), alist_In k (alist_add k n m) v -> n = v.
+  Proof.
+    destruct m as [| [k1 v1]]; intros.
+    - unfold alist_add in H.
+      unfold alist_In in H. simpl in H.
+      destruct (k ?[ eq ] k); inversion H; auto.
+    - unfold alist_add in H.
+      unfold alist_In in H.
+      simpl in H.
+      destruct (k ?[ eq ] k). inversion H; auto.
+      pose proof (@not_In_remove ((k1,v1)::m)).
+      unfold alist_In in H0. simpl in H0.
+      apply H0 in H.
+      contradiction.
+  Qed.
+
+  Lemma alist_find_remove_none:
+    forall (m : list (K*V)) (k1 k2 : K), k2 <> k1 -> alist_find k1 (alist_remove k2 m) = None -> alist_find k1 m = None.
+  Proof.
+    induction m as [| [? ?] m IH]; intros ?k1 ?k2 ineq HF; simpl in *.
+    - reflexivity.
+    - destruct (rel_dec_p k1 k).
+      + subst. eapply rel_dec_neq_false in ineq; eauto. rewrite ineq in HF. simpl in HF.
+        assert (k = k) by reflexivity.
+        apply rel_dec_correct in H. rewrite H in HF. inversion HF.
+      + destruct (rel_dec_p k2 k); simpl in *.
+        apply rel_dec_correct in e. rewrite e in HF. simpl in HF.
+        eapply rel_dec_neq_false in n; eauto. rewrite n. eapply IH. apply ineq. assumption.
+        eapply rel_dec_neq_false in n0; eauto. rewrite n0 in HF. simpl in HF.
+        eapply rel_dec_neq_false in n; eauto. rewrite n in *. eapply IH. apply ineq. assumption.
+  Qed.
+
+  Lemma alist_find_add_none:
+    forall m (k r :K) (v:V),
+    alist_find k (alist_add r v m) = None ->
+    alist_find k m = None.
+  Proof.
+    destruct m as [| [k1 v1]]; intros.
+    - reflexivity.
+    - simpl in *.
+      remember (k ?[ eq ] r) as x.
+      destruct x.  inversion H.
+      remember (r ?[ eq] k1) as y.
+      destruct y. simpl in *. symmetry in Heqy. rewrite rel_dec_correct in Heqy. subst.
+      rewrite <- Heqx.
+      apply (alist_find_remove_none _ k k1); auto.
+      rewrite rel_dec_sym in Heqx; eauto.
+      apply neg_rel_dec_correct. symmetry in Heqx. assumption.
+      simpl in H.
+      destruct (k ?[ eq ] k1); auto.
+      apply (alist_find_remove_none _ k r); auto.
+      rewrite rel_dec_sym in Heqx; eauto.
+      apply neg_rel_dec_correct. symmetry in Heqx. assumption.
+  Qed.
+
+
+  Lemma alist_find_neq : forall m (k r:K) (v:V), k <> r -> alist_find k (alist_add r v m) = alist_find k m.
+  Proof.
+    intros.
+    remember (alist_find k (alist_add r v m)) as x.
+    destruct x.
+    - symmetry in Heqx. apply In_add_In_ineq in Heqx; auto.
+    - symmetry in Heqx. symmetry. eapply alist_find_add_none. apply Heqx.
+ Qed.
+
+
+End alistFacts.
+Arguments alist_find {_ _ _ _}.
+Arguments alist_add {_ _ _ _}.
+Arguments alist_find {_ _ _ _}.
+Arguments alist_remove {_ _ _ _}.
+Require Import FunInd Recdef.
+
+Section nat_Show.
+  Local Open Scope string.
+
+  Definition get_last_digit (n: nat): string :=
+    match n mod 10 with
+    | 0 => "0" | 1 => "1" | 2 => "2" | 3 => "3" | 4 => "4" | 5 => "5"
+    | 6 => "6" | 7 => "7" | 8 => "8" | _ => "9"
+    end.
+
+  Function string_of_nat_aux (acc: string) (n : nat) {measure id n}: string :=
+    let acc' := get_last_digit n ++ acc in
+    match n / 10 with
+    | 0 => acc'
+    | n' => string_of_nat_aux acc' n'
+    end.
+  intros _ n m ineq.
+  unfold id; simpl.
+  destruct n as [| n]; [simpl in *; easy |].
+  rewrite <- ineq; apply Nat.div_lt; lia.
+  Defined.
+
+  Definition string_of_nat := string_of_nat_aux "".
+
+  Lemma mod_div_eq: forall a b q,
+      q <> 0 ->
+      a mod q = b mod q ->
+      a / q = b / q ->
+      a = b.
+  Proof.
+    intros.
+    rewrite (Nat.div_mod a q); auto.
+    rewrite (Nat.div_mod b q); auto.
+  Qed.
+
+  Lemma get_last_digit_inj: forall n m,
+      n <> m ->
+      n/10 = m/10 ->
+      get_last_digit n <>
+      get_last_digit m.
+  Proof.
+    intros n m ineq eq.
+    unfold get_last_digit.
+    do 9 (flatten_goal; [repeat flatten_goal; try easy; exfalso; apply ineq,(mod_div_eq n m 10); lia |]).
+    subst.
+    do 9 (flatten_goal; [easy |]).
+    subst.
+    exfalso.
+    destruct n8.
+    2: generalize (Nat.mod_upper_bound n 10 (ltac:(auto))); intros EQ; rewrite Heq in EQ; lia.
+    destruct n9.
+    2: generalize (Nat.mod_upper_bound m 10 (ltac:(auto))); intros EQ; rewrite Heq0 in EQ; lia.
+    exfalso; apply ineq,(mod_div_eq n m 10); lia.
+  Qed.
+
+  Lemma append_EmptyString: forall s,
+      s ++ "" = s.
+  Proof.
+    induction s as [| c s IH]; simpl; auto.
+    rewrite IH; auto.
+  Qed.
+
+  Lemma append_String: forall s c s',
+      s ++ String c s' = (s ++ String c "") ++ s'.
+  Proof.
+    induction s as [| c' s IH]; simpl; intros c s'; auto.
+    f_equal.
+    apply IH.
+  Qed.
+
+  Lemma append_char_simplify_r: forall s s' c,
+      s ++ String c "" = s' ++ String c "" ->
+      s = s'.
+  Proof.
+    induction s as [| c s IH]; intros [| c' s']; simpl; intros tl eq; auto.
+    - inv eq.
+      destruct s'; inv H1.
+    - inv eq.
+      destruct s; inv H1.
+    - inv eq.
+      f_equal.
+      eapply IH; eauto.
+  Qed.
+
+  Lemma append_simplify_r: forall s2 s1 s1',
+      s1 ++ s2 = s1' ++ s2 ->
+      s1 = s1'.
+  Proof.
+    induction s2 as [| c s2 IH].
+    - intros s1 s1' H; rewrite 2 append_EmptyString in H; auto.
+    - intros s1 s1' H.
+      rewrite append_String in H.
+      rewrite (append_String s1' c s2) in H.
+      apply IH,append_char_simplify_r in H.
+      assumption.
+  Qed.
+
+  Lemma append_simplify_l: forall s1 s2 s2',
+      s1 ++ s2 = s1 ++ s2' ->
+      s2 = s2'.
+  Proof.
+    induction s1 as [| c s1 IH]; simpl; intros s2 s2' eq; auto.
+    inv eq; apply IH; auto.
+  Qed.
+
+  Lemma append_assoc: forall s1 s2 s3,
+      s1 ++ s2 ++ s3 = (s1 ++ s2) ++ s3.
+  Proof.
+    induction s1 as [| c s1 IH]; simpl; intros; [reflexivity |].
+    rewrite IH; reflexivity.
+  Qed.
+
+  Lemma string_of_nat_aux_prepends:
+    forall n acc,
+    exists hd, hd <> "" /\ string_of_nat_aux acc n = hd ++ acc.
+  Proof.
+    induction n using (well_founded_induction lt_wf).
+    intros acc.
+    rewrite string_of_nat_aux_equation.
+    flatten_goal.
+    { eexists; split; [| reflexivity].
+      unfold get_last_digit.
+      do 9 (flatten_goal; [easy |]); easy.
+    }
+    edestruct (H (S n0)) as (hd & ineq & eq).
+    - rewrite <- Heq; apply Nat.div_lt.
+      { destruct n; [inv Heq| auto with arith]. }
+      auto with arith.
+    - rewrite eq.
+      rewrite append_assoc.
+      exists (hd ++ get_last_digit n); split; auto.
+      clear - ineq.
+      intros abs; apply ineq.
+      destruct hd; [reflexivity | inv abs].
+  Qed.
+
+  Lemma get_last_digit_len1: forall n,
+      String.length (get_last_digit n) = 1.
+  Proof.
+    intros n; unfold get_last_digit.
+    do 9 (flatten_goal; [reflexivity |]); reflexivity.
+  Qed.
+
+  Lemma length_append:
+    forall s s', String.length (s ++ s') = String.length s + String.length s'.
+  Proof.
+    induction s as [| c s IH]; intros s'; simpl; [reflexivity | rewrite IH; reflexivity].
+  Qed.
+
+  Lemma length_nonEmpty:
+    forall s, s <> "" -> String.length s > 0.
+  Proof.
+    intros []; [intros abs; easy | intros _; simpl; auto with arith].
+  Qed.
+
+  Lemma append_same_length_eq_l:
+    forall s1 s1' s2 s2',
+      s1 ++ s2 = s1' ++ s2' ->
+      String.length s1 = String.length s1' ->
+      s1 = s1'.
+  Proof.
+    induction s1 as [| c1 s1 IH]; simpl; intros.
+    - destruct s1'; [reflexivity | inv H0].
+    - destruct s1' as [| c1' s1']; [inv H0 |].
+      simpl in *.
+      inv H0.
+      inv H.
+      f_equal.
+      eapply IH; eauto.
+  Qed.
+
+  Lemma append_same_length_eq_r:
+    forall s1 s1' s2 s2',
+      s1 ++ s2 = s1' ++ s2' ->
+      String.length s2 = String.length s2' ->
+      s2 = s2'.
+  Proof.
+    intros.
+    assert (String.length s1 = String.length s1').
+    { generalize (length_append s1 s2).
+      intros ?.
+      rewrite H0,H, length_append in H1.
+      lia.
+    }
+    eapply append_same_length_eq_l in H1; eauto.
+    subst.
+    eapply append_simplify_l; eauto.
+  Qed.
+
+  Ltac eq_fun H f :=
+    match type of H with
+    | ?x1 = ?x2 => assert (f x1 = f x2) by (rewrite H; reflexivity)
+    end.
+
+  Lemma append_same_length_eq_r':
+    forall s1 s1' s2 s2',
+      s1 ++ s2 = s1' ++ s2' ->
+      String.length s2 = String.length s2' ->
+      s1 = s1'.
+  Proof.
+    intros.
+    generalize H; intros H'; apply append_same_length_eq_r in H'; auto; subst.
+    eapply append_same_length_eq_l; eauto.
+    eq_fun H String.length.
+    rewrite 2 length_append in H1.
+    lia.
+  Qed.
+
+  Lemma string_of_nat_aux_inj: forall n m acc,
+      n <> m ->
+      string_of_nat_aux acc n <>
+      string_of_nat_aux acc m.
+  Proof.
+    induction n using (well_founded_induction lt_wf).
+    intros m acc ineq.
+    rewrite 2 string_of_nat_aux_equation.
+    flatten_goal.
+    - flatten_goal.
+      + intros abs.
+        apply (get_last_digit_inj n m); try lia.
+        apply append_simplify_r in abs; auto.
+      + destruct (string_of_nat_aux_prepends (S n0) (get_last_digit m ++ acc)) as (hd & nonnil & ->).
+        intros abs.
+        match type of abs with
+        | ?s1 = ?s2 => assert (abs':String.length s1 = String.length s2) by (rewrite abs; reflexivity)
+        end.
+        rewrite 3 length_append, 2 get_last_digit_len1 in abs'.
+        clear - abs' nonnil.
+        apply length_nonEmpty in nonnil; simpl in *.
+        lia.
+    - flatten_goal.
+      + destruct (string_of_nat_aux_prepends (S n0) (get_last_digit n ++ acc)) as (hd & nonnil & ->).
+        intros abs.
+        match type of abs with
+        | ?s1 = ?s2 => assert (abs':String.length s1 = String.length s2) by (rewrite abs; reflexivity)
+        end.
+        rewrite 3 length_append, 2 get_last_digit_len1 in abs'.
+        clear - abs' nonnil.
+        apply length_nonEmpty in nonnil; simpl in *.
+        lia.
+      + destruct (Nat.eq_decidable (n mod 10) (m mod 10)).
+        * replace (get_last_digit m) with (get_last_digit n).
+          2:unfold get_last_digit; rewrite H0; reflexivity.
+          destruct (Nat.eq_decidable n0 n1).
+          { subst. exfalso.
+            eapply ineq, (mod_div_eq n m 10); lia.
+          }
+          apply H.
+          rewrite <- Heq; apply Nat.div_lt.
+          { destruct n; [inv Heq| auto with arith]. }
+          auto with arith.
+          auto.
+        * destruct (string_of_nat_aux_prepends (S n0) (get_last_digit n ++ acc)) as (hd & nonnil & ->).
+          destruct (string_of_nat_aux_prepends (S n1) (get_last_digit m ++ acc)) as (hd' & nonnil' & ->).
+          intros abs.
+          rewrite 2 append_assoc in abs.
+          apply append_simplify_r in abs.
+          apply append_same_length_eq_r in abs; [| rewrite 2get_last_digit_len1; reflexivity].
+          clear -abs H0.
+          unfold get_last_digit in abs.
+          apply H0; clear H0.
+          do 9 (flatten_all; [do 9 (flatten_all; try easy) |]).
+          do 9 (flatten_all; try easy).
+          subst.
+          assert (tmp:10 <> 0) by lia.
+          destruct n8; [| generalize (Nat.mod_upper_bound n 10 tmp); intros ineq; rewrite Heq in ineq; lia].
+          destruct n17; [easy| generalize (Nat.mod_upper_bound m 10 tmp); intros ineq; rewrite Heq8 in ineq; lia].
+  Qed.
+
+  Lemma string_of_nat_inj: forall n m,
+      n <> m ->
+      string_of_nat n <>
+      string_of_nat m.
+  Proof.
+    intros n m; unfold string_of_nat; apply string_of_nat_aux_inj.
+  Qed.
+
+  Definition string_of_Z (n: Z) : string :=
+    match n with
+    | Z0 => "0"
+    | Zpos p => string_of_nat (Pos.to_nat p)
+    | Zneg p => "-" ++ string_of_nat (Pos.to_nat p)
+    end.
+
+  Lemma get_last_digit_0_iff:
+    forall n, get_last_digit n = "0" <-> n mod 10 =  0.
+  Proof.
+    intros n; split; intros H.
+    - unfold get_last_digit in H.
+      flatten_hyp H; [subst; reflexivity |].
+      do 8 (flatten_hyp H; [inv H |]); inv H.
+    - unfold get_last_digit; rewrite H; reflexivity.
+  Qed.
+
+  Lemma string_of_nat_0_iff:
+    forall n, string_of_nat n = "0" <-> n = 0.
+  Proof.
+    intros n; split; intros H.
+    - destruct n as [|n]; [reflexivity | exfalso].
+      unfold string_of_nat in H; rewrite string_of_nat_aux_equation in H.
+      flatten_hyp H.
+      + rewrite append_EmptyString in H.
+        rewrite get_last_digit_0_iff in H.
+        generalize (Nat.mod_eq (S n) 10 (ltac:(lia))).
+        rewrite H, Heq; simpl; intros abs; inv abs.
+      + rewrite append_EmptyString in H; destruct (string_of_nat_aux_prepends (S n0) (get_last_digit (S n))) as (hd & eq & eq').
+        rewrite H in eq'.
+        replace "0" with ("" ++ "0") in eq' by reflexivity.
+        apply append_same_length_eq_r' in eq' ; [| rewrite get_last_digit_len1; reflexivity].
+        subst; tauto.
+    - subst; reflexivity.
+  Qed.
+
+  Lemma pos_to_nat_inj:
+    forall p p',
+      p <> p' ->
+      Pos.to_nat p <> Pos.to_nat p'.
+  Proof.
+    intros; intro abs; apply Pos2Nat.inj in abs; easy.
+  Qed.
+
+  Lemma string_of_nat_aux_hd_get_last_digit:
+    forall n c s acc, string_of_nat_aux acc n = String c s -> exists n', String c "" = get_last_digit n'.
+  Proof.
+    intros n c.
+    induction n using (well_founded_induction lt_wf).
+    intros s acc EQ.
+    unfold string_of_nat in EQ.
+    rewrite string_of_nat_aux_equation in EQ.
+    flatten_hyp EQ.
+    - replace (String c s) with (String c "" ++ s) in EQ by reflexivity.
+      apply append_same_length_eq_l in EQ; [| rewrite get_last_digit_len1; reflexivity].
+      rewrite <- EQ; eauto.
+    - apply H in EQ; [assumption |].
+      rewrite <- Heq; apply Nat.div_lt.
+      { destruct n; [inv Heq| auto with arith]. }
+      auto with arith.
+  Qed.
+
+  Lemma string_of_nat_hd_get_last_digit:
+    forall n c s, string_of_nat n = String c s -> exists n', String c "" = get_last_digit n'.
+  Proof.
+    intros; eapply string_of_nat_aux_hd_get_last_digit; eauto.
+  Qed.
+
+  Lemma string_of_Z_inj: forall n m,
+      n <> m ->
+      string_of_Z n <>
+      string_of_Z m.
+  Proof.
+    intros n m ineq.
+    destruct n, m; simpl; try easy.
+    try (intros abs; symmetry in abs; rewrite string_of_nat_0_iff in abs; lia).
+    try (intros abs; rewrite string_of_nat_0_iff in abs; lia).
+    {apply string_of_nat_inj, pos_to_nat_inj; intros abs; apply ineq; rewrite abs; reflexivity. }
+    { destruct (string_of_nat (Pos.to_nat p)) as [| c s] eqn:EQ; [easy |].
+      apply string_of_nat_hd_get_last_digit in EQ; destruct EQ as [? EQ].
+      intros abs; inv abs.
+      unfold get_last_digit in EQ.
+      do 9 (flatten_hyp EQ; [inv EQ |]); inv EQ.
+    }
+    { destruct (string_of_nat (Pos.to_nat p0)) as [| c s] eqn:EQ; [easy |].
+      apply string_of_nat_hd_get_last_digit in EQ; destruct EQ as [? EQ].
+      intros abs; inv abs.
+      unfold get_last_digit in EQ.
+      do 9 (flatten_hyp EQ; [inv EQ |]); inv EQ.
+    }
+    {intros abs; inv abs.
+     generalize H0.
+     apply string_of_nat_inj, pos_to_nat_inj; intros abs; apply ineq; rewrite abs; reflexivity. }
+  Qed.
+
+  Fixpoint nat_to_string (n: nat): string :=
+    match n with
+    | O => ""
+    | S n => String (ascii_of_nat 49) (nat_to_string n)
+    end.
+
+  Lemma nat_to_string_inj:
+    forall (n m: nat), n <> m -> nat_to_string n <> nat_to_string m.
+  Proof.
+    induction n as [| n IH]; simpl; intros m ineq.
+    - destruct m as [| m]; [lia | intros abs; inversion abs].
+    - destruct m as [| m]; [intros abs; inversion abs |].
+      simpl; intros abs; inversion abs; subst; clear abs.
+      apply (IH m); auto.
+  Qed.
+
+End nat_Show.
+
+(* Should go ext-lib *)
+Definition traverse_ {A: Type} {M: Type -> Type} `{Monad M} (f: A -> M unit): list A -> M unit :=
+  fix traverse__ l: M unit :=
+    match l with
+    | nil => ret tt
+    | a::l => (f a;; traverse__ l)%monad
+    end.
+

--- a/secure_example/_CoqProject
+++ b/secure_example/_CoqProject
@@ -1,0 +1,28 @@
+-Q ../theories/ ITree
+-R . SecureExample
+
+Lattice.v
+
+LabelledImp.v
+Fin.v
+KTreeFin.v
+CatTheory.v
+LabelledAsm.v
+Utils_tutorial.v
+
+LabelledAsmCombinators.v
+LabelledAsmHandler.v
+LabelledImp2Asm.v
+LabelledImpHandler.v
+LabelledImp2AsmCorrectness.v
+
+LabelledImpTypes.v
+LabelledImpTypesProgInsens.v
+LabelledImp2AsmNoninterferencePres.v
+
+LabelledImpInline.v
+LabelledImpInline2Asm.v
+LabelledImpInline2AsmCorrectness.v
+LabelledImpInline2AsmNoninterferencePres.v
+LabelledImpInlineTypes.v
+LabelledImpInlineTypesProgInsens.v

--- a/theories/Basics/HeterogeneousRelations.v
+++ b/theories/Basics/HeterogeneousRelations.v
@@ -45,11 +45,11 @@ Section RelationH_Operations.
   | inr_morphism b1 b2 : RB b1 b2 -> sum_rel RA RB (inr b1) (inr b2).
 
   (** Logical relation for the [prod] type. *)
-  Variant prod_rel {A1 A2 B1 B2 : Type}
+  Record prod_rel {A1 A2 B1 B2 : Type}
       (RA : relationH A1 A2) (RB : relationH B1 B2)
-    : relationH (A1 * B1) (A2 * B2) :=
-  | prod_morphism a1 a2 b1 b2 : RA a1 a2 -> RB b1 b2 -> prod_rel RA RB (a1, b1) (a2, b2)
-  .
+      (p1 : A1 * B1) (p2 : A2 * B2) : Prop := prod_morphism
+  { fst_rel : RA (fst p1) (fst p2)
+  ; snd_rel : RB (snd p1) (snd p2) }.
 
 End RelationH_Operations.
 
@@ -58,7 +58,8 @@ End RelationH_Operations.
 
 Arguments inl_morphism {A1 A2 B1 B2 RA RB}.
 Arguments inr_morphism {A1 A2 B1 B2 RA RB}.
-Arguments prod_morphism {A1 A2 B1 B2 RA RB}.
+Arguments fst_rel {A1 A2 B1 B2 RA RB}.
+Arguments snd_rel {A1 A2 B1 B2 RA RB}.
 
 Arguments rel_compose [A B C] S R.
 Arguments subrelationH [A B] R S.
@@ -475,8 +476,6 @@ Section ProdRelFacts.
       apply TransitiveH_Transitive in H. apply TransitiveH_Transitive in H0.
       unfold TransitiveH in *.
       inversion H1; inversion H2; subst; eauto; inversion H9; subst.
-      split. inversion H9.  eapply H;  eauto.
-      eapply H0; eauto.
     Qed.
 
     #[global]
@@ -525,7 +524,7 @@ Section ProdRelFacts.
   Proof.
     intros.
     unfold eq_rel; split; unfold subrelationH; intros.
-    - destruct x, y. repeat red in H. destruct H. cbn.  subst; reflexivity.
+    - destruct x, y. repeat red in H. destruct H. cbn in *; subst; reflexivity.
     - destruct x; destruct y. cbn in H. repeat red. inversion H. split; reflexivity.
   Qed.
 
@@ -553,20 +552,15 @@ Section ProdRelFacts.
     : (S ∘ R) ⊗ (U ∘ T) ≡ (S ⊗ U) ∘ (R ⊗ T).
   Proof.
     split; intros!.
-    - destruct x, y. repeat red. repeat red in H. destruct H.
-      unfold fst, snd. cbn in H, H0.
-      edestruct H as (b & HR & HS).
-      edestruct H0 as (e & HT & HU).
+    - destruct x, y. repeat red. repeat red in H. destruct H as [H1 H2].
+      unfold fst, snd. cbn in H1, H2.
+      edestruct H1 as (b & HR & HS).
+      edestruct H2 as (e & HT & HU).
       exists (b, e). split; cbn; split; eauto.
-    - destruct x, y. repeat red. repeat red in H. destruct H.
-      unfold fst, snd in H. destruct H.
-      cbn.
-      split. exists (fst x). split.
-      destruct x. cbn. cbn in H. inversion H ; inversion H0; subst. tauto.
-      inversion H; inversion H0; inversion H8; subst. inversion H8. subst.
-      cbn; auto.
-      inversion H; inversion H0. subst. inversion H8. subst.
-      esplit. split; eauto.
+    - destruct x, y. repeat red. repeat red in H. destruct H as [x [H1 H2]].
+      split.
+      + exists (fst x). cbn; split; [apply H1|apply H2].
+      + exists (snd x). cbn; split; [apply H1|apply H2].
   Qed.
 
   #[global]
@@ -760,7 +754,7 @@ Definition option_rel {X : Type} (R : relation X) : relation (option X) :=
             | None, None => True
             | _, _ => False
             end.
-Hint Unfold option_rel : core.
+#[export] Hint Unfold option_rel : core.
 
 Lemma option_rel_eq : forall {A : Type},
     eq_rel (@eq (option A)) (option_rel eq).
@@ -768,4 +762,4 @@ Proof.
   intros ?; split; intros [] [] EQ; subst; try inv EQ; cbn; auto.
 Qed.
 
-#[global] Hint Unfold option_rel : core.
+#[export] Hint Unfold option_rel : core.

--- a/theories/Basics/Tacs.v
+++ b/theories/Basics/Tacs.v
@@ -1,5 +1,5 @@
 
-Ltac inv H := inversion H; try subst; clear H.
+Ltac inv H := inversion H; clear H; subst.
 
 Global Tactic Notation "intros !" := repeat intro.
 

--- a/theories/Core/ITreeDefinition.v
+++ b/theories/Core/ITreeDefinition.v
@@ -287,8 +287,6 @@ Ltac hexploit x := eapply hexploit_mp; [eapply x|].
 Tactic Notation "hinduction" hyp(IND) "before" hyp(H)
   := move IND before H; revert_until IND; induction IND.
 
-Ltac inv H := inversion H; clear H; subst.
-
 Ltac rewrite_everywhere lem :=
   progress ((repeat match goal with [H: _ |- _] => rewrite lem in H end); repeat rewrite lem).
 

--- a/theories/Core/KTreeFacts.v
+++ b/theories/Core/KTreeFacts.v
@@ -103,16 +103,6 @@ Qed.
 
 (** ** [iter] *)
 
-Lemma eqit_mon {E R1 R2} (RR RR' : R1 -> R2 -> Prop) b1 b2 :
-  (RR <2= RR') ->
-  (eqit RR b1 b2 <2= @eqit E _ _ RR' b1 b2).
-Proof.
-  intros.
-  eapply paco2_mon_bot; eauto.
-  intros ? ? ?. red.
-  induction 1; auto with itree.
-Qed.
-
 #[global] Instance eq_itree_iter {E A B} :
   @Proper ((A -> itree E (A + B)) -> A -> itree E B)
           ((eq ==> eq_itree eq) ==> pointwise_relation _ (eq_itree eq))

--- a/theories/Dijkstra/StateSpecT.v
+++ b/theories/Dijkstra/StateSpecT.v
@@ -29,7 +29,7 @@ Section StateSpecT.
   Context {OrderW : OrderM W}.
   Context {OrderedMonadW : OrderedMonad W}.
   Context {EqW : Eq1 W}.
-  Context {EquivRel : forall A, Equivalence (EqW A) }.
+  Context {EquivRel : forall A, Equivalence (eq1 (A := A)) }.
   Context {MonadLawsW : MonadLawsE W}.
 
   Definition StateSpecT (A : Type) := stateT S W A.
@@ -60,10 +60,9 @@ Section StateSpecT.
       cbn.
       rewrite bind_ret_l. simpl. reflexivity.
     - intros A w. intro. cbn.
-      assert (HH : forall A B (x : A * B), (fst x, snd x) = x).
-      { intros ? ? []; reflexivity. }
-      setoid_rewrite HH.
-      rewrite bind_ret_r. reflexivity.
+      etransitivity; [ | apply bind_ret_r ].
+      eapply Proper_bind; [ reflexivity | ].
+      intros []; reflexivity.
     - intros A B C w f g. intro. cbn. rewrite bind_bind. reflexivity.
     - intros A B w1 w2 Hw k1 k2 Hk.
       cbn. do 2 red. intros. do 2 red in Hw. rewrite Hw. do 3 red in Hk.

--- a/theories/Eq/Eqit.v
+++ b/theories/Eq/Eqit.v
@@ -27,6 +27,7 @@ From Paco Require Import paco.
 
 From ITree Require Import
      Basics.Basics
+     Basics.Tacs
      Basics.HeterogeneousRelations
      Core.ITreeDefinition
      Eq.Paco2

--- a/theories/Eq/Rutt.v
+++ b/theories/Eq/Rutt.v
@@ -23,6 +23,7 @@ From ExtLib Require Import
      Structures.Monad.
 
 From ITree Require Import
+     Basics.Tacs
      Axioms
      ITree
      Eq

--- a/theories/Eq/SimUpToTaus.v
+++ b/theories/Eq/SimUpToTaus.v
@@ -22,6 +22,7 @@ From Coq Require Import
 
 From ITree Require Import
      Axioms
+     Basics.Tacs
      Core.ITreeDefinition
      Eq.Eqit
      Eq.UpToTaus

--- a/theories/Eq/UpToTaus.v
+++ b/theories/Eq/UpToTaus.v
@@ -39,6 +39,7 @@ From Coq Require Import Setoid Morphisms Relations.
 From Paco Require Import paco.
 
 From ITree Require Import
+     Basics.Tacs
      Core.ITreeDefinition
      Eq.Eqit
      Eq.Paco2

--- a/theories/Events/Concurrency.v
+++ b/theories/Events/Concurrency.v
@@ -4,8 +4,7 @@
 Set Implicit Arguments.
 Set Contextual Implicit.
 
-From Coq Require Import
-     String List.
+From Coq Require Import List.
 Import ListNotations.
 
 From ITree Require Import

--- a/theories/Events/FailFacts.v
+++ b/theories/Events/FailFacts.v
@@ -2,13 +2,12 @@
 
 (* begin hide *)
 From Coq Require Import
-     Program
-     Morphisms
-     Relations.
+     Morphisms.
 
 From Paco Require Import paco.
 
 From ITree Require Import
+     Basics.Tacs
      Basics.Basics
      Basics.Category
      Basics.CategoryKleisli
@@ -23,8 +22,7 @@ From ITree Require Import
      Indexed.Sum
      Interp.Interp
      Interp.InterpFacts
-     Interp.RecursionFacts
-     Events.State.
+     Interp.RecursionFacts.
 
 Import ITreeNotations.
 Import ITree.Basics.Basics.Monads.

--- a/theories/Events/Map.v
+++ b/theories/Events/Map.v
@@ -4,21 +4,15 @@
 Set Implicit Arguments.
 Set Contextual Implicit.
 
-From Coq Require Import
-     String List.
+From Coq Require Import List.
 Import ListNotations.
 
-From ExtLib Require Import
-     Core.RelDec.
-
-From ExtLib.Structures Require
-     Functor Monoid Maps.
+From ExtLib.Structures Require Maps.
 
 From ITree Require Import
      Basics.Basics
      Basics.CategoryOps
      Basics.MonadState
-     Indexed.Function
      Indexed.Sum
      Core.ITreeDefinition
      Core.Subevent

--- a/theories/Events/MapDefaultFacts.v
+++ b/theories/Events/MapDefaultFacts.v
@@ -4,28 +4,21 @@
 Set Implicit Arguments.
 Set Contextual Implicit.
 
-From Coq Require Import
-     Morphisms
-     Setoid
-     RelationClasses.
+From Coq Require Import Morphisms.
 
 From ExtLib Require Import
      Core.RelDec.
 
 From ExtLib.Structures Require
-     Functor Monoid Maps.
+     Maps.
 
 From Paco Require Import paco.
 
 From ITree Require Import
-     Basics.Basics
-     Basics.CategoryOps
      Basics.HeterogeneousRelations
      ITree
      ITreeFacts
      Eq.Paco2
-     Indexed.Sum
-     Interp.Interp
      Events.State
      Events.StateFacts
      Events.MapDefault.
@@ -163,7 +156,7 @@ Section MapFacts.
       eutt (prod_rel (@eq_map _ _ _ _ d) eq) (handle_map m s1) ((handle_map m s2) : itree E (map * X)).
   Proof.
     intros.
-    destruct m; cbn; red; apply eqit_Ret; constructor; auto.
+    destruct m; cbn; red; apply eqit_Ret; constructor; cbn; auto.
     - apply eq_map_add. assumption.
     - apply eq_map_remove. assumption.
   Qed.
@@ -196,11 +189,11 @@ Section MapFacts.
     - guclo eqit_clo_bind. econstructor.
       unfold pure_state.
       destruct e.
-      + cbn. eapply eqit_mon; [ | apply handle_map_eq; assumption ].
+      + cbn. eapply eqit_mon; [ exact (fun x => x) .. | | apply handle_map_eq; assumption ].
         auto. auto. intros.  apply PR.
       + cbn. apply eqit_Vis. intros.  apply eqit_Ret. constructor; auto.
       + intros. destruct u1. destruct u2. cbn.
-        inversion H. subst.
+        destruct H as [H1 H2]; cbn in H1, H2; subst.
         gstep; constructor.
         gbase. apply CH. assumption.
   Qed.
@@ -228,8 +221,7 @@ Section MapFacts.
         unfold pure_state.
         pstep. econstructor. intros. constructor. pfold. econstructor. constructor; auto.
       } 
-      intros.
-      inversion H. subst.
+      intros. destruct H as [HH1 ->].
       estep; constructor. ebase.
     - rewrite tau_euttge, unfold_interp_state.
       eauto.

--- a/theories/Events/Nondeterminism.v
+++ b/theories/Events/Nondeterminism.v
@@ -6,8 +6,7 @@
 Set Implicit Arguments.
 Set Contextual Implicit.
 
-From Coq Require Import
-     String List.
+From Coq Require Import List.
 Import ListNotations.
 
 From ITree Require Import

--- a/theories/Events/Reader.v
+++ b/theories/Events/Reader.v
@@ -6,8 +6,7 @@
 Set Implicit Arguments.
 Set Contextual Implicit.
 
-From Coq Require Import
-     String List.
+From Coq Require Import List.
 Import ListNotations.
 
 From ITree Require Import
@@ -16,7 +15,6 @@ From ITree Require Import
      Core.ITreeDefinition
      Indexed.Sum
      Core.Subevent
-     Events.Exception
      Interp.Interp
      Interp.Handler.
 (* end hide *)

--- a/theories/Events/StateFacts.v
+++ b/theories/Events/StateFacts.v
@@ -1,11 +1,7 @@
 (** * Theorems about State effects *)
 
 (* begin hide *)
-From Coq Require Import
-     Program
-     Setoid
-     Morphisms
-     RelationClasses.
+From Coq Require Import Program.Tactics Morphisms.
 
 From Paco Require Import paco.
 
@@ -209,7 +205,7 @@ Proof.
   rewrite 2 interp_state_bind.
   ebind; econstructor.
   - eapply Ht; auto.
-  - intros [s1' i1'] [s2' i2'] [? ? ? ? ? []]; cbn.
+  - intros [s1' i1'] [s2' i2'] [? []]; cbn.
     + rewrite 2 interp_state_tau. auto with paco.
     + rewrite 2 interp_state_ret. auto with paco.
 Qed.
@@ -257,10 +253,9 @@ Proof.
   - rewrite bind_ret_l, 2 interp_state_ret.
     pstep.
     constructor.
-    cbn.
-    split; auto using (proj1 H2).
-  - rewrite bind_ret_l, 2 interp_state_ret. pstep. constructor. cbn.
-    split; auto using (proj1 H2).
+    split; cbn; auto using (proj1 H2).
+  - rewrite bind_ret_l, 2 interp_state_ret. pstep. constructor.
+    split; cbn; auto using (proj1 H2).
 Qed.
 
 (* SAZ: These are probably too specialized. *)

--- a/theories/ITrace/ITraceBind.v
+++ b/theories/ITrace/ITraceBind.v
@@ -194,6 +194,7 @@ Proof.
         red in x1. cbn in x1. inversion x1. ddestruction.
         red in H0. specialize (H0 tt a (rar _ _ _)).
         specialize (REL0 a). pclearbot.
+        change (paco2 ?x ?y ?t ?u) with (eq_itree eq t u) in REL0.
         rewrite REL0. apply H0.
       * cbn. constructor; eauto. intros. contradiction.
     + rewrite <- x. cbn. constructor. eapply IHHrutt; eauto.

--- a/theories/ITrace/ITraceFacts.v
+++ b/theories/ITrace/ITraceFacts.v
@@ -7,7 +7,6 @@ From ITree Require Import
      ITreeFacts
      Eq.Rutt
      Props.Divergence
-     Props.EuttDiv
      ITrace.ITraceDefinition
 .
 

--- a/theories/ITreeFacts.v
+++ b/theories/ITreeFacts.v
@@ -1,7 +1,7 @@
 (** * Main module with theorems *)
 
-
 From ITree Require Export
+     Basics.Tacs
      Basics.Basics
      Basics.Category
      Basics.Monad

--- a/theories/Interp/RecursionFacts.v
+++ b/theories/Interp/RecursionFacts.v
@@ -10,10 +10,10 @@ Require Import Paco.paco.
 From Coq Require Import
      Program.Tactics
      Setoid
-     Morphisms
-     RelationClasses.
+     Morphisms.
 
 From ITree Require Import
+     Basics.Tacs
      Basics.Category
      Basics.Basics
      Basics.Function

--- a/theories/Interp/Traces.v
+++ b/theories/Interp/Traces.v
@@ -5,6 +5,7 @@ From Paco Require Import
      paco.
 
 From ITree Require Import
+     Basics.Tacs
      Axioms
      Core.ITreeDefinition
      Eq.Eqit

--- a/theories/Props/Finite.v
+++ b/theories/Props/Finite.v
@@ -3,9 +3,10 @@
 (* begin hide *)
 From ITree Require Import
      ITree
+     Basics.Tacs
      Eq.Eqit
      Leaf.
-From ITree Require Import Nondeterminism Exception. (* For counterexamples *)
+From ITree.Events Require Import Nondeterminism Exception. (* For counterexamples *)
 
 From Paco Require Import paco.
 From Coq Require Import Morphisms Basics Program.Equality.

--- a/theories/Props/HasPost.v
+++ b/theories/Props/HasPost.v
@@ -2,6 +2,7 @@
 From Paco Require Import paco.
 From Coq Require Import Morphisms.
 From ITree Require Import
+     Basics.Tacs
      ITree
      Eq.Eqit
      Basics.HeterogeneousRelations

--- a/theories/Props/Leaf.v
+++ b/theories/Props/Leaf.v
@@ -2,6 +2,7 @@
 
 (* begin hide *)
 From ITree Require Import
+     Basics.Tacs
      ITree
      Eq.Shallow
      Eq.Eqit.

--- a/theories/Secure/Labels.v
+++ b/theories/Secure/Labels.v
@@ -1,0 +1,28 @@
+(* Shared definitions for the Secure component. *)
+
+From ITree Require Import
+  Basics.Tacs
+  Axioms.
+
+Variant nonempty (A : Type) : Prop := ne (a : A).
+
+Variant empty (A : Type) : Prop := emp : (A -> False) -> empty A.
+
+Lemma classic_empty : forall A, empty A \/ nonempty A.
+Proof.
+  intros. destruct (classic (nonempty A)); eauto.
+  left. constructor. intros. apply H. constructor; auto.
+Qed.
+
+Class Preorder :=
+  {
+    L : Type;
+    leq : L -> L -> Prop;
+  }.
+
+Ltac contra_size :=
+  match goal with
+  | [ Hemp : empty ?A, Hne : nonempty ?A |- _ ] => inv Hemp; inv Hne; contradiction
+  | [ Hemp : empty ?A, a :?A |- _] => inv Hemp; contradiction
+  end
+.

--- a/theories/Secure/SecureEqBind.v
+++ b/theories/Secure/SecureEqBind.v
@@ -1,0 +1,281 @@
+From ITree Require Import
+     Axioms
+     ITree
+     ITreeFacts
+     Secure.SecureEqHalt
+     Secure.SecureEqWcompat
+.
+
+From Paco Require Import paco.
+
+Import Monads.
+Import MonadNotation.
+Local Open Scope monad_scope.
+
+Lemma eqit_bind_shalt_aux1:
+  forall (E : Type -> Type) (S2 S1 R1 R2 : Type) (RR : R1 -> R2 -> Prop)
+    (RS : S1 -> S2 -> Prop) (b1 b2 : bool) (Label : Preorder)
+    (priv : forall A : Type, E A -> L) (l : L) (k1 : R1 -> itree E S1)
+    (k2 : R2 -> itree E S2) (A : Type) (e : E A) (k0 : A -> itree E R1)
+    (t2 : itree E R2),
+    ~ leq (priv A e) l ->
+    empty A ->
+    paco2 (secure_eqit_ Label priv RR b1 b2 l id) bot2 (Vis e k0) t2 ->
+    forall (t1 : itree E R1),
+      VisF e k0 = observe t1 ->
+      paco2 (secure_eqit_ Label priv RS b1 b2 l id) bot2 (ITree.bind t1 k1) (ITree.bind t2 k2).
+Proof.
+  intros E S2 S1 R1 R2 RR RS b1 b2 Label priv l k1 k2 A e k0 t2 SECCHECK SIZECHECK H0 t1 Heqot1.
+  pstep. red. unfold ITree.bind at 1, observe at 1. cbn. rewrite <- Heqot1.
+  cbn. rewrite itree_eta' at 1. pstep_reverse.
+  generalize dependent t2. pcofix CIH. intros t2 Ht2.
+  pstep. red.
+  punfold Ht2. red in Ht2.
+  unfold ITree.bind at 1. unfold observe at 2. cbn in *.
+  inv Ht2; ddestruction; subst; try contra_size; try contradiction; try rewrite <- H; cbn;
+  try unpriv_halt; right; eapply CIH;  pclearbot; eauto;
+  try (pfold; rewrite H in H1; apply H1).
+  contra_size.
+Qed.
+
+Lemma eqit_bind_shalt_aux2:
+  forall (E : Type -> Type) (S2 S1 R1 R2 : Type) (RR : R1 -> R2 -> Prop)
+    (RS : S1 -> S2 -> Prop) (b1 b2 : bool) (Label : Preorder)
+    (priv : forall A : Type, E A -> L) (l : L) (k1 : R1 -> itree E S1)
+    (k2 : R2 -> itree E S2) (A : Type) (e : E A) (k0 : A -> itree E R2)
+    (t1 : itree E R1) (t2 : itree E R2),
+    ~ leq (priv A e) l ->
+    empty A ->
+    paco2 (secure_eqit_ Label priv RR b1 b2 l id) bot2 t1 (Vis e k0) ->
+    VisF e k0 = observe t2 ->
+    paco2 (secure_eqit_ Label priv RS b1 b2 l id) bot2 (ITree.bind t1 k1) (ITree.bind t2 k2).
+Proof.
+  intros E S2 S1 R1 R2 RR RS b1 b2 Label priv l k1 k2 A e k0 t1 t2 SECCHECK SIZECHECK H0 Heqot1.
+  pstep. red. unfold ITree.bind at 2, observe at 2. cbn. rewrite <- Heqot1.
+  cbn. rewrite itree_eta'. pstep_reverse.
+  generalize dependent t1. pcofix CIH. intros t1 Ht1.
+  pstep. red.
+  punfold Ht1. red in Ht1.
+  unfold ITree.bind at 1, observe at 1. cbn in *.
+  inv Ht1; ddestruction; subst; try contra_size; try contradiction; cbn;
+  try unpriv_halt; try contra_size; try (right; eapply CIH; pclearbot; eauto).
+  pfold. rewrite H0 in H1. auto. apply H1.
+Qed.
+
+Lemma secure_eqit_bind' : forall E R1 R2 S1 S2 (RR : R1 -> R2 -> Prop) (RS : S1 -> S2 -> Prop)
+                           b1 b2 Label priv l r
+    (t1 : itree E R1) (t2 : itree E R2) (k1 : R1 -> itree E S1) (k2 : R2 -> itree E S2),
+    (forall r1 r2, RR r1 r2 -> paco2 (secure_eqit_ Label priv RS b1 b2 l id) r (k1 r1) (k2 r2) ) ->
+    eqit_secure Label priv RR b1 b2 l t1 t2 ->
+    paco2 (secure_eqit_ Label priv RS b1 b2 l id) r (ITree.bind t1 k1) (ITree.bind t2 k2).
+Proof.
+  intros. revert H0. revert t1 t2. pcofix CIH. intros t1 t2 Ht12.
+  punfold Ht12. red in Ht12.
+  genobs t1 ot1. genobs t2 ot2.
+  hinduction Ht12 before r; intros; eauto.
+  - pstep. red. unfold ITree.bind, observe. unfold observe. cbn.
+    rewrite <- Heqot1. rewrite <- Heqot2. pstep_reverse.
+    eapply paco2_mon; eauto.
+  - pstep. red. unfold ITree.bind, observe. unfold observe. cbn.
+    rewrite <- Heqot1. rewrite <- Heqot2. cbn. constructor. right. eapply CIH. pclearbot.
+    auto.
+  - pstep. red. unfold ITree.bind at 1, observe at 1. cbn.
+    rewrite <- Heqot1. cbn. constructor; auto. pstep_reverse.
+  - pstep. red. unfold ITree.bind at 2, observe at 2. cbn.
+    rewrite <- Heqot2. cbn. constructor; auto. pstep_reverse.
+  - pstep. red. unfold ITree.bind, observe. unfold observe. cbn.
+    rewrite <- Heqot1. rewrite <- Heqot2. cbn. pclearbot.
+    constructor; auto. right. eapply CIH; eauto. apply H.
+  - pstep. red. unfold ITree.bind, observe. unfold observe. cbn.
+    rewrite <- Heqot1. rewrite <- Heqot2. cbn. unpriv_co.
+    right. pclearbot. eapply CIH; apply H.
+  - pstep. red. unfold ITree.bind, observe. unfold observe. cbn.
+    rewrite <- Heqot1. rewrite <- Heqot2. cbn. unpriv_co.
+    right. pclearbot. eapply CIH; apply H.
+  - pstep. red. unfold ITree.bind, observe. unfold observe. cbn.
+    rewrite <- Heqot1. rewrite <- Heqot2. cbn. unpriv_co.
+    right. pclearbot. eapply CIH; apply H.
+  - pstep. red. unfold ITree.bind at 1, observe at 1. cbn.
+    rewrite <- Heqot1. cbn. unpriv_ind. pstep_reverse; try eapply H0; eauto.
+  - pstep. red. unfold ITree.bind at 2, observe at 2. cbn.
+    rewrite <- Heqot2. cbn. unpriv_ind. pstep_reverse; try eapply H0; eauto.
+  - pclearbot.
+    eapply paco2_mon with (r := bot2); intros; try contradiction.
+    eapply eqit_bind_shalt_aux1; eauto. pfold. red. rewrite <- Heqot2.
+    cbn. unpriv_halt. left. eauto.
+  - pclearbot.
+    eapply paco2_mon with (r := bot2); intros; try contradiction.
+    eapply eqit_bind_shalt_aux2; eauto. pfold. red. cbn. rewrite <- Heqot1.
+    unpriv_halt. left. eauto.
+  - pclearbot.
+    eapply paco2_mon with (r := bot2); intros; try contradiction.
+    eapply eqit_bind_shalt_aux1 with (A := A); eauto.
+    pfold. red. rewrite <- Heqot2. cbn. unpriv_halt.
+  - pclearbot.
+    eapply paco2_mon with (r := bot2); intros; try contradiction.
+    eapply eqit_bind_shalt_aux2; eauto. pfold. red. cbn. rewrite <- Heqot1.
+    unpriv_halt.
+Qed.
+
+Lemma secure_eqit_bind : forall E R1 R2 S1 S2 (RR : R1 -> R2 -> Prop) (RS : S1 -> S2 -> Prop)
+                           b1 b2 Label priv l
+    (t1 : itree E R1) (t2 : itree E R2) (k1 : R1 -> itree E S1) (k2 : R2 -> itree E S2),
+    (forall r1 r2, RR r1 r2 -> eqit_secure Label priv RS b1 b2 l (k1 r1) (k2 r2) ) ->
+    eqit_secure Label priv RR b1 b2 l t1 t2 ->
+    eqit_secure Label priv RS b1 b2 l (ITree.bind t1 k1) (ITree.bind t2 k2).
+Proof.
+  intros.
+  eapply secure_eqit_bind'; eauto.
+Qed.
+
+Lemma iter_bind_shalt_aux1:
+  forall (E : Type -> Type) (B2 B1 A1 A2 : Type) (RA : A1 -> A2 -> Prop)
+    (RB : B1 -> B2 -> Prop) (b1 b2 : bool) (Label : Preorder)
+    (priv : forall A : Type, E A -> L) (l : L) (body1 : A1 -> itree E (A1 + B1))
+    (body2 : A2 -> itree E (A2 + B2)) (r : itree E B1 -> itree E B2 -> Prop)
+    (A : Type) (e : E A) (k1 : A -> itree E (A1 + B1)) (t0 : itree E (A2 + B2)),
+    ~ leq (priv A e) l ->
+    empty A ->
+    paco2 (secure_eqit_ Label priv (HeterogeneousRelations.sum_rel RA RB) b1 b2 l id) bot2
+          (Vis e k1) t0 ->
+    paco2 (secure_eqit_ Label priv RB b1 b2 l id) r
+          (Vis e
+               (fun x : A =>
+                  ITree.bind (k1 x)
+                             (fun lr : A1 + B1 =>
+                                match lr with
+                                | inl l0 => Tau (ITree.iter body1 l0)
+                                | inr r0 => Ret r0
+                                end)))
+          (ITree.bind t0
+                      (fun lr : A2 + B2 =>
+                         match lr with
+                         | inl l0 => Tau (ITree.iter body2 l0)
+                         | inr r0 => Ret r0
+                         end)).
+Proof.
+  intros E B2 B1 A1 A2 RA RB b1 b2 Label priv l body1 body2 r A e k1 t0 SECCHECK SIZECHECK H.
+  generalize dependent t0. pcofix CIH. intros t0 Ht0.
+  pstep. red. cbn. unfold observe. cbn. punfold Ht0.
+  red in Ht0. cbn in *. inv Ht0; inv_vis_secure; cbn; pclearbot; unpriv_halt; try contra_size;
+    right; eauto.
+  eapply CIH; eauto.
+  rewrite H in H1. pfold. red. auto.
+Qed.
+
+Lemma iter_bind_shalt_aux2:
+  forall (E : Type -> Type) (B2 B1 A1 A2 : Type) (RA : A1 -> A2 -> Prop)
+    (RB : B1 -> B2 -> Prop) (b1 b2 : bool) (Label : Preorder)
+    (priv : forall A : Type, E A -> L) (l : L) (body1 : A1 -> itree E (A1 + B1))
+    (body2 : A2 -> itree E (A2 + B2)) (r : itree E B1 -> itree E B2 -> Prop)
+    (A : Type) (e : E A) (t0 : itree E (A1 + B1)) (k2 : A -> itree E (A2 + B2)),
+    ~ leq (priv A e) l ->
+    empty A ->
+    paco2 (secure_eqit_ Label priv (HeterogeneousRelations.sum_rel RA RB) b1 b2 l id) bot2 t0
+          (Vis e k2) ->
+    paco2 (secure_eqit_ Label priv RB b1 b2 l id) r
+          (ITree.bind t0
+                      (fun lr : A1 + B1 =>
+                         match lr with
+                         | inl l0 => Tau (ITree.iter body1 l0)
+                         | inr r0 => Ret r0
+                         end))
+          (Vis e
+               (fun x : A =>
+                  ITree.bind (k2 x)
+                             (fun lr : A2 + B2 =>
+                                match lr with
+                                | inl l0 => Tau (ITree.iter body2 l0)
+                                | inr r0 => Ret r0
+                                end))).
+Proof.
+  intros E B2 B1 A1 A2 RA RB b1 b2 Label priv l body1 body2 r A e t0 k2 SECCHECK SIZECHECK H.
+  generalize dependent t0. pcofix CIH. intros t0 Ht0.
+  pstep. red. cbn. unfold observe. cbn. punfold Ht0.
+  red in Ht0. cbn in *. inv Ht0; inv_vis_secure; cbn; pclearbot; unpriv_halt; try contra_size;
+  try (right; eauto).
+  eapply CIH; eauto.
+  rewrite H0 in H1. pfold. red. auto.
+Qed.
+
+Lemma iter_bind_aux:
+  forall (E : Type -> Type) (B2 B1 A1 A2 : Type) (RA : A1 -> A2 -> Prop)
+    (RB : B1 -> B2 -> Prop) (b1 b2 : bool) (Label : Preorder)
+    (priv : forall A : Type, E A -> L) (l : L) (body1 : A1 -> itree E (A1 + B1))
+    (body2 : A2 -> itree E (A2 + B2)) (r : itree E B1 -> itree E B2 -> Prop)
+    (t1 : itree E (A1 + B1)) (t2 : itree E (A2 + B2)),
+    paco2 (secure_eqit_ Label priv (HeterogeneousRelations.sum_rel RA RB) b1 b2 l id) bot2 t1 t2 ->
+    (forall (a1 : A1) (a2 : A2), RA a1 a2 -> r (ITree.iter body1 a1) (ITree.iter body2 a2)) ->
+    paco2 (secure_eqit_ Label priv RB b1 b2 l id) r
+          (ITree.bind t1
+                      (fun lr : A1 + B1 =>
+                         match lr with
+                         | inl l0 => Tau (ITree.iter body1 l0)
+                         | inr r0 => Ret r0
+                         end))
+          (ITree.bind t2
+                      (fun lr : A2 + B2 =>
+                         match lr with
+                         | inl l0 => Tau (ITree.iter body2 l0)
+                         | inr r0 => Ret r0
+                         end)).
+Proof.
+  intros E B2 B1 A1 A2 RA RB b1 b2 Label priv l body1 body2 r t1 t2 H CIH0.
+  generalize dependent t2. revert t1. pcofix CIH1.
+  intros t1 t2 Ht12. punfold Ht12. pstep. red.
+  unfold observe. cbn.
+  hinduction Ht12 before r; intros; cbn; eauto; pclearbot;
+  try (unpriv_co; fail);
+  try (constructor; auto; pclearbot; right; eapply CIH1; eauto with itree; fail).
+  - inv H; cbn; eauto with itree.
+  - unpriv_ind. unfold observe at 1. cbn. eapply H0; eauto with itree.
+  - unpriv_ind. unfold observe at 3. cbn. eapply H0; eauto with itree.
+  - unpriv_halt. left. eapply iter_bind_shalt_aux1; eauto with itree.
+  - unpriv_halt. left. eapply iter_bind_shalt_aux2; eauto with itree.
+  - unpriv_halt. specialize (H b). left. eapply iter_bind_shalt_aux1; eauto with itree.
+  - unpriv_halt. specialize (H a). left. eapply iter_bind_shalt_aux2; eauto with itree.
+Qed.
+
+
+Lemma secure_eqit_iter : forall E A1 A2 B1 B2 (RA : A1 -> A2 -> Prop) (RB : B1 -> B2 -> Prop)
+                           b1 b2 Label priv l
+                           (body1 : A1 -> itree E (A1 + B1) ) (body2 : A2 -> itree E (A2 + B2) )
+                           (a1 : A1) (a2 : A2),
+    RA a1 a2 ->
+    (forall a1 a2, RA a1 a2 -> eqit_secure Label priv (HeterogeneousRelations.sum_rel RA RB) b1 b2 l (body1 a1) (body2 a2) ) ->
+    eqit_secure Label priv RB b1 b2 l (ITree.iter body1 a1) (ITree.iter body2 a2).
+Proof.
+  intros. rename H0 into Hbody. generalize dependent a2. revert a1.
+  (* gcofix CIH. intros. setoid_rewrite unfold_iter.
+  guclo eqit_bind_clo. *)
+
+  (* look into the more general secure_eqitC closure, see if that is weakly compatible, *)
+  pcofix CIH.
+  intros a1 a2 Ha. specialize (Hbody a1 a2 Ha) as Hbodya.
+  punfold Hbodya. red in Hbodya. pfold. red.
+  unfold observe. (* write lemmas for unfolding the observe of iter *) cbn.
+  hinduction Hbodya before r; intros; cbn; auto with itree.
+  - inv H; cbn; eauto with itree.
+  - cbn. pclearbot. constructor.
+    left. eapply iter_bind_aux; eauto.
+  - constructor; auto. pclearbot. left. eapply iter_bind_aux; eauto.
+  - unpriv_co. pclearbot. left. eapply iter_bind_aux; eauto.
+  -  unpriv_co. pclearbot. left. eapply iter_bind_aux; eauto.
+  - unpriv_co. pclearbot. left. eapply iter_bind_aux; eauto.
+  - unpriv_ind. (* here is  where it gets bad, I am pretty sure H0 does match up but could
+                  take very particular *) unfold observe at 1. cbn.
+    eauto.
+  - unpriv_ind. unfold observe at 3. cbn. eauto.
+  - pclearbot. unpriv_halt.
+    left. eapply iter_bind_shalt_aux1; eauto.
+  - unpriv_halt. pclearbot. left. eapply iter_bind_shalt_aux2; eauto.
+  - unpriv_halt. pclearbot. specialize (H b). left.
+    eapply iter_bind_shalt_aux1; eauto.
+  - unpriv_halt. pclearbot. specialize (H a). left. eapply iter_bind_shalt_aux2; eauto.
+Qed.
+
+Lemma secure_eqit_ret : forall (E : Type -> Type) Label priv l b1 b2 (R1 R2 : Type) (RR : R1 -> R2 -> Prop) (r1 : R1) (r2 : R2),
+    RR r1 r2 -> @eqit_secure E R1 R2 Label priv RR b1 b2 l (Ret r1) (Ret r2).
+Proof.
+  intros. pfold. constructor. auto.
+Qed.

--- a/theories/Secure/SecureEqEuttHalt.v
+++ b/theories/Secure/SecureEqEuttHalt.v
@@ -1,0 +1,948 @@
+From Coq Require Import Morphisms.
+
+From ITree Require Import
+     Axioms
+     ITree
+     ITreeFacts
+     Secure.Labels
+     Secure.SecureEqHalt
+.
+
+From Paco Require Import paco.
+
+Import Monads.
+Import MonadNotation.
+Local Open Scope monad_scope.
+
+Lemma tau_eqit_secure : forall E R1 R2 Label priv l RR (t1 : itree E R1) (t2 : itree E R2),
+    eqit_secure Label priv RR true true l (Tau t1) t2 -> eqit_secure Label priv RR true true l t1 t2.
+Proof.
+  intros E R1 R2 Label priv l RR.  intros t1 t2 Hsec. pstep. red.
+  punfold Hsec. red in Hsec. cbn in *. remember (TauF t1) as x.
+  hinduction Hsec before priv; intros;  inv Heqx; pclearbot; try inv CHECK; auto with itree.
+  - constructor; auto. pstep_reverse.
+  - unpriv_ind. pstep_reverse.
+  - punfold H.
+Qed.
+
+Lemma unpriv_e_eqit_secure : forall E A R1 R2 Label priv l RR (e : E A) (k : A -> itree E R1)
+      (t : itree E R2),
+    (~leq (priv A e) l ) ->
+    eqit_secure Label priv RR true true l (Vis e k) t ->
+    forall a, eqit_secure Label priv RR true true l (k a) t.
+Proof.
+  intros. generalize dependent t. rename H into Hunpriv. generalize dependent a.
+  intros. punfold H0. red in H0. cbn in *. pfold. red.
+  remember (VisF e k) as x. genobs_clear t ot.
+  hinduction H0 before l; intros; try inv Heqx;
+    ddestruction; subst; try contradiction; try contra_size; auto.
+  - constructor; auto. eapply IHsecure_eqitF; eauto.
+  - pclearbot. constructor; auto. pstep_reverse.
+  - unpriv_ind. pstep_reverse. pclearbot. apply H.
+  - unpriv_ind. eapply H0; eauto.
+  - pclearbot. rewrite itree_eta'. pstep_reverse.
+Qed.
+
+
+(* reformat this lemma? useful but unclear *)
+Lemma eses_aux1: forall (E : Type -> Type) (R2 R1 : Type) (Label : Preorder)
+                    (priv : forall A : Type, E A -> L) (l : L) (RR : R1 -> R2 -> Prop)
+                    (r : itree E R1 -> itree E R2 -> Prop) (m1 m2 : itree E R1),
+              m1 ≈ m2 ->
+               (forall (t1 t1' : itree E R1) (t2 : itree E R2),
+                   t1 ≈ t1' -> eqit_secure Label priv RR true true l t1 t2 -> r t1' t2) ->
+               forall (X : Type) (e : E X) (k : X -> itree E R2),
+                 secure_eqitF Label priv RR true true l id
+                              (upaco2 (secure_eqit_ Label priv RR true true l id) bot2) (observe m1)
+                              (VisF e k) ->
+                 leq (priv X e) l ->
+                 secure_eqitF Label priv RR true true l id
+                              (upaco2 (secure_eqit_ Label priv RR true true l id) r) (observe m2)
+                              (VisF e k).
+Proof.
+  intros E R2 R1 Label priv l RR r m1 m2 REL CIH X e k Hsec SECCHECK.
+  remember (VisF e k) as x. punfold REL. red in REL. rewrite Heqx.
+  hinduction Hsec before r; intros; try inv Heqx; ddestruction; subst; try contradiction; auto.
+  - eapply IHHsec; eauto.
+    pstep_reverse. setoid_rewrite <- tau_eutt at 1. pfold. auto.
+  - pclearbot. remember (VisF e0 k1) as y.
+    hinduction REL before r; intros; try inv Heqy; ddestruction; subst; auto.
+    + constructor; auto. right. eapply CIH; eauto; try apply H.
+      pclearbot. apply REL.
+    + constructor; eauto.
+  - rewrite H2. remember (VisF e k1) as y.
+    hinduction REL before r; intros; try inv Heqy; ddestruction; subst; auto.
+    + pclearbot. rewrite <- H2. unpriv_ind. rewrite H2. eapply H0; eauto.
+      Unshelve. all: auto. pstep_reverse.
+    + constructor; auto. eapply IHREL; eauto.
+Qed.
+
+Lemma eses_aux2:
+forall (E : Type -> Type) (R2 R1 : Type) (Label : Preorder)
+    (priv : forall A : Type, E A -> L) (l : L) (RR : R1 -> R2 -> Prop)
+    (r : itree E R1 -> itree E R2 -> Prop) (m1 m2 : itree E R1) (r0 : R2),
+  m1 ≈ m2 ->
+  secure_eqitF Label priv RR true true l id
+    (upaco2 (secure_eqit_ Label priv RR true true l id) bot2) (observe m1)
+    (RetF r0) ->
+  secure_eqitF Label priv RR true true l id
+    (upaco2 (secure_eqit_ Label priv RR true true l id) r) (observe m2)
+    (RetF r0).
+Proof.
+  intros E R2 R1 Label priv l RR r m1 m2 r0 Heutt Hsec.
+  punfold Heutt. red in Heutt. remember (RetF r0) as x.
+  rewrite Heqx. hinduction Hsec before r; intros; inv Heqx; auto with itree.
+  - remember (RetF r1) as y.
+    hinduction Heutt before r; intros; inv Heqy; auto with itree.
+    constructor; auto. eapply IHHeutt; eauto.
+  - eapply IHHsec; eauto. pstep_reverse. rewrite <- tau_eutt at 1. pfold. auto.
+  - remember (VisF e k1) as y.
+    hinduction Heutt before r; intros; inv Heqy; ddestruction; subst; auto.
+    +  unpriv_ind. rewrite H2. eapply H0; eauto.
+       pclearbot. pstep_reverse.
+    + constructor; auto. eapply IHHeutt; eauto.
+Qed.
+
+Definition classic_empty := Secure.Labels.classic_empty.
+
+(*tomorrow start on the transitivity proof *)
+Lemma eutt_secure_eqit_secure : forall E Label priv l R1 R2 RR (t1 t1': itree E R1) (t2 : itree E R2),
+    t1 ≈ t1' -> eqit_secure Label priv RR true true l t1 t2 ->
+    eqit_secure Label priv RR true true l t1' t2.
+Proof.
+  intros E Label priv l R1 R2 RR. pcofix CIH. intros t1 t1' t2 Heutt Hsec.
+  punfold Heutt. red in Heutt. punfold Hsec. red in Hsec.
+  pfold. red. hinduction Heutt before r; intros; subst; auto with itree.
+  - remember (RetF r2) as x. hinduction Hsec before r; intros; try inv Heqx; auto with itree.
+    + constructor; auto. eapply IHHsec; eauto.
+    + unpriv_ind. eapply H0; eauto.
+  - genobs_clear t2 ot2.
+    assert (Ht2 : (exists m3, ot2 = TauF m3) \/ (forall m3, ot2 <> TauF m3) ).
+    { destruct ot2; eauto; right; repeat intro; discriminate. }
+    (* because of the extra inductive cases this is not enough *)
+    destruct Ht2 as [ [m3 Hm3] | Ht2 ].
+    + subst. pclearbot. constructor. right. eapply CIH; eauto.
+      apply tau_eqit_secure. apply eqit_secure_sym. apply tau_eqit_secure.
+      apply eqit_secure_sym. pfold. auto.
+    + destruct ot2; try (exfalso; eapply Ht2; eauto; fail).
+      * pclearbot. rewrite itree_eta' at 1. eapply eses_aux2 with (m1 := Tau m1); eauto.
+        do 2 rewrite tau_eutt. auto.
+      * assert (leq (priv _ e) l \/ ~ leq (priv _ e) l).
+        { apply classic. }
+        destruct H as [SECCHECK | SECCHECK]; destruct ( classic_empty X  ).
+        ++ pclearbot. rewrite itree_eta' at 1. apply eses_aux1 with (m1 := Tau m1); auto.
+           do 2 rewrite tau_eutt. auto.
+        ++ pclearbot. rewrite itree_eta' at 1. apply eses_aux1 with (m1 := Tau m1); auto.
+           do 2 rewrite tau_eutt. auto.
+        ++ unpriv_halt. pclearbot. right. eapply CIH; eauto.
+           apply tau_eqit_secure. pfold. auto.
+        ++ pclearbot.
+           unpriv_co. pclearbot. right. eapply CIH. apply REL.
+           apply tau_eqit_secure.
+           apply eqit_secure_sym.
+           eapply unpriv_e_eqit_secure; eauto.
+           apply eqit_secure_sym. pfold. auto.
+  - pclearbot. rewrite itree_eta' at 1. pstep_reverse.
+    assert (eqit_secure Label priv RR true true l (Vis e k1) t2 ).
+    { pfold; auto. }
+    clear Hsec. rename H into Hsec.
+    destruct (classic (leq (priv _ e) l ) ).
+    + pstep. red. punfold Hsec. red in Hsec.
+      cbn in *. remember (VisF e k1) as x.
+      hinduction Hsec before r; intros; inv Heqx; ddestruction; subst; try contradiction; auto.
+      * constructor; auto. eapply IHHsec; eauto.
+      * constructor; auto; intros. right. eapply CIH; try apply REL. pclearbot. apply H.
+      * rewrite itree_eta' at 1. unpriv_ind. eapply H0; eauto.
+    + destruct (classic_empty u).
+      * pfold. red. cbn.  punfold Hsec. red in Hsec. cbn in *.
+        destruct (observe t2).
+        -- inv Hsec; contra_size.
+        -- unpriv_halt. right. apply CIH with (t1 := Vis e k1).
+           ++ pfold. constructor. left. auto.
+           ++ inv Hsec; ddestruction; subst; try contradiction;  try contra_size. pfold. auto.
+              pclearbot. auto.
+        -- inv Hsec; ddestruction; subst; try contradiction; try contra_size.
+           ++ unpriv_halt. right. apply CIH with (t1 := Vis e k1).
+              { pfold. constructor. red. auto. }
+              { rewrite H1 in H3. pfold. apply H3. }
+           ++ pclearbot. unpriv_halt. right. apply CIH with (t1 := Vis e k1).
+              { pfold. constructor. red. auto. }
+              { apply H2. }
+           ++ pclearbot. unpriv_halt. contra_size.
+      * pfold. red. cbn.  punfold Hsec. red in Hsec. cbn in *.
+        destruct (observe t2).
+        ++ rewrite itree_eta' at 1. rewrite itree_eta' in Hsec at 1.
+           eapply eses_aux2; eauto. pfold. constructor. red. auto.
+        ++ unpriv_co. right. apply CIH with (t1 := k1 a); try apply REL.
+           eapply unpriv_e_eqit_secure; eauto. apply eqit_secure_sym.
+           apply tau_eqit_secure. apply eqit_secure_sym. pfold. auto.
+        ++ destruct (classic (leq (priv _ e0) l )).
+           ** rewrite itree_eta' at 1.
+              eapply eses_aux1 with (m1 := Vis e k1); eauto.
+              pfold. constructor. red. auto.
+           ** destruct (classic_empty X).
+              --- unpriv_halt. right. eapply CIH; try apply REL.
+                  eapply unpriv_e_eqit_secure; eauto. pfold. auto.
+              --- unpriv_co. right. eapply CIH; try apply REL.
+                  (* eapply unpriv_e_eqit_secure; eauto. *)
+                  do 2 (eapply unpriv_e_eqit_secure; eauto; apply eqit_secure_sym).
+                  pfold. auto.
+  - eapply IHHeutt; eauto. pstep_reverse.
+    apply tau_eqit_secure. pfold. auto.
+Qed.
+
+
+Lemma eqit_secure_TauLR :
+  forall (E : Type -> Type) (R3 : Type) (Label : Preorder) (priv : forall x : Type, E x -> L)
+    (l : L) (b1 b2 : bool) (R2 : Type) (RR2 : R2 -> R3 -> Prop) (t0 : itree E R2)
+    (t4 : itree E R3),
+    eqit_secure Label priv RR2 b1 b2 l (Tau t0) (Tau t4) ->
+    eqit_secure Label priv RR2 b1 b2 l t0 t4.
+Proof.
+  intros E R3 Label priv l b1 b2 R2 RR2.
+  intros. punfold H. red in H. cbn in *. pstep. red.
+  remember (TauF t0) as x. remember (TauF t4) as y.
+  hinduction H before b2; intros;  try discriminate.
+  - inv Heqx; inv Heqy. pclearbot. pstep_reverse.
+  - inv Heqx. inv H; eauto with itree.
+    + pclearbot. unpriv_ind. pstep_reverse.
+    + unpriv_ind. rewrite H1 in H2.
+      specialize (H2 a). genobs (k1 a) ok1. clear Heqok1.
+      remember (TauF t4) as y.
+      hinduction H2 before b2; intros; inv Heqy; try inv CHECK; eauto with itree.
+      * pclearbot. constructor; auto; pstep_reverse.
+      * pclearbot. unpriv_ind. pstep_reverse.
+      * pclearbot. punfold H.
+    + pclearbot. punfold H2.
+  - inv Heqy. inv H; eauto with itree.
+    + pclearbot. unpriv_ind. pstep_reverse.
+    + rewrite H0 in H2. unpriv_ind. specialize (H2 a).
+      genobs (k2 a) ok2. clear Heqok2.
+      remember (TauF t0) as y.
+      hinduction H2 before b2; intros; inv Heqy; try inv CHECK; eauto with itree.
+      * pclearbot. constructor; auto. pstep_reverse.
+      * unpriv_ind. pclearbot. pstep_reverse.
+      * pclearbot. punfold H.
+    + pclearbot. punfold H2.
+Qed.
+
+Lemma eqit_secure_TauLVisR:
+  forall (E : Type -> Type) (R3 : Type) (Label : Preorder) (priv : forall x : Type, E x -> L)
+    (l : L) (b1 b2 : bool) (R2 : Type) (RR2 : R2 -> R3 -> Prop),
+    forall (t3 : itree E R2) (X : Type) (e : E X) (k : X -> itree E R3) (a : X),
+      (~ leq (priv _ e) l) ->
+      eqit_secure Label priv RR2 b1 b2 l (Tau t3) (Vis e k) ->
+      eqit_secure Label priv RR2 b1 b2 l t3 (k a).
+Proof.
+  intros E R3 Label priv l b1 b2 R2 RR t3 A e k a He Hsec.
+  punfold Hsec. red in Hsec. cbn in *.
+  remember (TauF t3) as x. remember (VisF e k) as y.
+  hinduction Hsec before b2; intros; try discriminate.
+  - inv Heqx. inv CHECK.
+    remember (VisF e k) as y. pfold. red. clear IHHsec.
+    hinduction Hsec before b2; intros; inv Heqy; ddestruction;  subst;
+    try contradiction; try contra_size; eauto with itree.
+    + constructor; auto. pclearbot. pstep_reverse.
+    + unpriv_ind. pclearbot. pstep_reverse.
+    + pclearbot. specialize (H a). punfold H.
+  - inv Heqx. inv Heqy. ddestruction; subst. pclearbot. apply H.
+  - inv Heqx. inv Heqy. ddestruction; subst. rewrite H2 in H.
+    clear H0. clear H2 t1. remember (TauF t3) as x.
+    pfold. red. specialize (H a).
+    hinduction H before b2; intros; inv Heqx; try contra_size; eauto with itree.
+    + pclearbot. constructor; auto. pstep_reverse.
+    + pclearbot. unpriv_ind. pstep_reverse.
+    + pclearbot. punfold H.
+  -  pclearbot. inv Heqx. inv Heqy. ddestruction; subst. contra_size.
+Qed.
+
+Lemma eqit_secure_TauRVisL:
+  forall (E : Type -> Type) (R3 : Type) (Label : Preorder) (priv : forall x : Type, E x -> L)
+    (l : L) (b1 b2 : bool) (R2 : Type) RR2,
+    forall (t3 : itree E R2) (X : Type) (e : E X) (k : X -> itree E R3) (a : X),
+      (~ leq (priv _ e) l) ->
+      eqit_secure Label priv RR2 b1 b2 l (Vis e k) (Tau t3)->
+      eqit_secure Label priv RR2 b1 b2 l (k a) t3.
+Proof.
+  intros E R3 Label priv l b1 b2 R2 RR t3 A e k a He Hsec.
+  punfold Hsec. red in Hsec. cbn in *.
+  remember (TauF t3) as x. remember (VisF e k) as y.
+  hinduction Hsec before b2; intros; try discriminate.
+  - inv Heqx. inv CHECK. remember (VisF e k) as y. pfold. red. clear IHHsec.
+    hinduction Hsec before b1; intros; inv Heqy; ddestruction; subst;
+    try contradiction; eauto with itree.
+    + constructor; auto with itree. pclearbot. pstep_reverse.
+    + unpriv_ind. pclearbot. pstep_reverse.
+    + contra_size.
+    + contra_size.
+    + pclearbot. specialize (H a). punfold H.
+  - inv Heqx. inv Heqy. ddestruction; subst. pclearbot. apply H.
+  - inv Heqx. inv Heqy. ddestruction; subst. pclearbot. rewrite H2 in H. inv CHECK.
+    specialize (H a). pfold. red. remember (TauF t3) as y.
+    hinduction H before b2; intros; inv Heqy; try contra_size; eauto with itree.
+    + pclearbot. constructor; auto. pstep_reverse.
+    + pclearbot. unpriv_ind. pstep_reverse.
+    + pclearbot. punfold H.
+  - inv Heqx. inv Heqy. ddestruction; subst. contra_size.
+Qed.
+
+Lemma eqit_secure_VisLR:
+  forall (E : Type -> Type) (R3 : Type) (Label : Preorder) (priv : forall x : Type, E x -> L)
+    (l : L) (b1 b2 : bool) (R2 : Type) (RR2 : R2 -> R3 -> Prop) (A : Type)
+    (e : E A) (k2 : A -> itree E R2),
+    ~ leq (priv A e) l ->
+    forall (X : Type) (e0 : E X) (k : X -> itree E R3) (a : A),
+      ~ leq (priv X e0) l ->
+      forall a0 : X,
+        eqit_secure Label priv RR2 b1 b2 l (Vis e k2) (Vis e0 k) ->
+        eqit_secure Label priv RR2 b1 b2 l (k2 a) (k a0).
+Proof.
+  intros E R3 Label priv l b1 b2 R2 RR2 A e k2 SECCHECK X e0 k a H0 a0 H1.
+  pfold. red.
+  punfold H1. red in H1. cbn in *. remember (VisF e k2) as x.
+  remember (VisF e0 k) as y.
+  hinduction H1 before l; intros; try discriminate.
+  - inv Heqx. inv Heqy. ddestruction; subst. contradiction.
+  - pclearbot. inv Heqx. inv Heqy. ddestruction; subst. pstep_reverse.
+  - inv Heqx. ddestruction; subst. inv CHECK. clear H0.
+    specialize (H a).
+    rewrite Heqy in H. clear Heqy. remember (VisF e1 k) as y.
+    hinduction H before l; intros; inv Heqy; ddestruction; subst; try contradiction;
+    try contra_size; eauto with itree.
+    + pclearbot. constructor; auto. pstep_reverse.
+    + unpriv_ind. pclearbot. pstep_reverse.
+    + pclearbot. specialize (H a0). punfold H.
+
+  - inv Heqy.  ddestruction; subst. inv CHECK. clear H0.
+    rewrite Heqx in H. specialize (H a0).
+    remember (VisF e0 k0) as y.
+    hinduction H before b1; intros; inv Heqy; ddestruction; subst; try contradiction;
+    try contra_size; eauto with itree.
+    + pclearbot. constructor; auto. pstep_reverse.
+    + pclearbot. unpriv_ind. pstep_reverse.
+    + pclearbot. specialize (H a). punfold H.
+  - inv Heqx; inv Heqy; ddestruction; subst. contra_size.
+  - inv Heqx; inv Heqy; ddestruction; subst. contra_size.
+Qed.
+
+Lemma eqit_secure_private_VisLR:
+  forall (E : Type -> Type) (R3 : Type) (Label : Preorder) (priv : forall x : Type, E x -> L)
+    (l : L) (b1 b2 : bool) (R2 : Type) (RR2 : R2 -> R3 -> Prop) (A : Type)
+    (e : E A) (k2 : A -> itree E R2),
+    nonempty A ->
+    ~ leq (priv A e) l ->
+    forall (X : Type) (e0 : E X) (k : X -> itree E R3),
+      ~ leq (priv X e0) l ->
+      nonempty X ->
+      (forall a a0,
+        eqit_secure Label priv RR2 b1 b2 l (k2 a) (k a0)) ->
+        eqit_secure Label priv RR2 b1 b2 l (Vis e k2) (Vis e0 k) .
+Proof.
+  intros. pfold. red. cbn. unpriv_co. left. apply H3.
+Qed.
+
+Lemma eqit_secure_private_VisL:
+  forall (E : Type -> Type) (R3 : Type) (Label : Preorder) (priv : forall x : Type, E x -> L)
+    (l : L) (b2 : bool) (R2 : Type) (RR2 : R2 -> R3 -> Prop) (A : Type)
+    (e : E A) (k2 : A -> itree E R2) (t : itree E R3),
+    nonempty A ->
+    ~ leq (priv A e) l ->
+    (forall a,
+        eqit_secure Label priv RR2 true b2 l (k2 a) t) ->
+        eqit_secure Label priv RR2 true b2 l (Vis e k2) t .
+Proof.
+  intros. pfold. red. cbn. unpriv_ind. pstep_reverse. apply H1.
+Qed.
+
+Lemma eqit_secure_private_VisR:
+  forall (E : Type -> Type) (R3 : Type) (Label : Preorder) (priv : forall x : Type, E x -> L)
+    (l : L) (b1 : bool) (R2 : Type) (RR2 : R2 -> R3 -> Prop) (A : Type)
+    (e : E A) (k2 : A -> itree E R3) (t : itree E R2),
+    nonempty A ->
+    ~ leq (priv A e) l ->
+    (forall a,
+        eqit_secure Label priv RR2 b1 true l t (k2 a)) ->
+        eqit_secure Label priv RR2 b1 true l t (Vis e k2).
+Proof.
+  intros. pfold. red. cbn. unpriv_ind. pstep_reverse. apply H1.
+Qed.
+
+Lemma eqit_secure_public_Vis :  forall (E : Type -> Type) (R1 R2 : Type) (Label : Preorder) (priv : forall x : Type, E x -> L)
+    (l : L) (b1 b2 : bool) (RR : R1 -> R2 -> Prop) (A : Type)
+    (e : E A) (k1: A -> itree E R1) (k2 : A -> itree E R2),
+    leq (priv A e) l ->
+    (eqit_secure Label priv RR b1 b2 l (Vis e k1) (Vis e k2) <->
+    forall a, eqit_secure Label priv RR b1 b2 l (k1 a) (k2 a)).
+Proof.
+  split; intros.
+  - pinversion H0; ddestruction; subst; try contradiction; apply H2.
+  - pfold. constructor; auto. left. apply H0.
+Qed.
+
+Lemma eqit_secure_trans_aux1:
+  forall (E : Type -> Type) (R3 R1 : Type) (Label : Preorder)
+    (priv : forall x : Type, E x -> L) (l : L) (b2 : bool) (R2 : Type)
+    (RR1 : R1 -> R2 -> Prop) (RR2 : R2 -> R3 -> Prop) (r : itree E R1 -> itree E R3 -> Prop)
+    (r0 : R3) (t4 : itree E R2),
+    secure_eqitF Label priv RR2 true b2 l id
+                 (upaco2 (secure_eqit_ Label priv RR2 true b2 l id) bot2) (observe t4)
+                 (RetF r0) ->
+    forall t : itree E R1,
+      paco2 (secure_eqit_ Label priv RR1 true b2 l id) bot2 t t4 ->
+      secure_eqitF Label priv (rcompose RR1 RR2) true b2 l id
+                   (upaco2 (secure_eqit_ Label priv (rcompose RR1 RR2) true b2 l id) r)
+                   (observe t) (RetF r0).
+Proof.
+  intros E R3 R1 Label priv l b2 R2 RR1 RR2 r r0 t4 Ht23 t H.
+  punfold H. red in H.
+  remember (RetF r0) as x.
+  hinduction Ht23 before r; intros; inv Heqx; try inv CHECK; auto.
+  - remember (RetF r1) as y.
+    hinduction H0 before r; intros; inv Heqy; eauto with itree.
+    rewrite itree_eta'. unpriv_ind. cbn. eapply H0; eauto.
+  - eapply IHHt23; eauto.
+    remember (TauF t1) as y.
+    hinduction H before r; intros; inv Heqy; try inv CHECK; eauto with itree.
+    + pclearbot. constructor; auto. pstep_reverse.
+    + pclearbot. unpriv_ind. pstep_reverse.
+    + pclearbot. punfold H.
+  - assert (Hne : nonempty A). { eauto. } (* add the condition that lets us assume this*)
+    inv Hne. eapply (H0 a); eauto.
+    remember (VisF e k1) as y.
+    hinduction H1 before r; intros; inv Heqy; try inv CHECK; ddestruction; subst;
+    try contradiction; try contra_size; eauto with itree.
+    + pclearbot. constructor; auto. pstep_reverse.
+    + pclearbot. unpriv_ind. pstep_reverse.
+    + pclearbot. rewrite itree_eta' at 1. pstep_reverse.
+Qed.
+
+Lemma eqit_secure_trans_aux2:
+  forall (E : Type -> Type) (R3 R1 : Type) (Label : Preorder)
+    (priv : forall x : Type, E x -> L) (l : L) (b2 : bool) (R2 : Type)
+    (RR1 : R1 -> R2 -> Prop) (RR2 : R2 -> R3 -> Prop) (r : itree E R1 -> itree E R3 -> Prop)
+    (X : Type) (e0 : E X) (k : X -> itree E R3) (t4 : itree E R2),
+    leq (priv X e0) l ->
+    secure_eqitF Label priv RR2 true b2 l id
+                 (upaco2 (secure_eqit_ Label priv RR2 true b2 l id) bot2) (observe t4)
+                 (VisF e0 k) ->
+    (forall (t1 : itree E R1) (t2 : itree E R2) (t3 : itree E R3),
+        eqit_secure Label priv RR1 true b2 l t1 t2 ->
+        eqit_secure Label priv RR2 true b2 l t2 t3 -> r t1 t3) ->
+    forall t : itree E R1,
+      paco2 (secure_eqit_ Label priv RR1 true b2 l id) bot2 t t4 ->
+      secure_eqitF Label priv (rcompose RR1 RR2) true b2 l id
+                   (upaco2 (secure_eqit_ Label priv (rcompose RR1 RR2) true b2 l id) r)
+                   (observe t) (VisF e0 k).
+Proof.
+  intros E R3 R1 Label priv l b2 R2 RR1 RR2 r X e0 k t4 He0 Ht23 CIH0 t Ht.
+  punfold Ht. red in Ht. remember (VisF e0 k) as x.
+  hinduction Ht23 before r; intros; inv Heqx; try inv CHECK;
+  ddestruction; subst; try contradiction; eauto.
+  - eapply IHHt23; eauto. clear IHHt23. remember (TauF t1) as y.
+    hinduction Ht before r; intros; inv Heqy; try inv CHECK; eauto with itree.
+    + pclearbot. constructor; auto. pstep_reverse.
+    + pclearbot. unpriv_ind. pstep_reverse.
+    + pclearbot. punfold H.
+  - pclearbot. remember (VisF e0 k1) as y.
+    hinduction Ht before r; intros; inv Heqy; try inv CHECK;
+    ddestruction; subst; try contradiction; eauto with itree.
+    + pclearbot. constructor; auto. right. eapply CIH0. apply H.
+      apply H0.
+    + rewrite itree_eta'. unpriv_ind. eapply H0; eauto.
+  - assert (nonempty A); eauto. inv H1. eapply H0; eauto.
+    Unshelve. all : auto. clear H0. rewrite H2 in H.
+    remember (VisF e k1) as y.
+    hinduction Ht before r; intros; inv Heqy; try inv CHECK; ddestruction; subst;
+    try contradiction; try contra_size; eauto with itree.
+    + pclearbot. constructor; auto. pstep_reverse.
+    + pclearbot. unpriv_ind. pstep_reverse.
+    + pclearbot. rewrite itree_eta' at 1. pstep_reverse.
+
+Qed.
+
+
+Lemma secret_halt_trans_1 : forall E Label priv l b1 b2 (R1 R2 R3 A : Type) (RR1 : R1 -> R2 -> Prop)
+            (RR2 : R2 -> R3 -> Prop) t1 (e : E A) k t3,
+    (~ leq (priv A e) l ) ->
+    empty A ->
+    eqit_secure Label priv RR1 b1 b2 l t1 (Vis e k) ->
+    eqit_secure Label priv RR2 b1 b2 l (Vis e k) t3 ->
+    eqit_secure Label priv (rcompose RR1 RR2) b1 b2 l t1 t3.
+Proof.
+  intros E Label priv l b1 b2 R1 R2 R3 A RR1 RR2 t1 e k t3 He HA.
+  generalize dependent t3. generalize dependent t1.
+  pcofix CIH. intros t1 t3 Ht1 Ht3.
+  pfold. red. punfold Ht1. red in Ht1. punfold Ht3. red in Ht3.
+  cbn in *.
+  remember (VisF e k) as x.
+  hinduction Ht1 before r; intros; inv Heqx; ddestruction; subst;
+  try contradiction; try contra_size; eauto with itree.
+  - pclearbot. inv Ht3; ddestruction; subst; try contradiction; try contra_size.
+    + constructor. right. apply CIH; auto. pfold. auto.
+    + unpriv_co; auto. right. apply CIH; auto. pfold. rewrite H0 in H2. apply H2.
+    + pclearbot. constructor. right. apply CIH; auto.
+    + pclearbot. destruct (classic_empty B).
+      * unpriv_halt. right. apply CIH; auto with itree. pfold.
+        red. cbn. unpriv_halt.
+      * unpriv_co. right. apply CIH; auto. apply H1.
+    + pclearbot. unpriv_halt. right. apply CIH; auto. pfold.
+      red. cbn. unpriv_halt. contra_size.
+  - pclearbot.  inv Ht3; ddestruction; subst; try contradiction; try contra_size.
+    + unpriv_halt. right. apply CIH; auto.
+      * pfold. red. cbn. unpriv_halt.
+      * pfold. auto.
+    + unpriv_halt. right. apply CIH; auto.
+      * pfold. red. cbn. unpriv_halt.
+      * pfold. auto. rewrite H0 in H2. apply H2.
+    + pclearbot. unpriv_halt. right. apply CIH; auto.
+      pfold. red. cbn. unpriv_halt.
+    + pclearbot. unpriv_halt. right. apply CIH.
+      * pfold. red. cbn. unpriv_halt.
+      * apply H1.
+    + unpriv_halt. contra_size.
+  - pclearbot. inv Ht3; ddestruction; subst; try contradiction; try contra_size;
+    destruct (classic_empty A0).
+    + unpriv_halt. right. apply CIH; auto.
+      * pfold. red. cbn. unpriv_halt. contra_size.
+      * pfold. auto.
+    + unpriv_co. right. apply CIH; auto; try apply H.
+      pfold. auto.
+    + unpriv_halt. right. apply CIH; auto.
+      * pfold. red. cbn. unpriv_halt. contra_size.
+      * pfold. rewrite H0 in H2. apply H2.
+    + unpriv_co. right. apply CIH. apply H. rewrite H0 in H2.
+      pfold. apply H2.
+    + pclearbot. unpriv_halt. right. apply CIH; auto. pfold.
+      red. cbn. unpriv_halt. contra_size.
+    + pclearbot. unpriv_co. right. apply CIH; auto. apply H.
+    + unpriv_halt. pclearbot. right. apply CIH; try apply H1.
+      pfold. red. cbn. unpriv_halt. contra_size.
+    + pclearbot. destruct (classic_empty B).
+      * unpriv_halt. right. apply CIH; auto. apply H.
+        pfold. red. cbn. unpriv_halt.
+      * unpriv_co. right. apply CIH; eauto. apply H. apply H1.
+    + pclearbot. unpriv_halt. contra_size.
+    + pclearbot. unpriv_halt. right. apply CIH; auto. apply H.
+      pfold. red. cbn. unpriv_halt. contra_size.
+Qed.
+
+Lemma secret_halt_trans_2 :  forall E Label priv l b1 b2 (R1 R2 R3 A : Type) (RR1 : R1 -> R2 -> Prop)
+            (RR2 : R2 -> R3 -> Prop) (e : E A) k t2 t3,
+    (~ leq (priv A e) l ) ->
+    empty A ->
+    eqit_secure Label priv RR1 b1 b2 l (Vis e k) t2 ->
+    eqit_secure Label priv RR2 b1 b2 l t2 t3 ->
+    eqit_secure Label priv (rcompose RR1 RR2) b1 b2 l (Vis e k) t3.
+Proof.
+  intros E Label priv l b1 b2 R1 R2 R3 A RR1 RR2 e k t2 t3 He HA.
+  generalize dependent t3. generalize dependent t2.
+  pcofix CIH. intros t2 t3 Ht2 Ht23. pfold.
+  red. cbn. punfold Ht2. punfold Ht23. red in Ht2. red in Ht23.
+  cbn in *.
+  hinduction Ht23 before r; intros; eauto with itree.
+  - inv Ht2. ddestruction; subst. contra_size.
+  - unpriv_halt. right. pclearbot. eapply CIH; eauto.
+    inv Ht2; ddestruction; subst; try contra_size; try contradiction; pclearbot;  eauto.
+    pfold. auto.
+  - eapply IHHt23; eauto.
+    inv Ht2; ddestruction; subst; try contra_size; try contradiction; pclearbot; eauto.
+    punfold H0.
+  - pclearbot.
+    inv Ht2; ddestruction; subst; try contra_size; try contradiction; pclearbot; eauto.
+  - unpriv_halt. pclearbot.  inv SIZECHECK. right. eapply CIH; try apply H.
+    Unshelve. all : auto.
+    inv Ht2; ddestruction; subst; try contra_size; try contradiction; pclearbot; eauto.
+    + pfold. apply H2.
+    + apply H1.
+  - pclearbot. unpriv_halt. right. eapply CIH; try apply H.
+    inv Ht2; ddestruction; subst; try contra_size; try contradiction; pclearbot; eauto.
+    pfold. auto.
+  - pclearbot. unpriv_halt. inv SIZECHECK1. inv SIZECHECK2. right. eapply CIH; try apply H.
+    Unshelve. all : auto.
+    inv Ht2; ddestruction; subst; try contra_size; try contradiction; pclearbot; eauto.
+    + pfold. apply H2.
+    + apply H1.
+  - inv SIZECHECK.  eapply H0; eauto. Unshelve. all : auto.
+    inv Ht2; ddestruction; subst; try contra_size; try contradiction; pclearbot; eauto.
+    rewrite itree_eta' at 1. pstep_reverse.
+  - unpriv_halt. right. eapply CIH; eauto. pfold. apply Ht2.
+    pfold. apply H.
+  - pclearbot. unpriv_halt. right. eapply CIH; eauto. pfold. auto.
+  - unpriv_halt. contra_size.
+  - unpriv_halt. right. pclearbot. eapply CIH with (t2 := Vis e1 k1); eauto.
+    + pfold. auto.
+    + apply H.
+  - unpriv_halt. contra_size.
+Qed.
+
+Lemma eqit_secure_RR_imp : forall E b1 b2 R1 R2 (RR1 RR2 : R1 -> R2 -> Prop) Label priv l
+                (t1 : itree E R1) (t2 : itree E R2),
+    RR1 <2= RR2 ->
+    eqit_secure Label priv RR1 b1 b2 l t1 t2 ->
+    eqit_secure Label priv RR2 b1 b2 l t1 t2.
+Proof.
+  intros. generalize dependent t2. revert t1.
+  pcofix CIH. intros t1 t2 Ht12. pfold. red.
+  punfold Ht12. red in Ht12.
+  hinduction Ht12 before r; intros; eauto;
+  try (pclearbot; constructor; auto; right; eapply CIH; eauto; fail);
+  try (pclearbot; unpriv_co; right; eapply CIH; eauto; apply H0; fail).
+  pclearbot. constructor; auto. right. eapply CIH; eauto. apply H0.
+  - pclearbot. unpriv_halt. right. eapply CIH; eauto. apply H0.
+  - pclearbot. unpriv_halt. right. eapply CIH; eauto. apply H0.
+Qed.
+
+Lemma secret_halt_trans_3 :  forall E Label priv l b1 b2 (R1 R2 R3 A : Type) (RR1 : R1 -> R2 -> Prop)
+            (RR2 : R2 -> R3 -> Prop)  t1 t2 (e : E A) k,
+    (~ leq (priv A e) l ) ->
+    empty A ->
+    eqit_secure Label priv RR1 b1 b2 l t1 t2 ->
+    eqit_secure Label priv RR2 b1 b2 l t2 (Vis e k) ->
+    eqit_secure Label priv (rcompose RR1 RR2) b1 b2 l t1 (Vis e k).
+Proof.
+  intros. apply eqit_secure_sym in H1. apply eqit_secure_sym in H2.
+  apply eqit_secure_sym. eapply secret_halt_trans_2 in H1; eauto.
+  eapply eqit_secure_RR_imp; eauto.
+  intros. inv PR. econstructor; eauto.
+Qed.
+
+Lemma eqit_secure_trans : forall E Label priv l b1 b2 (R1 R2 R3 : Type) (RR1 : R1 -> R2 -> Prop)
+            (RR2 : R2 -> R3 -> Prop) (t1 : itree E R1) (t2 : itree E R2) (t3 : itree E R3),
+    eqit_secure Label priv RR1 b1 b2 l t1 t2 ->
+    eqit_secure Label priv RR2 b1 b2 l t2 t3 ->
+    eqit_secure Label priv (rcompose RR1 RR2) b1 b2 l t1 t3.
+Proof.
+  intros E Label priv l b1 b2 R1 R2 R3 RR1 RR2.
+  pcofix CIH0. intros t1 t2 t3 Ht12 Ht23.
+  punfold Ht12. red in Ht12. punfold Ht23. red in Ht23. pfold. red.
+  hinduction Ht12 before r; intros; try inv CHECK; auto with itree.
+  - remember (RetF r2) as x.
+    hinduction Ht23 before r; intros; inv Heqx; try inv CHECK; eauto with itree.
+    rewrite itree_eta' at 1. unpriv_ind. eapply H0; eauto.
+  - pclearbot. genobs t4 ot4.
+    assert ( (exists t5, ot4 = TauF t5) \/ (forall t5, ot4 <> TauF t5) ).
+    { destruct ot4; eauto; right; intros; discriminate. }
+    destruct H0 as [ [t5 Ht4] | Ht4].
+    + subst. rewrite Ht4. rewrite Ht4 in Ht23. constructor.
+      right. eapply CIH0; eauto. eapply eqit_secure_TauLR. pfold.
+      auto.
+    + destruct ot4; try (exfalso; eapply Ht4;  eauto; fail  ).
+      * inv Ht23. inv CHECK. rewrite itree_eta' at 1.
+        assert (eqit_secure Label priv (rcompose RR1 RR2) true b2 l (Tau t0) (Ret r0)  ).
+        { pfold. red. cbn. rewrite itree_eta' at 1. eapply eqit_secure_trans_aux1; eauto.
+          pfold. red. constructor; auto. pstep_reverse. }
+        rewrite itree_eta'. pstep_reverse. eapply paco2_mon; eauto.
+        intros; contradiction.
+      * destruct (classic (leq (priv _ e) l ) ).
+        -- inv Ht23; ddestruction; subst; try contradiction; try inv CHECK.
+           constructor; auto. eapply eqit_secure_trans_aux2; eauto.
+        -- destruct (classic_empty X).
+           ++ rewrite itree_eta'. rewrite itree_eta' at 1.
+              pstep_reverse.
+              eapply paco2_mon with (r := bot2); intros; try contradiction.
+              eapply secret_halt_trans_3 with (t2 := Tau t3); eauto.
+              ** pfold. constructor. left. auto.
+              ** pfold. auto.
+           ++ unpriv_co. right. eapply CIH0; eauto.
+              assert (eqit_secure Label priv RR2 b1 b2 l (Tau t3) (Vis e k)).
+              pfold. auto. eapply eqit_secure_TauLVisR; eauto.
+  - apply IHHt12; auto.
+    remember (TauF t0) as y.
+    hinduction Ht23 before r; intros; inv Heqy; try inv CHECK; eauto with itree.
+    + pclearbot. constructor; auto. pstep_reverse.
+    + pclearbot. unpriv_ind. pstep_reverse.
+    + pclearbot. punfold H.
+  - pclearbot. remember (VisF e k2) as x.
+    hinduction Ht23 before r; intros; inv Heqx; try inv CHECK; ddestruction; subst;
+    try contradiction; eauto with itree.
+    + pclearbot. constructor; auto. intros. right. eapply CIH0; eauto; try apply H0.
+      apply H.
+    + rewrite itree_eta' at 1. unpriv_ind. eapply H0; eauto.
+  - pclearbot. remember (TauF t0) as x.
+    hinduction Ht23 before r; intros; inv Heqx; try inv CHECK; auto.
+    + pclearbot. unpriv_co. right. eapply CIH0; try apply H0.
+      auto.
+    + destruct ot2.
+      * clear IHHt23. rewrite itree_eta'. unpriv_ind.
+        remember (k1 a) as t. specialize (H a). setoid_rewrite <- Heqt in H.
+        clear Heqt a k1. cbn. eapply eqit_secure_trans_aux1; eauto.
+      * unpriv_co. right. eapply CIH0; try apply H.
+        clear IHHt23. remember (TauF t) as y.
+        pfold. red.
+        hinduction Ht23 before r; intros; inv Heqy; try inv CHECK; eauto with itree.
+        -- pclearbot. constructor; auto. pstep_reverse.
+        -- pclearbot. unpriv_ind. pstep_reverse.
+        -- pclearbot. punfold H.
+      * destruct (classic (leq (priv _ e0) l ) ).
+        -- rewrite itree_eta'. unpriv_ind. cbn.
+           clear IHHt23. remember (k1 a) as t. specialize (H a). setoid_rewrite <- Heqt in H.
+           clear Heqt a k1. eapply eqit_secure_trans_aux2; eauto.
+        -- destruct (classic_empty X).
+           ++ rewrite itree_eta'. unpriv_ind.
+              pstep_reverse. apply paco2_mon with (r := bot2); intros; try contradiction.
+              eapply secret_halt_trans_3; eauto. apply H.
+              pfold. auto.
+           ++ unpriv_co. right. eapply CIH0. apply H.
+              clear IHHt23. pstep. red. remember (VisF e0 k) as y.
+              hinduction Ht23 before r; intros; inv Heqy; try inv CHECK;
+                ddestruction; subst; try contradiction; try contra_size; eauto with itree.
+              ** pclearbot. constructor; auto. pstep_reverse.
+              ** unpriv_ind. pclearbot. pstep_reverse.
+              ** pclearbot. rewrite itree_eta' at 1. pstep_reverse.
+    + constructor; auto. eapply IHHt23; eauto.
+    + pclearbot. unpriv_co. right. eapply CIH0; try apply H0. apply H.
+    + rewrite itree_eta' at 1. unpriv_ind. eapply H0; eauto.
+    + unpriv_halt. right. pclearbot. eapply CIH0; eauto. apply H0.
+  - pclearbot.
+    genobs_clear t3 ot3.
+    assert (Hne : nonempty A); eauto. inv Hne.
+    assert ( (exists t4, ot3 = TauF t4) \/ (forall t4, ot3 <> TauF t4) ).
+    { destruct ot3; eauto; right; intros; discriminate. }
+    destruct H0 as [ [t4 Ht3] | Ht3].
+    + subst. constructor. right. eapply CIH0; try apply H.
+      Unshelve. all: auto.
+      eapply eqit_secure_TauRVisL; eauto. pfold. auto.
+       (* should be fine but new lemma, also shelved goal *)
+    +
+      destruct ot3; try (exfalso; eapply Ht4;  eauto; fail  ).
+      * inv Ht23; inv CHECK. ddestruction. subst. clear CIH0.
+        constructor; auto. rewrite H4. eapply eqit_secure_trans_aux1; eauto.
+        rewrite <- H4. apply H1. Unshelve. auto. (* shelved goal*)
+      * constructor. right. eapply CIH0; try apply H.
+        eapply eqit_secure_TauRVisL; eauto. pfold. auto.
+        (* same goal as last admit *)
+      * destruct (classic (leq (priv _ e0) l ) ).
+        -- inv Ht23; try inv CHECK; ddestruction; subst; try contradiction.
+           constructor; auto. rewrite H5. eapply eqit_secure_trans_aux2; eauto.
+           rewrite <- H5. apply H2. Unshelve. all : auto.
+        -- destruct (classic_empty X).
+           ++ rewrite itree_eta'. rewrite itree_eta' at 1. pstep_reverse.
+              eapply paco2_mon with (r := bot2); intros; try contradiction.
+              eapply secret_halt_trans_3 with (t2 := Vis e k2); eauto.
+              ** pfold. red. cbn. unpriv_co.
+              ** pfold. auto.
+           ++ unpriv_co. right. eapply CIH0; try apply H.
+              Unshelve. all : auto.
+              assert (eqit_secure Label priv RR2 b1 b2 l (Vis e k2) (Vis e0 k) ).
+              pfold. auto. eapply eqit_secure_VisLR; eauto.
+  - pclearbot. remember (VisF e2 k2) as x.
+    (* maybe need to separate the inductive and coinductive progress cases? *)
+    hinduction Ht23 before r; intros; inv Heqx; try inv CHECK; try contradiction;
+    try contra_size;
+    ddestruction; subst; auto.
+    + constructor; auto. eapply IHHt23; eauto.
+    + pclearbot. unpriv_co. right. eapply CIH0; try apply H0. apply H.
+    + pclearbot. assert (Hne : nonempty B); eauto. inv Hne.
+      unpriv_co. right. eapply CIH0; eauto; try eapply H0. apply H.
+      Unshelve. auto.
+    + pclearbot. assert (Hne : nonempty B0); eauto. inv Hne.
+      unpriv_co. right. eapply CIH0; try apply H0. apply H.
+      Unshelve. auto.
+    + genobs t2 ot2. destruct ot2.
+      * assert (Hne : nonempty B); eauto. inv Hne.
+        rewrite itree_eta'. unpriv_ind. eapply eqit_secure_trans_aux1; eauto.
+        Unshelve. auto.
+      * assert (Hne : nonempty B); eauto. inv Hne.
+        unpriv_co. right. eapply CIH0; try apply H1. Unshelve. all : auto.
+        clear H0. specialize (H a). pfold. red. genobs (k2 a) ok2.
+        clear Heqok2 H1 k2.
+        remember (TauF t) as y.
+        hinduction H before r; intros; inv Heqy; try inv CHECK; auto.
+        -- constructor; auto. pclearbot. pstep_reverse.
+        -- constructor; eauto.
+        -- pclearbot. unpriv_ind. pstep_reverse.
+        -- unpriv_ind. eapply H0; eauto.
+        -- pclearbot. rewrite itree_eta' at 1. pstep_reverse.
+      * inv SIZECHECK2.
+        destruct (classic (leq (priv _ e) l ) ).
+        -- rewrite itree_eta'. unpriv_ind.
+           eapply eqit_secure_trans_aux2; eauto. Unshelve. all : auto.
+        -- destruct (classic_empty X).
+           ++ unpriv_halt. right. eapply CIH0; eauto. apply H1.
+              pfold. apply H. Unshelve. auto.
+           ++ unpriv_co. right. eapply CIH0; try apply H1.
+              Unshelve. all : auto.
+              clear H0. pstep. red. remember (VisF e k) as y.
+              specialize (H a). clear Heqot2. genobs (k2 a) ok2.
+              clear Heqok2.
+              hinduction H before r; intros; inv Heqy; try inv CHECK;
+                ddestruction; subst; try contradiction; try contra_size; eauto with itree.
+              ** pclearbot. constructor; auto. pstep_reverse.
+              ** unpriv_ind. pclearbot. pstep_reverse.
+              ** pclearbot. rewrite itree_eta' at 1. pstep_reverse.
+    + rewrite itree_eta' at 1. unpriv_ind. eapply H0; eauto.
+    + pclearbot. inv SIZECHECK2. unpriv_halt. right. eapply CIH0; eauto. apply H0.
+      apply H. Unshelve. auto.
+  - remember (VisF e k2) as x. hinduction Ht23 before r; intros; inv Heqx; try inv CHECK;
+    ddestruction; subst; try contradiction; try contra_size;  auto.
+    + constructor; auto. eapply IHHt23; eauto.
+    + constructor; auto. pclearbot. assert (Hne : nonempty A0); eauto. inv Hne. eapply H0; eauto.
+      pstep_reverse. Unshelve. auto.
+    + unpriv_ind. assert (Hne : nonempty A0); eauto. inv Hne. eapply H0; eauto.
+      pclearbot. pstep_reverse. Unshelve. auto.
+    + assert (Hne : nonempty A0). { eauto. } inv Hne. eauto. Unshelve.  auto.
+    + unpriv_ind. eauto.
+    + pclearbot. rewrite itree_eta'. pstep_reverse.
+      apply paco2_mon with (r := bot2); intros; try contradiction.
+      inv SIZECHECK0.
+      eapply secret_halt_trans_3 with (t2 := k0 a); eauto.
+      * pfold. apply H1.
+      * apply H.
+  - pclearbot.
+    remember (TauF t0) as y.
+    hinduction Ht23 before r; intros; inv Heqy; subst; eauto with itree; pclearbot.
+    + unpriv_halt. right. eapply CIH0; eauto.
+    + clear IHHt23. rewrite itree_eta'. rewrite itree_eta' at 1.
+      pstep_reverse. apply paco2_mon with (r := bot2); intros; try contradiction.
+      eapply secret_halt_trans_2; eauto. pfold. auto.
+    + unpriv_halt. right. eapply CIH0; eauto. apply H.
+    + rewrite itree_eta' at 1. unpriv_ind. eapply H0; eauto.
+    + unpriv_halt. contra_size.
+  - pclearbot.
+    inv Ht23; ddestruction; subst; try contra_size; try contradiction;
+    try inv CHECK.
+    + constructor. right. eapply CIH0; eauto. pfold. auto.
+    + unpriv_co. right. eapply CIH0; eauto. rewrite H0 in H2.
+      pfold. apply H2.
+    + pclearbot. constructor. right. eapply CIH0; eauto.
+    + pclearbot. destruct (classic_empty B).
+      * unpriv_halt. right. eapply CIH0; eauto. pfold. red. cbn. unpriv_halt.
+      * unpriv_co. right. eapply CIH0; eauto. apply H1.
+    + pclearbot. unpriv_halt. right. eapply CIH0; eauto.
+      pfold. red. cbn. unpriv_halt. contra_size.
+ - pclearbot. rewrite itree_eta' at 1. pstep_reverse.
+   apply paco2_mon with (r := bot2); intros; try contradiction.
+   eapply secret_halt_trans_2 with (t2 := Vis e2 k2); eauto.
+   + pfold. red. cbn. unpriv_halt.
+   + pfold. auto.
+ - pclearbot. destruct (classic_empty A).
+   + inv Ht23; ddestruction; subst; try contradiction; try contra_size; try inv CHECK.
+     * unpriv_halt. right. eapply CIH0 with (t2 := Vis e2 k2); eauto.
+       -- pfold. red. cbn. unpriv_halt. contra_size.
+       -- pfold. auto.
+     * unpriv_halt. right. rewrite H1 in H3. eapply CIH0 with (t2 := Vis e2 k2); eauto.
+       -- pfold. red. cbn. unpriv_halt. contra_size.
+       -- pfold. apply H3.
+     * unpriv_halt. pclearbot. right. eapply CIH0; eauto.
+       pfold. red. cbn. unpriv_halt. contra_size.
+     * unpriv_halt. pclearbot. right. eapply CIH0 with (t2 := Vis e2 k2); eauto.
+       -- pfold. red. cbn. unpriv_halt. contra_size.
+       -- apply H2.
+     * unpriv_halt. contra_size.
+   + destruct (observe t3).
+     * inv Ht23; ddestruction; subst; try contra_size; try contradiction.
+     * unpriv_co. right. eapply CIH0; eauto. apply H.
+       inv Ht23; ddestruction; subst; try contra_size; try contradiction.
+       pfold. auto. pclearbot. auto.
+     * destruct (classic (leq (priv _ e) l ) ).
+       { inv Ht23; ddestruction; subst; try contra_size; try contradiction. }
+       destruct (classic_empty X).
+       -- unpriv_halt. right. eapply CIH0; eauto. apply H. pfold. auto.
+       -- unpriv_co. right. eapply CIH0; eauto. apply H.
+          inv Ht23; ddestruction; subst; try contra_size; try contradiction.
+          ++ pfold. apply H5.
+          ++ pclearbot. apply H4.
+Qed.
+
+
+Lemma eqit_itree_eqit_secure : forall E Label priv l R1 R2 RR (t1 t1': itree E R1) (t2 : itree E R2),
+    t1 ≅ t1' -> eqit_secure Label priv RR false false l t1 t2 ->
+    eqit_secure Label priv RR false false l t1' t2.
+Proof.
+  intros E Label priv l R1 R2 RR. pcofix CIH.
+  intros t1 t1' t2 Heq Hsec. pstep. red.
+  punfold Heq. red in Heq. punfold Hsec. red in Hsec.
+  inv Heq; try inv CHECK.
+  - rewrite <- H0 in Hsec. rewrite itree_eta' at 1. pstep_reverse.
+    eapply paco2_mon with (r := bot2); intros; try contradiction. pfold.
+    red. cbn. remember (RetF r2) as x. clear H H0.
+    hinduction Hsec before r; intros; inv Heqx; eauto with itree.
+  - pclearbot. genobs t2 ot2.
+    assert ( (exists t3, ot2 = TauF t3) \/ (forall t3, ot2 <> TauF t3) ).
+    { destruct ot2; eauto; right; intros; discriminate. }
+    destruct H1 as [ [t3 Ht2] | Ht2].
+    + subst. rewrite Ht2. rewrite Ht2 in Hsec. constructor.
+      right. eapply CIH; eauto. rewrite <- H0 in Hsec. inv Hsec; try inv CHECK. pclearbot. auto.
+    + destruct ot2; try (exfalso; eapply Ht2;  eauto; fail  ).
+      * rewrite <- H0 in Hsec. inv Hsec; try inv CHECK.
+      * rewrite <- H0 in Hsec. inv Hsec; ddestruction; subst; try inv CHECK.
+        -- pclearbot. unpriv_co. right. eapply CIH; eauto. apply H3.
+        -- pclearbot. unpriv_halt. right. eapply CIH; eauto.
+  - rewrite <- H0 in Hsec. inv Hsec; ddestruction; subst; try inv CHECK; try contradiction; try contra_size.
+    + pclearbot. constructor; auto. right. eapply CIH; eauto with itree. apply H2.
+    + pclearbot. unpriv_co. right. eapply CIH; eauto with itree. apply H2.
+    + pclearbot. unpriv_co. right. eapply CIH; eauto with itree. apply H2.
+    + pclearbot. unpriv_halt. right. eapply CIH; eauto. pfold. constructor. left. auto.
+    + pclearbot. unpriv_halt. right. eapply CIH with (t1 := Vis e k1); try apply H2.
+      pfold. constructor. left. auto.
+    + pclearbot. unpriv_halt. right. eapply CIH; eauto with itree. apply H2.
+Qed.
+
+Lemma eqit_secure_eq_trans : forall E R b1 b2 Label priv l (t1 t2 t3 : itree E R),
+    eqit_secure Label priv eq b1 b2 l t1 t2 ->
+    eqit_secure Label priv eq b1 b2 l t2 t3 ->
+    eqit_secure Label priv eq b1 b2 l t1 t3.
+Proof.
+  intros. apply eqit_secure_RR_imp with (RR1 := rcompose eq eq).
+  { intros. inv PR. auto. }
+  eapply eqit_secure_trans; eauto.
+Qed.
+
+Lemma eqit_secure_anything : forall E R1 b Label priv l
+                      (t1 : itree E R1) t2,
+    eqit_secure Label priv eq b b l t1 t2 ->
+    eqit_secure Label priv eq b b l t1 t1.
+Proof.
+  intros.
+  eapply eqit_secure_eq_trans; eauto.
+  apply eqit_secure_sym. eapply eqit_secure_RR_imp; eauto.
+Qed.
+
+
+Global Instance proper_eqit_secure_eqit {E} {R1 R2 : Type} {b} {RR : R1 -> R2 -> Prop} {Label priv l} :
+       Proper (eqit eq b b ==> eqit eq b b ==> iff) (@eqit_secure E R1 R2 Label priv RR b b l).
+Proof.
+  repeat intro. destruct b; split; intros.
+  - eapply eutt_secure_eqit_secure; eauto.
+    apply eqit_secure_sym. eapply eutt_secure_eqit_secure; eauto.
+    apply eqit_secure_sym. auto.
+  - assert (x ≈ y); auto. assert (x0 ≈ y0); auto.
+    symmetry in H2.
+    eapply eutt_secure_eqit_secure; eauto.
+    symmetry in H3. apply eqit_secure_sym.
+    eapply eutt_secure_eqit_secure; eauto.
+    apply eqit_secure_sym. auto.
+  - eapply eqit_itree_eqit_secure; eauto.
+    apply eqit_secure_sym. eapply eqit_itree_eqit_secure; eauto.
+    apply eqit_secure_sym. auto.
+  - assert (x ≅ y); auto. assert (x0 ≅ y0); auto.
+    symmetry in H2. symmetry in H3.
+    eapply eqit_itree_eqit_secure; eauto.
+    apply eqit_secure_sym. eapply eqit_itree_eqit_secure; eauto.
+    apply eqit_secure_sym. auto.
+Qed.
+
+Global Instance proper_eqit_secure_eqit_secure
+       {E} {b} {R1 R2 : Type} {RR : R1 -> R2 -> Prop} {Label priv l} :
+  Proper (eqit_secure Label priv eq b b l ==> eqit_secure Label priv eq b b l ==> iff)
+         (@eqit_secure E R1 R2 Label priv RR b b l).
+Proof.
+  repeat intro; split; intros.
+  - eapply eqit_secure_RR_imp with (RR1 := rcompose RR eq); eauto.
+    { intros. inv PR. auto. }
+    eapply eqit_secure_trans; eauto.
+    apply eqit_secure_sym.
+    eapply eqit_secure_RR_imp with (RR1 := rcompose (flip RR) eq); eauto.
+    { intros. inv PR. auto. }
+    eapply eqit_secure_trans; eauto. apply eqit_secure_sym. auto.
+  - assert (eqit_secure Label priv eq b b l y0 x0).
+    { apply eqit_secure_sym. eapply eqit_secure_RR_imp; eauto. }
+    eapply eqit_secure_RR_imp with (RR1 := rcompose RR eq).
+    { intros. inv PR. auto. }
+    eapply eqit_secure_trans; eauto.
+    assert (eqit_secure Label priv eq b b l y x).
+    { apply eqit_secure_sym. eapply eqit_secure_RR_imp; eauto. }
+    eapply eqit_secure_RR_imp with (RR1 := rcompose eq RR).
+    { intros. inv PR. auto. }
+    eapply eqit_secure_trans; eauto.
+Qed.

--- a/theories/Secure/SecureEqEuttTrans.v
+++ b/theories/Secure/SecureEqEuttTrans.v
@@ -1,0 +1,152 @@
+From ITree Require Import
+     Axioms
+     ITree
+     ITreeFacts
+     Secure.SecureEqHalt
+     Secure.SecureEqEuttHalt
+.
+
+From Paco Require Import paco.
+
+Import Monads.
+Import MonadNotation.
+Local Open Scope monad_scope.
+
+
+Lemma eses_aux3:
+  forall (E : Type -> Type) (R3 R1 : Type) (Label : Preorder)
+    (priv : forall A : Type, E A -> L) (l : L) (R2 : Type) (RR1 : R1 -> R2 -> Prop)
+    (RR2 : R2 -> R3 -> Prop) (r : itree E R1 -> itree E R3 -> Prop)
+    (m1 : itree E R2) (m2 : itree E R3),
+    paco2 (eqit_ RR2 true true id) bot2 m1 m2 ->
+    forall r0 : R1,
+      secure_eqitF Label priv RR1 true true l id
+                   (upaco2 (secure_eqit_ Label priv RR1 true true l id) bot2) (RetF r0)
+                   (observe m1) ->
+      secure_eqitF Label priv (rcompose RR1 RR2) true true l id
+                   (upaco2 (secure_eqit_ Label priv (rcompose RR1 RR2) true true l id) r)
+                   (RetF r0) (observe m2).
+Proof.
+  intros E R3 R1 Label priv l R2 RR1 RR2 r m1 m2 REL r0 Hsec.
+  remember (RetF r0) as x.
+  punfold REL. red in REL. hinduction Hsec before r; intros; inv Heqx; eauto.
+  - remember (RetF r2) as y. hinduction REL before r; intros; inv Heqy; eauto with itree.
+  - eapply IHHsec; eauto. pstep_reverse. setoid_rewrite <- tau_eutt at 1. pfold. auto.
+  - remember (VisF e k2) as y.
+    hinduction REL before r; intros; inv Heqy; ddestruction; subst; eauto with itree.
+    pclearbot. unpriv_ind. eapply H0; eauto. pstep_reverse.
+Qed.
+
+
+Lemma eses_aux4:
+  forall (E : Type -> Type) (R3 R1 : Type) (Label : Preorder)
+    (priv : forall A : Type, E A -> L) (l : L) (R2 : Type) (RR1 : R1 -> R2 -> Prop)
+    (RR2 : R2 -> R3 -> Prop) (r : itree E R1 -> itree E R3 -> Prop)
+    (m1 : itree E R2) (m2 : itree E R3),
+    (forall (t1 : itree E R1) (t2 : itree E R2) (t3 : itree E R3),
+        eqit_secure Label priv RR1 true true l t1 t2 -> eutt RR2 t2 t3 -> r t1 t3) ->
+    paco2 (eqit_ RR2 true true id) bot2 m1 m2 ->
+    forall (X : Type) (e : E X) (k : X -> itree E R1),
+      secure_eqitF Label priv RR1 true true l id
+                   (upaco2 (secure_eqit_ Label priv RR1 true true l id) bot2) (VisF e k)
+                   (observe m1) ->
+      leq (priv X e) l ->
+      secure_eqitF Label priv (rcompose RR1 RR2) true true l id
+                   (upaco2 (secure_eqit_ Label priv (rcompose RR1 RR2) true true l id) r)
+                   (VisF e k) (observe m2).
+Proof.
+  intros E R3 R1 Label priv l R2 RR1 RR2 r m1 m2 CIH REL X e k Hsec SECCHECK.
+  punfold REL. red in REL. remember (VisF e k) as y.
+  hinduction Hsec before r; intros; inv Heqy; ddestruction; subst; try contradiction.
+  - eapply IHHsec; eauto. pstep_reverse. rewrite <- tau_eutt at 1. pfold. auto.
+  - pclearbot. inv REL; ddestruction; subst.
+    + constructor; auto. right. pclearbot. eapply CIH; eauto with itree.
+      apply H.
+    + constructor; auto. remember (VisF e0 k2) as y.
+      hinduction REL0 before r; intros; inv Heqy; ddestruction; subst; try contradiction.
+      * constructor; auto. right. pclearbot. eapply CIH; eauto with itree. apply H.
+      * constructor; auto. eapply IHREL0; eauto.
+  - rewrite H2. remember (VisF e k2) as y.
+    hinduction REL before r; intros; inv Heqy; ddestruction; subst; try contradiction.
+    + rewrite itree_eta' at 1. unpriv_ind. rewrite <- H2. eapply H0; eauto.
+      pclearbot.
+      pstep_reverse.
+    + constructor; auto. eapply IHREL; eauto.
+Qed.
+
+(*This lemma lets us lift compiler correctness results to compiler security preservation results*)
+Lemma eutt_secure_eqit_secure : forall E Label priv l R1 R2 R3 (RR1 : R1 -> R2 -> Prop) (RR2 : R2 -> R3 -> Prop)
+  (t1 : itree E R1) (t2 : itree E R2) (t3 : itree E R3),
+    eqit_secure Label priv RR1 true true l t1 t2 -> eutt RR2 t2 t3 ->
+    eqit_secure Label priv (rcompose RR1 RR2) true true l t1 t3.
+Proof.
+  intros E Label priv l R1 R2 R3 RR1 RR2. pcofix CIH. intros t1 t2 t3 Hsec Heutt.
+  punfold Heutt. red in Heutt. punfold Hsec. red in Hsec.
+  pfold. red. hinduction Heutt before r; intros; subst; auto with itree.
+  - remember (RetF r2) as x. remember (RetF r1)  as y. hinduction Hsec before r; intros; try inv Heqx; try inv Heqy; subst; auto with itree.
+    + constructor; eauto with itree.
+    + constructor; auto. eapply IHHsec; eauto.
+    + rewrite itree_eta'. unpriv_ind. eapply H0; eauto.
+  - genobs_clear t1 ot1.
+    assert (Ht1 : (exists m3, ot1 = TauF m3) \/ (forall m3, ot1 <> TauF m3) ).
+    { destruct ot1; eauto; right; repeat intro; discriminate. }
+    (* because of the extra inductive cases this is not enough *)
+    destruct Ht1 as [ [m3 Hm3] | Ht1 ].
+    + subst. pclearbot. constructor. right. eapply CIH; eauto.
+      apply tau_eqit_secure. apply eqit_secure_sym. apply tau_eqit_secure.
+      apply eqit_secure_sym. pfold. auto.
+    + destruct ot1; try (exfalso; eapply Ht1; eauto; fail).
+      * pclearbot. rewrite itree_eta'. rewrite itree_eta' in Hsec.
+        eapply eses_aux3; eauto. pfold. constructor.
+        left. auto.
+      * assert (leq (priv _ e) l \/ ~ leq (priv _ e) l).
+        { apply classic. }
+        destruct H as [SECCHECK | SECCHECK]; destruct ( classic_empty X  ).
+        ++ pclearbot. rewrite itree_eta'. rewrite itree_eta' in Hsec.
+           eapply eses_aux4; eauto. do 2 rewrite tau_eutt. auto.
+        ++ pclearbot. rewrite itree_eta'.
+           rewrite itree_eta' in Hsec. eapply eses_aux4; eauto.
+           do 2 rewrite tau_eutt. auto.
+        ++ unpriv_halt. pclearbot. right. eapply CIH; eauto.
+           apply eqit_secure_sym. apply tau_eqit_secure. apply eqit_secure_sym.
+           pfold. auto.
+        ++ pclearbot.
+           unpriv_co. pclearbot. right. eapply CIH; try apply REL.
+           apply eqit_secure_sym. apply tau_eqit_secure.
+           apply eqit_secure_sym.
+           eapply unpriv_e_eqit_secure; eauto.
+           pfold. auto.
+  - pclearbot. destruct (classic (leq (priv _ e) l ) ).
+    + genobs_clear t1 ot1.
+      remember (VisF e k1) as y.
+      hinduction Hsec before r; intros; try inv Heqy; ddestruction; subst; try contradiction;
+      eauto with itree.
+      * constructor; auto. right. pclearbot. eapply CIH; eauto with itree. apply H.
+      * rewrite itree_eta'. unpriv_ind. eapply H0; eauto.
+    + remember (VisF e k1) as y.
+      hinduction Hsec before r; intros; inv Heqy; ddestruction; subst; try contradiction.
+      * eauto with itree.
+      * pclearbot. unpriv_co. right. eapply CIH; eauto with itree. apply H.
+      * pclearbot. unpriv_co. right. eapply CIH; eauto with itree. apply H.
+      * rewrite itree_eta'. unpriv_ind. eapply H0; eauto.
+      * destruct (observe t0).
+        -- rewrite itree_eta' at 1. unpriv_ind.
+           specialize (H a).
+           eapply eses_aux3; eauto.
+        -- unpriv_co. right. eapply CIH; eauto with itree. apply tau_eqit_secure.
+           pfold. apply H.
+        -- destruct (classic (leq (priv _ e) l ) ).
+           ++ rewrite itree_eta' at 1. unpriv_ind.
+              eapply eses_aux4; eauto.
+           ++ destruct (classic_empty X).
+              ** unpriv_halt. right. eapply CIH; eauto with itree. pfold. apply H.
+              ** unpriv_co. right. eapply CIH; eauto with itree.
+                 eapply unpriv_e_eqit_secure; eauto. pfold. apply H.
+      * pclearbot. unpriv_halt. right. eapply CIH; eauto. pfold.
+        constructor; intros; auto with itree.
+      * pclearbot. unpriv_halt. right. eapply CIH; eauto with itree. apply H.
+      * pclearbot. unpriv_halt. right. eapply CIH; eauto with itree. apply H.
+        pfold. constructor; auto with itree.
+  - eapply IHHeutt; eauto. pstep_reverse. apply eqit_secure_sym.
+    apply tau_eqit_secure. apply eqit_secure_sym. pfold. auto.
+Qed.

--- a/theories/Secure/SecureEqHalt.v
+++ b/theories/Secure/SecureEqHalt.v
@@ -1,0 +1,218 @@
+From ITree Require Import
+     Basics.Tacs
+     Axioms
+     ITree
+     ITreeFacts
+.
+
+From ITree Require Export Secure.Labels.
+
+From Paco Require Import paco.
+
+Import Monads.
+Import MonadNotation.
+Local Open Scope monad_scope.
+
+Ltac pmonauto_itree :=
+  let IN := fresh "IN" in
+  try (repeat intro; destruct IN; eauto with paco itree; fail).
+
+(* will need more propositional constraints on Preorders *)
+
+Section SecureUntimed.
+  Context {E : Type -> Type} {R1 R2 : Type}.
+  Context (Label : Preorder).
+  Context (priv : forall A, E A -> L).
+  Context (RR : R1 -> R2 -> Prop).
+
+  Coercion is_true : bool >-> Sortclass.
+  Inductive secure_eqitF (b1 b2 : bool) (l : L) vclo (sim : itree E R1 -> itree E R2 -> Prop) : itree' E R1 -> itree' E R2 -> Prop :=
+
+    (* eqitF constructors *)
+    | secEqRet r1 r2 : RR r1 r2 -> secure_eqitF b1 b2 l vclo sim (RetF r1) (RetF r2)
+    | secEqTau t1 t2 : sim t1 t2 -> secure_eqitF b1 b2 l vclo sim (TauF t1) (TauF t2)
+    | secEqTauL t1 ot2 (CHECK : b1) : secure_eqitF b1 b2 l vclo sim (observe t1) ot2 -> secure_eqitF b1 b2 l vclo sim (TauF t1) ot2
+    | secEqTauR ot1 t2 (CHECK : b2) : secure_eqitF b1 b2 l vclo sim ot1 (observe t2) -> secure_eqitF b1 b2 l vclo sim ot1 (TauF t2)
+    (* info_flow protecting coinductive constructors *)
+    | EqVisPriv {A} (e : E A) k1 k2 (SECCHECK : leq (priv A e) l) :
+        ((forall a, vclo sim (k1 a) (k2 a) : Prop)) -> secure_eqitF b1 b2 l vclo sim (VisF e k1) (VisF e k2)
+    | EqVisUnPrivTauLCo {A} (e : E A) k1 t2 (SECCHECK : ~ leq (priv A e) l) (SIZECHECK : nonempty A) :
+        (forall a, vclo sim (k1 a) t2) -> secure_eqitF b1 b2 l vclo sim (VisF e k1) (TauF t2)
+    | EqVisUnPrivTauRCo {A} (e : E A) t1 k2 (SECCHECK : ~ leq (priv A e) l) (SIZECHECK : nonempty A) :
+        (forall a, vclo sim t1 (k2 a)) -> secure_eqitF b1 b2 l vclo sim (TauF t1) (VisF e k2)
+    | EqVisUnPrivVisCo {A B} (e1 : E A) (e2 : E B) k1 k2 (SECCHECK1 : ~ leq (priv A e1) l) (SECCHECK2 : ~ leq (priv B e2) l)
+        (SIZECHECK1 : nonempty A ) (SIZECHECK2 : nonempty B) :
+        (forall a b, vclo sim (k1 a) (k2 b)) -> secure_eqitF b1 b2 l vclo sim (VisF e1 k1) (VisF e2 k2)
+    (* info_flow protecting inductive constructors *)
+    | EqVisUnPrivLInd {A} (e : E A) k1 t2 (CHECK : b1) (SECCHECK : ~ leq (priv A e) l) (SIZECHECK : nonempty A) :
+        (forall a, secure_eqitF b1 b2 l vclo sim (observe (k1 a)) (observe t2) ) ->
+        secure_eqitF b1 b2 l vclo sim (VisF e k1) (observe t2)
+    | EqVisUnPrivRInd {A} (e : E A) t1 k2 (CHECK : b2) (SECCHECK : ~ leq (priv A e) l) (SIZECHECK : nonempty A) :
+        (forall a, secure_eqitF b1 b2 l vclo sim (observe t1) (observe (k2 a) )) ->
+        secure_eqitF b1 b2 l vclo sim (observe t1) (VisF e k2)
+    (* info_flow protecting constructors for halting events, should capture the notion that a secret halt means
+       that either it halted or it is performing some secret or silent computation and you can't tell which *)
+    | EqVisUnprivHaltLTauR {A} (e : E A) k1 t2 (SECCHECK : ~ leq (priv A e) l ) (SIZECHECK : empty A) :
+        sim (Vis e k1) t2 -> secure_eqitF b1 b2 l vclo sim (VisF e k1) (TauF t2)
+    | EqVisUnprivHaltRTauL {A} (e : E A) t1 k2 (SECCHECK : ~ leq (priv A e) l ) (SIZECHECK : empty A) :
+        sim t1 (Vis e k2) -> secure_eqitF b1 b2  l vclo sim (TauF t1) (VisF e k2)
+    | EqVisUnprivHaltLVisR {A B} (e1 : E A) (e2 : E B) k1 k2 (SECCHECK1 : ~ leq (priv A e1) l) (SECCHECK2 : ~ leq (priv B e2) l)
+            (SIZECHECK : empty A) :
+      (forall b, vclo sim (Vis e1 k1) (k2 b) ) -> secure_eqitF b1 b2 l vclo sim (VisF e1 k1) (VisF e2 k2)
+    | EqVisUnprivHaltRVisL {A B} (e1 : E A) (e2 : E B) k1 k2 (SECCHECK1 : ~ leq (priv A e1) l) (SECCHECK2 : ~ leq (priv B e2) l)
+            (SIZECHECK : empty B) :
+        (forall a, vclo sim (k1 a) (Vis e2 k2)) -> secure_eqitF b1 b2 l vclo sim (VisF e1 k1) (VisF e2 k2)
+  .
+
+  Hint Constructors secure_eqitF : itree.
+
+  Definition secure_eqit_ (b1 b2 : bool) (l : L) vclo (sim : itree E R1 -> itree E R2 -> Prop) : itree E R1 -> itree E R2 -> Prop :=
+    fun t1 t2 => secure_eqitF b1 b2 l vclo sim (observe t1) (observe t2).
+
+  Hint Unfold secure_eqit_ : itree.
+
+  Lemma secure_eqitF_mono b1 b2 l x0 x1 vclo vclo' sim sim'
+        (IN: secure_eqitF b1 b2 l vclo sim x0 x1)
+        (MON: monotone2 vclo)
+        (LEc: vclo <3= vclo')
+        (LE: sim <2= sim'):
+    secure_eqitF b1 b2 l vclo' sim' x0 x1.
+  Proof.
+    intros. induction IN; eauto with itree.
+  Qed.
+
+  Lemma secure_eqit_mono b1 b2 l vclo (MON: monotone2 vclo) : monotone2 (secure_eqit_ b1 b2 l vclo).
+  Proof.
+    do 2 red. intros; eapply secure_eqitF_mono; eauto.
+  Qed.
+
+  Hint Resolve secure_eqit_mono : paco.
+
+  Definition eqit_secure b1 b2 l := paco2 (secure_eqit_ b1 b2 l id) bot2.
+
+  (* want and eqitC_secure which could help prove some interesting stuff
+
+   *)
+
+
+  (*
+    Note that this is not reflexive (think it is symmetric and transitive)
+    Suppose SecureFlip : E bool has privilege 1 and trigger SecureFlip is
+    observed at privilege 0. We end to prove eqit_secure false false 0 of it
+    requires us to show forall a b, eqit_secure false false 0 (Ret a) (Ret b)
+    this is false, suppose a = true and b = false and the relation is equality
+
+   *)
+
+
+End SecureUntimed.
+
+#[global] Hint Resolve secure_eqit_mono : paco.
+
+#[global] Hint Constructors secure_eqitF : itree.
+
+Definition NatPreorder : Preorder :=
+  {|
+  L := nat;
+  leq := fun n m => n <= m
+  |}.
+
+Ltac unpriv_co := try apply EqVisUnPrivVisCo;
+                  try apply EqVisUnPrivTauLCo;
+                  try apply EqVisUnPrivTauRCo;
+                  auto with itree; intros.
+
+Ltac unpriv_ind := try apply EqVisUnPrivLInd;
+                   try apply EqVisUnPrivRInd;
+                   auto with itree; intros.
+
+Ltac unpriv_halt :=
+  match goal with
+  | [  Hemp : empty ?A |- secure_eqitF _ _ _ _ _ _ _ _ (@VisF _ _ _ ?A _ _) _ ] =>
+    try apply EqVisUnprivHaltLTauR; try apply EqVisUnprivHaltLVisR; auto with itree; intros
+
+  | [  Hemp : empty ?A |- secure_eqitF _ _ _ _ _ _ _ _ _ (@VisF _ _ _ ?A _ _)  ] =>
+    try apply EqVisUnprivHaltRTauL; try apply EqVisUnprivHaltRVisL; auto with itree; intros end.
+
+Section SecureUntimedUnReflexive.
+
+Section eqit_secureC.
+  (* might not be the order I eventually want but whatever*)
+  Context {E: Type -> Type} {R1 R2 : Type} (RR : R1 -> R2 -> Prop).
+  Context (Label : Preorder) (priv : forall A, E A -> L) (l : L).
+
+
+  Variant eqit_secure_trans_clo (b1 b2 b1' b2' : bool) (r : itree E R1 -> itree E R2 -> Prop) :
+    itree E R1 -> itree E R2 -> Prop :=
+        eqit_secure_trans_clo_intro t1 t2 t1' t2' RR1 RR2
+      (EQVl: eqit_secure Label priv RR1 b1 b1' l t1 t1')
+      (EQVr: eqit_secure Label priv RR2 b2 b2' l t2 t2')
+      (REL: r t1' t2')
+      (LERR1: forall x x' y, RR1 x x' -> RR x' y -> RR x y)
+      (LERR2: forall x y y', RR2 y y' -> RR x y' -> RR x y) :
+      eqit_secure_trans_clo b1 b2 b1' b2' r t1 t2.
+
+  Hint Constructors eqit_secure_trans_clo : itree.
+
+  Definition eqit_secureC b1 b2 := eqit_secure_trans_clo b1 b2 false false.
+  Hint Unfold eqit_secureC : itree.
+
+  Lemma eqit_secureC_mon b1 b2 r1 r2 t1 t2
+    (IN : eqit_secureC b1 b2 r1 t1 t2)
+    (LE: r1 <2= r2) :
+    eqit_secureC b1 b2 r2 t1 t2.
+  Proof.
+    destruct IN; eauto with itree.
+  Qed.
+
+End eqit_secureC.
+
+
+Ltac gfinal_with H := gfinal; left; apply H.
+
+Lemma eqit_secure_sym : forall b1 b2 E R1 R2 RR Label priv l (t1 : itree E R1) (t2 : itree E R2),
+    eqit_secure Label priv RR b1 b2 l t1 t2 -> eqit_secure Label priv (flip RR) b2 b1 l t2 t1.
+Proof.
+  intros b1 b2 E R1 R2 RR Label priv l. pcofix CIH.
+  intros t1 t2 Hsec. pfold. red. punfold Hsec. red in Hsec.
+  hinduction Hsec before r; intros; eauto with itree; pclearbot;
+  try (unpriv_co; right; apply CIH; apply H);
+  try unpriv_halt.
+  - constructor; auto with itree. intros. right. apply CIH; apply H.
+  - specialize (H a). remember (k2 a) as t. clear Heqt k2.
+     left.
+     intros. pfold. red. cbn. punfold H. red in H. cbn in H.
+     inv H; ddestruction; subst; try contra_size; try contradiction; pclearbot; eauto;
+     try (unpriv_halt; fail).
+     +  unpriv_halt. right. apply CIH. pfold. auto.
+     + rewrite H0. rewrite H0 in H2. unpriv_halt.
+       right. apply CIH. pfold. apply H2.
+     + unpriv_halt. right. apply CIH. apply H1.
+     + unpriv_halt. right. apply CIH. apply H1.
+  - specialize (H b). remember (k1 b) as t. clear Heqt k1.
+     left.
+     intros. pfold. red. cbn. punfold H. red in H. cbn in H.
+     inv H; ddestruction; subst; try contra_size; try contradiction; pclearbot; eauto;
+     try (unpriv_halt; fail).
+     +  unpriv_halt. right. apply CIH. pfold. auto.
+     + rewrite H1. rewrite H1 in H2. unpriv_halt.
+       right. apply CIH. pfold. apply H2.
+     + unpriv_halt. inv SIZECHECK0. contradiction.
+     + unpriv_halt. right. apply CIH. apply H2.
+Qed.
+
+Lemma secure_eqit_mon : forall E (b1 b2 b3 b4 : bool) R1 R2 RR1 RR2 Label priv l
+      (t1 : itree E R1) (t2 : itree E R2),
+    (b1 -> b3) -> (b2 -> b4) -> (RR1 <2= RR2) ->
+    eqit_secure Label priv RR1 b1 b2 l t1 t2 -> eqit_secure Label priv RR2 b3 b4 l t1 t2.
+Proof.
+  intros. generalize dependent t2. revert t1. pcofix CIH.
+  intros t1 t2 Ht12. pstep. red.
+  punfold Ht12. red in Ht12.
+  hinduction Ht12 before r; intros; eauto; pclearbot;
+  try (unpriv_co; right; apply CIH; try red; eauto; fail);
+  try (unpriv_halt; try contra_size; right; apply CIH; try red; eauto; fail).
+  constructor; auto. right.  eauto. apply CIH; apply H2.
+Qed.
+
+End SecureUntimedUnReflexive.

--- a/theories/Secure/SecureEqHaltProgInsens.v
+++ b/theories/Secure/SecureEqHaltProgInsens.v
@@ -1,0 +1,314 @@
+From ITree Require Import
+     Axioms
+     ITree
+     ITreeFacts
+.
+
+From ITree Require Export Secure.Labels.
+
+From Paco Require Import paco.
+
+(* will need more propositional constraints on Preorders *)
+
+Section SecureUntimed.
+  Context {E : Type -> Type} {R1 R2 : Type}.
+  Context (Label : Preorder).
+  Context (priv : forall A, E A -> L).
+  Context (RR : R1 -> R2 -> Prop).
+
+  Coercion is_true : bool >-> Sortclass.
+
+  Variant secure_eqitF (b1 b2 : bool) (l : L) vclo (sim : itree E R1 -> itree E R2 -> Prop) : itree' E R1 -> itree' E R2 -> Prop :=
+
+    (* eqitF constructors *)
+    | secEqRet r1 r2 : RR r1 r2 -> secure_eqitF b1 b2 l vclo sim (RetF r1) (RetF r2)
+    | secEqTau t1 t2 : sim t1 t2 -> secure_eqitF b1 b2 l vclo sim (TauF t1) (TauF t2)
+    | secEqTauL t1 t2 (CHECK : b1) : sim t1 t2 -> secure_eqitF b1 b2 l vclo sim (TauF t1) (observe t2)
+    | secEqTauR t1 t2 (CHECK : b2) : sim t1 t2 -> secure_eqitF b1 b2 l vclo sim (observe t1) (TauF t2)
+    (* info_flow protecting coinductive constructors *)
+    | EqVisPriv {A} (e : E A) k1 k2 (SECCHECK : leq (priv A e) l) :
+        ((forall a, vclo sim (k1 a) (k2 a) : Prop)) -> secure_eqitF b1 b2 l vclo sim (VisF e k1) (VisF e k2)
+    | EqVisUnPrivTauLCo {A} (e : E A) k1 t2 (SECCHECK : ~ leq (priv A e) l) (SIZECHECK : nonempty A) :
+        (forall a, vclo sim (k1 a) t2) -> secure_eqitF b1 b2 l vclo sim (VisF e k1) (TauF t2)
+    | EqVisUnPrivTauRCo {A} (e : E A) t1 k2 (SECCHECK : ~ leq (priv A e) l) (SIZECHECK : nonempty A) :
+        (forall a, vclo sim t1 (k2 a)) -> secure_eqitF b1 b2 l vclo sim (TauF t1) (VisF e k2)
+    | EqVisUnPrivVisCo {A B} (e1 : E A) (e2 : E B) k1 k2 (SECCHECK1 : ~ leq (priv A e1) l) (SECCHECK2 : ~ leq (priv B e2) l)
+        (SIZECHECK1 : nonempty A ) (SIZECHECK2 : nonempty B) :
+        (forall a b, vclo sim (k1 a) (k2 b)) -> secure_eqitF b1 b2 l vclo sim (VisF e1 k1) (VisF e2 k2)
+    (* info_flow protecting inductive constructors *)
+    | EqVisUnPrivLInd {A} (e : E A) k1 t2 (CHECK : b1) (SECCHECK : ~ leq (priv A e) l) (SIZECHECK : nonempty A) :
+        (forall a, vclo sim (k1 a) t2) ->
+        secure_eqitF b1 b2 l vclo sim (VisF e k1) (observe t2)
+    | EqVisUnPrivRInd {A} (e : E A) t1 k2 (CHECK : b2) (SECCHECK : ~ leq (priv A e) l) (SIZECHECK : nonempty A) :
+        (forall a, vclo sim t1 (k2 a) ) ->
+        secure_eqitF b1 b2 l vclo sim (observe t1) (VisF e k2)
+    (* info_flow protecting constructors for halting events, should capture the notion that a secret halt means
+       that either it halted or it is performing some secret or silent computation and you can't tell which *)
+    | EqVisUnprivHaltLTauR {A} (e : E A) k1 t2 (SECCHECK : ~ leq (priv A e) l ) (SIZECHECK : empty A) :
+        sim (Vis e k1) t2 -> secure_eqitF b1 b2 l vclo sim (VisF e k1) (TauF t2)
+    | EqVisUnprivHaltRTauL {A} (e : E A) t1 k2 (SECCHECK : ~ leq (priv A e) l ) (SIZECHECK : empty A) :
+        sim t1 (Vis e k2) -> secure_eqitF b1 b2  l vclo sim (TauF t1) (VisF e k2)
+    | EqVisUnprivHaltLVisR {A B} (e1 : E A) (e2 : E B) k1 k2 (SECCHECK1 : ~ leq (priv A e1) l) (SECCHECK2 : ~ leq (priv B e2) l)
+            (SIZECHECK : empty A) :
+      (forall b, vclo sim (Vis e1 k1) (k2 b) ) -> secure_eqitF b1 b2 l vclo sim (VisF e1 k1) (VisF e2 k2)
+    | EqVisUnprivHaltRVisL {A B} (e1 : E A) (e2 : E B) k1 k2 (SECCHECK1 : ~ leq (priv A e1) l) (SECCHECK2 : ~ leq (priv B e2) l)
+            (SIZECHECK : empty B) :
+        (forall a, vclo sim (k1 a) (Vis e2 k2)) -> secure_eqitF b1 b2 l vclo sim (VisF e1 k1) (VisF e2 k2)
+  .
+
+  Hint Constructors secure_eqitF : itree.
+
+  Definition secure_eqit_ (b1 b2 : bool) (l : L) vclo (sim : itree E R1 -> itree E R2 -> Prop) : itree E R1 -> itree E R2 -> Prop :=
+    fun t1 t2 => secure_eqitF b1 b2 l vclo sim (observe t1) (observe t2).
+
+  Hint Unfold secure_eqit_ : itree.
+
+  Lemma secure_eqitF_mono b1 b2 l x0 x1 vclo vclo' sim sim'
+        (IN: secure_eqitF b1 b2 l vclo sim x0 x1)
+        (MON: monotone2 vclo)
+        (LEc: vclo <3= vclo')
+        (LE: sim <2= sim'):
+    secure_eqitF b1 b2 l vclo' sim' x0 x1.
+  Proof.
+    intros. induction IN; eauto with itree.
+  Qed.
+
+  Lemma secure_eqit_mono b1 b2 l vclo (MON: monotone2 vclo) : monotone2 (secure_eqit_ b1 b2 l vclo).
+  Proof.
+    do 2 red. intros; eapply secure_eqitF_mono; eauto.
+  Qed.
+
+  Hint Resolve secure_eqit_mono : paco.
+
+  Definition eqit_secure b1 b2 l := paco2 (secure_eqit_ b1 b2 l id) bot2.
+
+  (* want and eqitC_secure which could help prove some interesting stuff
+
+   *)
+
+
+  (*
+    Note that this is not reflexive (think it is symmetric and transitive)
+    Suppose SecureFlip : E bool has privilege 1 and trigger SecureFlip is
+    observed at privilege 0. We end to prove eqit_secure false false 0 of it
+    requires us to show forall a b, eqit_secure false false 0 (Ret a) (Ret b)
+    this is false, suppose a = true and b = false and the relation is equality
+
+   *)
+
+
+End SecureUntimed.
+
+#[export] Hint Resolve secure_eqit_mono : paco.
+
+#[export] Hint Constructors secure_eqitF : itree.
+
+Definition NatPreorder : Preorder :=
+  {|
+  L := nat;
+  leq := fun n m => n <= m
+  |}.
+
+Section SecureUntimedUnReflexive.
+(*
+  Variant NonDet : Type -> Type :=
+    | SecureFlip : NonDet bool
+    | PublicOut : NonDet unit
+    | Halt : NonDet void
+
+.
+
+(*
+CoInductive itree E R :=
+...
+| Vis {A : Type} (e : E A) (k : A -> itree E R)
+
+suppose A := void
+
+k ≅ empty_cont
+
+bind (Vis Halt k1) k2 ≅ Vis Halt k1
+
+E := HaltE unit
+
+Definition halt : itree E R := Vis HaltE (fun _ => Tau Tau ...)
+
+*)
+
+  Definition priv_counter : forall A, NonDet A -> nat :=
+    fun _ e =>
+      match e with
+      | SecureFlip => 1
+      | PublicOut => 0
+      | Halt => 10
+      end.
+
+
+  Variant Exc : Type -> Type :=
+    Throw : Exc void.
+
+  Definition refl_counter : itree NonDet bool := trigger SecureFlip. (* b := Flip; return b *)
+
+  Lemma refl_counter_counter : ~ eqit_secure NatPreorder priv_counter eq true true 0 refl_counter refl_counter.
+    Proof.
+      intro Hcontra. punfold Hcontra; try eapply secure_eqit_mono; eauto.
+      red in Hcontra. cbn in *. inv Hcontra; ddestruction; subst.
+      - cbv in SECCHECK. inv SECCHECK.
+      - specialize (H0 true false). pclearbot. pinversion H0; try eapply secure_eqit_mono; eauto.
+        discriminate.
+      - rewrite H3 in H0. clear H3. specialize (H0 true). cbn in *.
+        inv H0; ddestruction; subst. specialize (H2 false). rewrite H in H2.
+        inv H2. discriminate.
+      -  rewrite H in H0. injection H0; intros; ddestruction; subst; ddestruction; subst.
+         specialize (H1 true). cbn in *. inv H1; ddestruction; subst; ddestruction; subst.
+         rewrite H6 in H3. specialize (H3 false). cbn in *. inv H3; discriminate.
+      - inv SIZECHECK. apply H; apply true.
+      - inv SIZECHECK. apply H; apply true.
+    Qed.
+
+
+    Lemma halt_not_ret : forall A (a : A) k, ~ eqit_secure NatPreorder priv_counter eq true true 0 (Vis Halt k) (Ret a).
+    Proof.
+      intros. intro Hcontra. pinversion Hcontra. ddestruction; subst.
+      inv SIZECHECK. contradiction.
+    Qed.
+
+    Lemma halt_spin : eqit_secure NatPreorder priv_counter eq true true 0 (trigger Halt) (ITree.spin).
+    Proof.
+      pcofix CIH. pfold. red. cbn. eapply EqVisUnprivHaltLTauR.
+      - intro. inv H.
+      - constructor. intros; contradiction.
+      - right. apply CIH.
+    Qed.
+
+
+
+    (*transitivity problems in presence of E void *)
+    Definition refl_counter2 : itree NonDet unit := ITree.bind refl_counter (fun b : bool => if b then Ret tt else trigger PublicOut).
+    (* b := SecretFlip; if b then return tt else PublicOut; return tt*)
+    Lemma refl_counter2_counter : ~ eqit_secure NatPreorder priv_counter eq true true 0 refl_counter2 refl_counter2.
+      Proof.
+        unfold refl_counter2. intro Hcontra. punfold Hcontra; try eapply secure_eqit_mono; eauto.
+        red in Hcontra. cbn in Hcontra. inv Hcontra; ddestruction; subst; try (inv SIZECHECK; apply H; constructor; fail).
+        - inv SECCHECK.
+        - specialize (H0 true false). pclearbot. punfold H0; try eapply secure_eqit_mono; eauto.
+          red in H0. cbn in *. inv H0; ddestruction; subst.
+          cbn in *. apply SECCHECK; auto.
+        - rewrite H3 in H0; clear H3. specialize (H0 true). cbn in *.
+          inv H0; ddestruction; subst; ddestruction.
+          specialize (H2 false). rewrite H in H2. cbn in *. inv H2;
+          ddestruction; subst; apply SECCHECK1; constructor.
+        - rewrite <- H0 in H. injection H; intros; ddestruction; subst; ddestruction; subst.
+          specialize (H1 true). inv H1; ddestruction; subst.
+          rewrite H6 in H3. specialize (H3 false). cbn in *.
+          inv H3; ddestruction; subst. apply SECCHECK1; constructor.
+      Qed.
+
+*)
+Section eqit_secureC.
+  (* might not be the order I eventually want but whatever*)
+  Context {E: Type -> Type} {R1 R2 : Type} (RR : R1 -> R2 -> Prop).
+  Context (Label : Preorder) (priv : forall A, E A -> L) (l : L).
+
+
+  Variant eqit_secure_trans_clo (b1 b2 b1' b2' : bool) (r : itree E R1 -> itree E R2 -> Prop) :
+    itree E R1 -> itree E R2 -> Prop :=
+        eqit_secure_trans_clo_intro t1 t2 t1' t2' RR1 RR2
+      (EQVl: eqit_secure Label priv RR1 b1 b1' l t1 t1')
+      (EQVr: eqit_secure Label priv RR2 b2 b2' l t2 t2')
+      (REL: r t1' t2')
+      (LERR1: forall x x' y, RR1 x x' -> RR x' y -> RR x y)
+      (LERR2: forall x y y', RR2 y y' -> RR x y' -> RR x y) :
+      eqit_secure_trans_clo b1 b2 b1' b2' r t1 t2.
+
+  Hint Constructors eqit_secure_trans_clo : itree.
+
+  Definition eqit_secureC b1 b2 := eqit_secure_trans_clo b1 b2 false false.
+  Hint Unfold eqit_secureC : itree.
+
+  Lemma eqit_secureC_mon b1 b2 r1 r2 t1 t2
+    (IN : eqit_secureC b1 b2 r1 t1 t2)
+    (LE: r1 <2= r2) :
+    eqit_secureC b1 b2 r2 t1 t2.
+  Proof.
+    destruct IN; eauto with itree.
+  Qed.
+
+End eqit_secureC.
+
+
+
+Ltac unpriv_co := try apply EqVisUnPrivVisCo;
+                  try apply EqVisUnPrivTauLCo;
+                  try apply EqVisUnPrivTauRCo;
+                  auto with itree; intros.
+
+Ltac unpriv_ind := try apply EqVisUnPrivLInd;
+                   try apply EqVisUnPrivRInd;
+                   auto with itree; intros.
+
+Ltac unpriv_halt :=
+  match goal with
+  | [  Hemp : empty ?A |- secure_eqitF _ _ _ _ _ _ _ _ (@VisF _ _ _ ?A _ _) _ ] =>
+    try apply  EqVisUnprivHaltLTauR; try apply EqVisUnprivHaltLVisR; auto with itree; intros
+
+  | [  Hemp : empty ?A |- secure_eqitF _ _ _ _ _ _ _ _ _ (@VisF _ _ _ ?A _ _)  ] =>
+    try apply EqVisUnprivHaltRTauL; try apply EqVisUnprivHaltRVisL; auto with itree; intros end.
+
+Ltac contra_size :=
+  match goal with
+  | [ Hemp : empty ?A, Hne : nonempty ?A |- _ ] => inv Hemp; inv Hne; contradiction end.
+
+(*
+Ltac unpriv_halt := try apply EqVisUnprivHaltLTauR;
+                    try apply EqVisUnprivHaltRTauL;
+                    try apply
+*)
+Ltac gfinal_with H := gfinal; left; apply H.
+
+Ltac ne A := let Hne := fresh "H" in assert (Hne : nonempty A); eauto; inv Hne.
+
+Lemma eqit_secure_sym : forall b1 b2 E R1 R2 RR Label priv l (t1 : itree E R1) (t2 : itree E R2),
+    eqit_secure Label priv RR b1 b2 l t1 t2 -> eqit_secure Label priv (flip RR) b2 b1 l t2 t1.
+Proof.
+  intros b1 b2 E R1 R2 RR Label priv l. pcofix CIH.
+  intros t1 t2 Hsec. pfold. red. punfold Hsec. red in Hsec.
+  hinduction Hsec before r; intros; eauto with itree; pclearbot;
+  try (unpriv_co; right; apply CIH; apply H);
+  try unpriv_halt.
+  - constructor; auto. intros. right. apply CIH; apply H.
+  - constructor; auto. right. eapply CIH. apply H.
+  - constructor; auto. right. eapply CIH. apply H.
+  - specialize (H a). remember (k2 a) as t. clear Heqt k2.
+     left.
+     intros. pfold. red. cbn. punfold H. red in H. cbn in H.
+     inv H; ddestruction; subst; try contra_size; try contradiction; pclearbot; eauto with itree;
+     try (unpriv_halt; fail).
+     + constructor; auto. right. eapply CIH; eauto. apply H2.
+     + unpriv_halt. right. eapply CIH. apply H1.
+     + unpriv_halt. right. eapply CIH. apply H1.
+  - specialize (H b). remember (k1 b) as t. clear Heqt k1.
+     left.
+     intros. pfold. red. cbn. punfold H. red in H. cbn in H.
+     inv H; ddestruction; subst; try contra_size; try contradiction; pclearbot; eauto with itree;
+     try (unpriv_halt; fail).
+     + constructor; auto. right. eapply CIH; eauto. apply H2.
+     + unpriv_halt. right. inv SIZECHECK0. contradiction.
+     + unpriv_halt. right. eapply CIH. apply H2.
+Qed.
+
+Lemma secure_eqit_mon : forall E (b1 b2 b3 b4 : bool) R1 R2 RR1 RR2 Label priv l
+      (t1 : itree E R1) (t2 : itree E R2),
+    (b1 -> b3) -> (b2 -> b4) -> (RR1 <2= RR2) ->
+    eqit_secure Label priv RR1 b1 b2 l t1 t2 -> eqit_secure Label priv RR2 b3 b4 l t1 t2.
+Proof.
+  intros. generalize dependent t2. revert t1. pcofix CIH.
+  intros t1 t2 Ht12. pstep. red.
+  punfold Ht12. red in Ht12.
+  hinduction Ht12 before r; intros; eauto; pclearbot;
+  try (unpriv_co; right; apply CIH; try red; eauto; fail);
+  try (unpriv_halt; try contra_size; right; apply CIH; try red; eauto; fail).
+  all : (constructor; auto; right;  eauto; apply CIH; apply H2).
+Qed.
+
+End SecureUntimedUnReflexive.

--- a/theories/Secure/SecureEqProgInsens.v
+++ b/theories/Secure/SecureEqProgInsens.v
@@ -1,0 +1,502 @@
+From Coq Require Import Morphisms.
+
+From ITree Require Import
+     Axioms
+     ITree
+     ITreeFacts
+     Secure.SecureEqHalt
+.
+
+From Paco Require Import paco.
+
+Import Monads.
+Import MonadNotation.
+Local Open Scope monad_scope.
+
+
+(* will need more propositional constraints on Preorders *)
+
+Section SecureProgInsens.
+  Context {E : Type -> Type} {R1 R2 : Type}.
+  Context (Label : Preorder).
+  Context (priv : forall A, E A -> L).
+  Context (RR : R1 -> R2 -> Prop).
+
+  (*
+  Context (RE : forall A, E A -> E A -> A -> A -> Prop).
+  want it to be an equivalence
+  *)
+
+  Variant pi_secure_eqitF (b1 b2 : bool) (l : L) vclo (sim : itree E R1 -> itree E R2 -> Prop) : itree' E R1 -> itree' E R2 -> Prop :=
+
+    (* eqitF constructors *)
+    | pisecEqRet r1 r2 : RR r1 r2 -> pi_secure_eqitF b1 b2 l vclo sim (RetF r1) (RetF r2)
+    | pisecEqTau t1 t2 : sim t1 t2 -> pi_secure_eqitF b1 b2 l vclo sim (TauF t1) (TauF t2)
+    | pisecEqTauL t1 t2 (CHECK : b1) : sim t1 t2 -> pi_secure_eqitF b1 b2 l vclo sim (TauF t1) (observe t2)
+    | pisecEqTauR t1 t2 (CHECK : b2) : sim t1 t2 -> pi_secure_eqitF b1 b2 l vclo sim (observe t1) (TauF t2)
+    (* info_flow protecting coinductive constructors *)
+    | piEqVisPriv {A} (e : E A) k1 k2 (SECCHECK : leq (priv A e) l) :
+        ((forall a, vclo sim (k1 a) (k2 a) : Prop)) -> pi_secure_eqitF b1 b2 l vclo sim (VisF e k1) (VisF e k2)
+    | piEqVisUnPrivTauLCo {A} (e : E A) k1 t2 (SECCHECK : ~ leq (priv A e) l) :
+        (forall a, vclo sim (k1 a) t2) -> pi_secure_eqitF b1 b2 l vclo sim (VisF e k1) (TauF t2)
+    | piEqVisUnPrivTauRCo {A} (e : E A) t1 k2 (SECCHECK : ~ leq (priv A e) l) :
+        (forall a, vclo sim t1 (k2 a)) -> pi_secure_eqitF b1 b2 l vclo sim (TauF t1) (VisF e k2)
+    | piEqVisUnPrivVisCo {A B} (e1 : E A) (e2 : E B) k1 k2 (SECCHECK1 : ~ leq (priv A e1) l) (SECCHECK2 : ~ leq (priv B e2) l)
+        :
+        (forall a b, vclo sim (k1 a) (k2 b)) -> pi_secure_eqitF b1 b2 l vclo sim (VisF e1 k1) (VisF e2 k2)
+    (* info_flow protecting inductive constructors *)
+    | piEqVisUnPrivLInd {A} (e : E A) k1 t2 (CHECK : b1) (SECCHECK : ~ leq (priv A e) l) :
+        (forall a, vclo sim (k1 a) t2 ) ->
+        pi_secure_eqitF b1 b2 l vclo sim (VisF e k1) (observe t2)
+    | piEqVisUnPrivRInd {A} (e : E A) t1 k2 (CHECK : b2) (SECCHECK : ~ leq (priv A e) l) :
+        (forall a, vclo sim t1 (k2 a) ) ->
+        pi_secure_eqitF b1 b2 l vclo sim (observe t1) (VisF e k2)
+  .
+
+  Hint Constructors pi_secure_eqitF : itree.
+
+  Definition pi_secure_eqit_ (b1 b2 : bool) (l : L) vclo (sim : itree E R1 -> itree E R2 -> Prop) : itree E R1 -> itree E R2 -> Prop :=
+    fun t1 t2 => pi_secure_eqitF b1 b2 l vclo sim (observe t1) (observe t2).
+
+  Hint Unfold pi_secure_eqit_ : itree.
+
+  Lemma pi_secure_eqitF_mono b1 b2 l x0 x1 vclo vclo' sim sim'
+        (IN: pi_secure_eqitF b1 b2 l vclo sim x0 x1)
+        (MON: monotone2 vclo)
+        (LEc: vclo <3= vclo')
+        (LE: sim <2= sim'):
+    pi_secure_eqitF b1 b2 l vclo' sim' x0 x1.
+  Proof.
+    intros. induction IN; eauto with itree.
+  Qed.
+
+  Lemma pi_secure_eqit_mono b1 b2 l vclo (MON: monotone2 vclo) : monotone2 (pi_secure_eqit_ b1 b2 l vclo).
+  Proof.
+    do 2 red. intros; eapply pi_secure_eqitF_mono; eauto with itree.
+  Qed.
+
+  Hint Resolve pi_secure_eqit_mono : paco.
+
+  Definition pi_eqit_secure b1 b2 l := paco2 (pi_secure_eqit_ b1 b2 l id) bot2.
+
+  (* want and eqitC_secure which could help prove some interesting stuff
+
+   *)
+
+
+End SecureProgInsens.
+
+#[export] Hint Resolve pi_secure_eqit_mono : paco.
+#[export] Hint Constructors pi_secure_eqitF : itree.
+
+Ltac unpriv_pi := try apply piEqVisUnPrivVisCo;
+                  try apply piEqVisUnPrivTauLCo;
+                  try apply piEqVisUnPrivTauRCo;
+                  try apply piEqVisUnPrivLInd;
+                  try apply piEqVisUnPrivRInd;
+                  auto with itree; intros.
+
+Ltac contra_size :=
+  match goal with
+  | [ Hemp : empty ?A, Hne : nonempty ?A |- _ ] => inv Hemp; inv Hne; contradiction end.
+
+
+Lemma eqit_secure_imp_pi_eqit_scure b1 b2 E R1 R2 RR Label priv l : forall (t1 : itree E R1) (t2 : itree E R2),
+    eqit_secure Label priv RR b1 b2 l t1 t2 -> pi_eqit_secure Label priv RR b1 b2 l t1 t2.
+Proof.
+  pcofix CIH. intros t1 t2 Hps. pfold. red. punfold Hps. red in Hps.
+  hinduction Hps before r; intros.
+  - constructor; auto with itree.
+  - constructor. right. pclearbot. eauto with itree.
+  - rewrite itree_eta'. constructor; auto with itree. right. eapply CIH. pfold. apply Hps.
+  - rewrite itree_eta' at 1. constructor; auto with itree. right. eapply CIH. pfold. apply Hps.
+  - pclearbot. constructor; auto with itree. right. eapply CIH; eauto with itree. apply H.
+  - pclearbot. unpriv_pi. right. eapply CIH; apply H.
+  - pclearbot. unpriv_pi. right. eapply CIH; apply H.
+  - pclearbot. unpriv_pi. right. eapply CIH; apply H.
+  - pclearbot. unpriv_pi. right. eapply CIH. pfold. apply H.
+  - pclearbot. unpriv_pi. right. eapply CIH. pfold. apply H.
+  - unpriv_pi. inv SIZECHECK. contradiction.
+  - unpriv_pi. inv SIZECHECK. contradiction.
+  - unpriv_pi. inv SIZECHECK. contradiction.
+  - unpriv_pi. inv SIZECHECK. contradiction.
+Qed.
+
+
+Lemma pi_eqit_secure_sym b1 b2 E R1 R2 RR Label priv l : forall (t1 : itree E R1) (t2 : itree E R2),
+    pi_eqit_secure Label priv RR b1 b2 l t1 t2 -> pi_eqit_secure Label priv (flip RR) b2 b1 l t2 t1.
+Proof.
+  pcofix CIH. intros t1 t2 Hsec.
+  punfold Hsec. pfold. red in Hsec. red. inversion Hsec; pclearbot; eauto;
+  try (unpriv_pi; right; eapply CIH; apply H1; fail).
+  constructor; auto. right. eapply CIH; apply H1.
+Qed.
+
+
+Lemma pi_secure_eqit_mon : forall E (b1 b2 b3 b4 : bool) R1 R2 RR1 RR2 Label priv l
+      (t1 : itree E R1) (t2 : itree E R2),
+    (b1 -> b3) -> (b2 -> b4) -> (RR1 <2= RR2) ->
+    pi_eqit_secure Label priv RR1 b1 b2 l t1 t2 -> pi_eqit_secure Label priv RR2 b3 b4 l t1 t2.
+Proof.
+  intros. generalize dependent t2. revert t1. pcofix CIH.
+  intros t1 t2 Ht12. pstep. red.
+  punfold Ht12. red in Ht12.
+  hinduction Ht12 before r; intros; eauto; pclearbot;
+  try (unpriv_pi; right; apply CIH; try red; eauto; fail);
+  constructor; auto. right.  eauto. apply CIH; apply H2.
+Qed.
+
+
+Lemma pi_eqit_secure_spin b E R1 R2 (RR : R1 -> R2 -> Prop) Label priv l : forall (t1 : itree E R1),
+    pi_eqit_secure Label priv RR b true l t1 (ITree.spin).
+Proof.
+  pcofix CIH. intros. pfold. red. cbn. constructor; auto.
+Qed.
+
+Lemma pi_eqit_secure_private_halt b E R1 R2 (RR : R1 -> R2 -> Prop) Label priv l A (e : E A) k:
+  empty A -> ~ leq (priv A e) l -> forall (t1 : itree E R1),
+    pi_eqit_secure Label priv RR b true l t1 (Vis e k).
+Proof.
+  intros HA t1. pfold. red. cbn. intros. unpriv_pi. inv HA; contradiction.
+Qed.
+
+Lemma pi_eqit_secure_mixed_trans_aux1:
+  forall (E : Type -> Type) (R1 : Type) (b2 : bool) (R2 : Type) (RR1 : R1 -> R2 -> Prop)
+    (Label : Preorder) (priv : forall A : Type, E A -> L) (l : L) t1 t2,
+    paco2 (pi_secure_eqit_ Label priv RR1 true b2 l id) bot2 t1 (Tau t2)  ->
+    pi_eqit_secure Label priv RR1 true b2 l t1 t2.
+Proof.
+  intros E R1 b2 R2 RR1 Label priv l. pcofix CIH.
+  intros t1 t2 Htau. punfold Htau. red in Htau.
+  pfold. red. cbn in *. inv Htau; pclearbot; eauto.
+  - constructor; auto. left. eapply paco2_mon; eauto. intros; contradiction.
+  - constructor; auto. right. eapply CIH; eauto. pfold. red. rewrite <- H0.
+    cbn. pstep_reverse.
+  - pstep_reverse. eapply paco2_mon; eauto. intros; contradiction.
+  - unpriv_pi. left.  eapply paco2_mon; eauto. intros; contradiction.
+  - unpriv_pi. right. eapply CIH. pfold. red. rewrite <- H0.
+    cbn. pstep_reverse.
+Qed.
+
+Lemma pi_eqit_secure_mixed_trans b1 b2 E R1 R2 R3 (RR1 : R1 -> R2 -> Prop) (RR2 : R2 -> R3 -> Prop)
+      Label priv l : forall (t1 : itree E R1) t2 t3,
+    pi_eqit_secure Label priv RR1 b1 b2 l t1 t2 -> eqit RR2 b1 b2 t2 t3 ->
+    pi_eqit_secure Label priv (rcompose RR1 RR2) b1 b2 l t1 t3.
+Proof.
+  pcofix CIH. intros t1 t2 t3 Hsec Heq. punfold Heq.
+  red in Heq. punfold Hsec. red in Hsec. pfold. red.
+  hinduction Heq before r; intros; try inv CHECK; pclearbot.
+  - inv Hsec; eauto with itree; unpriv_pi; pclearbot.
+    + rewrite itree_eta'. constructor; auto with itree. right. eapply CIH; eauto.
+      pfold. red. rewrite H0. constructor. auto.
+    + rewrite itree_eta'. unpriv_pi. right. eapply CIH; eauto.
+      apply H1. pfold. red. rewrite H0. constructor; auto.
+  - inv Hsec; pclearbot; eauto with itree.
+    + constructor. right. eapply CIH; eauto with itree.
+      pfold. red. rewrite H0. constructor; auto. pstep_reverse.
+    + unpriv_pi. right. eapply CIH; eauto. apply H1.
+    + rewrite itree_eta'. unpriv_pi. right. eapply CIH; eauto.
+      inv CHECK. apply pi_eqit_secure_mixed_trans_aux1.
+      pfold. red. rewrite <- H0. cbn. pstep_reverse.
+  - inv Hsec.
+    + pclearbot. rewrite itree_eta'. constructor; auto. right. eapply CIH; eauto.
+      pfold. red. rewrite H0. constructor. left. auto.
+    + ddestruction. subst. constructor; auto with itree. right.
+      pclearbot. eapply CIH; eauto with itree. apply H1.
+    + ddestruction. subst. unpriv_pi. right. pclearbot.
+      eapply CIH; eauto with itree. apply H1.
+    + ddestruction. subst. unpriv_pi. right. pclearbot.
+      eapply CIH; eauto with itree. apply H1.
+    + pclearbot. remember (VisF e k2) as ovis. rewrite itree_eta'.
+      unpriv_pi. rewrite Heqovis. right. eapply CIH; eauto with itree. apply H1.
+      pfold. red. rewrite H0. constructor. left. auto.
+    + ddestruction. subst. unpriv_pi. right. eapply CIH; eauto with itree. pclearbot. apply H1.
+  - eapply IHHeq; eauto. clear IHHeq. inv Hsec; pclearbot.
+    + constructor; auto.
+    + constructor; auto. left. apply pi_eqit_secure_mixed_trans_aux1. pfold. red.
+      rewrite <- H0. cbn. pstep_reverse.
+    + pstep_reverse.
+    + unpriv_pi.
+    + unpriv_pi. left. apply pi_eqit_secure_mixed_trans_aux1. pfold. red.
+      rewrite <- H0. cbn. pstep_reverse.
+  - constructor; auto. left. pfold. eapply IHHeq; eauto.
+Qed.
+
+Lemma pi_eqit_secure_RR_imp b1 b2 E R1 R2 (RR1 : R1 -> R2 -> Prop ) (RR2 : R1 -> R2 -> Prop)
+      Label priv l : (forall r1 r2, RR1 r1 r2 -> RR2 r1 r2) ->
+                     forall (t1 : itree E R1) (t2 : itree E R2),
+      pi_eqit_secure Label priv RR1 b1 b2 l t1 t2 ->
+      pi_eqit_secure Label priv RR2 b1 b2 l t1 t2.
+Proof.
+  intro Himp. pcofix CIH.
+  intros. pfold. red. punfold H0. red in H0.
+  inv H0; eauto;
+  try (constructor; auto; pclearbot; eauto; fail);
+  try (pclearbot; constructor; auto; right; eapply CIH; eauto; try apply H2; fail).
+Qed.
+
+Lemma pi_eqit_secureC_wcompat_id :  forall b1 b2 E R1 R2 (RR : R1 -> R2 -> Prop )
+      Label priv l
+, wcompatible2 (@pi_secure_eqit_ E R1 R2 Label priv RR b1 b2 l id)
+                                         (eqitC RR b1 b2) .
+Proof.
+  econstructor. pmonauto_itree.
+  intros. destruct PR.
+  punfold EQVl. punfold EQVr. unfold_eqit. red in REL. red.
+  hinduction REL before r; intros; clear t1' t2'; try inv CHECK.
+  - genobs_clear t1 ot1. genobs_clear t2 ot2.
+    remember (RetF r1) as x.
+    hinduction EQVl before r; intros; inv Heqx; eauto.
+    + remember (RetF r3) as y.
+      hinduction EQVr before r; intros; inv Heqy; eauto with itree.
+      rewrite itree_eta' at 1. constructor; eauto with itree. gstep. red.
+      eapply IHEQVr; eauto.
+    + rewrite itree_eta'. constructor; auto. cbn. gstep. red. cbn.
+      eauto.
+  - remember (TauF t1) as y.
+    hinduction EQVl before r; intros; inv Heqy; try inv CHECK; subst; eauto.
+    + remember (TauF t2) as x.
+      hinduction EQVr before r; intros; inv Heqx; try inv CHECK; subst; eauto.
+      pclearbot. constructor. gclo. econstructor; eauto with paco.
+      pclearbot.
+      remember (TauF m1) as ot1. rewrite itree_eta' at 1.
+      constructor; auto. rewrite Heqot1. gstep. red. cbn. eauto.
+    + constructor; auto. gstep. red. eapply IHEQVl; eauto.
+  - inv EQVl; pclearbot; try inv CHECK.
+    + constructor; auto. gclo. econstructor; eauto with paco itree.
+    + constructor; auto. gclo. econstructor; eauto with paco itree.
+      apply eqit_inv_Tau_r. pfold. auto.
+  - inv EQVr; pclearbot; try inv CHECK.
+    + constructor; auto. gclo. econstructor; eauto with paco itree.
+    + constructor; auto. gclo. econstructor; eauto with paco itree.
+      apply eqit_inv_Tau_r. pfold. auto.
+  - remember (VisF e k1) as x.
+    hinduction EQVl before r; intros; inv Heqx; try inv CHECK; eauto.
+    + ddestruction. subst. remember (VisF e0 k3) as y.
+      hinduction EQVr before r; intros; inv Heqy; try inv CHECK; eauto.
+      * ddestruction. subst. constructor; auto.
+        intros. apply gpaco2_clo. pclearbot. econstructor; eauto with itree. apply H.
+      * pclearbot. remember (VisF e0 k1) as ovis. rewrite itree_eta' at 1.
+        constructor; auto. rewrite Heqovis. gstep. red. eapply IHEQVr; eauto with itree.
+    + constructor; auto. gstep. red. eapply IHEQVl; eauto.
+  - remember (VisF e k1) as x.
+    hinduction EQVl before r; intros; inv Heqx; try inv CHECK; subst; eauto.
+    + ddestruction. subst. pclearbot. remember (TauF t2) as y.
+      hinduction EQVr before r; intros; inv Heqy; try inv CHECK; subst; pclearbot; eauto.
+      * unpriv_pi. gclo. econstructor; cycle -1; eauto with paco itree. gfinal. left. apply H.
+      * remember (VisF e0 k1) as ovis. rewrite itree_eta' at 1. constructor; auto.
+        rewrite Heqovis. gstep. red. eapply IHEQVr; eauto.
+    + constructor; auto. gstep. red. eapply IHEQVl; eauto.
+  - remember (TauF t1) as x.
+    hinduction EQVl before r; intros; inv Heqx; try inv CHECK; subst; eauto.
+    + remember (VisF e k2) as y.
+      hinduction EQVr before r; intros; inv Heqy; try inv CHECK; subst; eauto.
+      * ddestruction. subst.
+        pclearbot. unpriv_pi. gclo. econstructor; cycle -1; eauto with paco itree.
+        gfinal. left. apply H.
+      * remember (TauF m1) as otm1. rewrite itree_eta' at 1. constructor; auto.
+        gstep. rewrite Heqotm1. red. eapply IHEQVr; eauto.
+   + constructor; auto. gstep. red. eapply IHEQVl; eauto.
+  - remember (VisF e1 k1) as x.
+    hinduction EQVl before r; intros; inv Heqx; try inv CHECK; subst; eauto.
+    + ddestruction. subst. remember (VisF e2 k3) as y.
+      hinduction EQVr before r; intros; inv Heqy; try inv CHECK; subst; eauto.
+      * ddestruction. subst. unpriv_pi. gclo. pclearbot.
+        econstructor; eauto with paco itree. gfinal. left. apply H.
+      * remember (VisF e1 k1) as ovis. rewrite itree_eta' at 1.
+        constructor; auto. rewrite Heqovis. gstep. eapply IHEQVr; eauto.
+    + remember (VisF e2 k2) as x.
+      hinduction EQVr before r; intros; inv Heqx; try inv CHECK; subst; eauto.
+      * ddestruction. subst. pclearbot. unpriv_pi.
+         gclo. eapply eqit_trans_clo_intro with (t1' := Vis e1 k0); eauto with paco itree.
+         gstep. red. cbn. unpriv_pi. gfinal. left. apply H.
+       * remember (TauF t3) as ott3. rewrite itree_eta' at 1. constructor; auto.
+         rewrite Heqott3. gstep. red. eapply IHEQVr; eauto.
+  - remember (VisF e k1) as x.
+    hinduction EQVl before r; intros; inv Heqx; try inv CHECK; eauto.
+    + ddestruction. subst. pclearbot. unpriv_pi.
+      gclo. econstructor; eauto with paco itree. gfinal. left. apply H.
+    + constructor; auto. gstep. eapply IHEQVl; eauto.
+  - remember (VisF e k2) as x.
+    hinduction EQVr before r; intros; inv Heqx; try inv CHECK; eauto.
+    + ddestruction. subst. pclearbot. unpriv_pi.
+      gclo. econstructor; eauto with paco itree. gfinal. left. apply H.
+    + constructor; auto. gstep. eapply IHEQVr; eauto.
+Qed.
+
+#[export] Hint Resolve pi_eqit_secureC_wcompat_id : paco.
+
+Global Instance geuttgen_cong_secure_eqit {E} {Label priv l} {R1 R2 : Type} {RR1 : R1 -> R1 -> Prop}
+    {RR2 : R2 -> R2 -> Prop} {RS : R1 -> R2 -> Prop} (b1 b2 : bool) {r rg} :
+    (forall (x x' : R1) (y : R2), (RR1 x x' : Prop) -> (RS x' y : Prop) -> RS x y) ->
+    (forall (x : R1) (y y' : R2), (RR2 y y' : Prop) -> RS x y' -> RS x y) ->
+    Proper (@eq_itree E R1 R1 RR1 ==> eq_itree RR2 ==> flip impl)
+           (gpaco2 (pi_secure_eqit_ Label priv RS b1 b2 l id) (eqitC RS b1 b2) r rg ).
+Proof.
+  repeat intro. gclo. econstructor; eauto with itree.
+  - eapply eqit_mon, H1; eauto; discriminate.
+  - eapply eqit_mon, H2; eauto; discriminate.
+Qed.
+
+Global Instance geuttgen_cong_eq_secure_eqit {E} {Label priv l} {R1 R2 : Type} {RS : R1 -> R2 -> Prop} (b1 b2 : bool) {r rg} :
+    Proper (@eq_itree E R1 R1 eq ==> eq_itree eq ==> flip impl)
+           (gpaco2 (pi_secure_eqit_ Label priv RS b1 b2 l id) (eqitC RS b1 b2) r rg ).
+Proof.
+  eapply geuttgen_cong_secure_eqit; eauto; intros; subst; auto.
+Qed.
+
+Global Instance pi_eqit_secure_eq_itree_proper {E} {Label priv l} {R1 R2 : Type} {RS : R1 -> R2 -> Prop} (b1 b2 : bool) :
+   Proper (@eutt E R1 R1 eq ==> eutt eq ==> flip impl)
+          (pi_eqit_secure Label priv RS true true l).
+Proof.
+  intros t1 t2 Ht12 t3 t4 Ht34. intros Hsec.
+  apply pi_eqit_secure_RR_imp with (RR1 := rcompose RS eq).
+  { intros. inv H. auto. }
+  eapply pi_eqit_secure_mixed_trans. 2: { symmetry in Ht34. apply Ht34. }
+  apply pi_eqit_secure_sym in Hsec. apply pi_eqit_secure_sym.
+  symmetry in Ht12.
+  apply pi_eqit_secure_RR_imp with (RR1 := rcompose (flip RS) eq).
+  { intros. inv H. auto. }
+  eapply pi_eqit_secure_mixed_trans; eauto.
+Qed.
+
+Global Instance pi_eqit_secure_eutt_proper {E} {Label priv l} {R1 R2 : Type} {RS : R1 -> R2 -> Prop} (b1 b2 : bool) :
+   Proper (@eq_itree E R1 R1 eq ==> eq_itree eq ==> flip impl)
+          (pi_eqit_secure Label priv RS b1 b2 l).
+Proof.
+  repeat intro. ginit. rewrite H, H0. gfinal. eauto.
+Qed.
+
+Lemma pi_eqit_secure_ret E Label priv l b1 b2 R1 R2 (RR : R1 -> R2 -> Prop) r1 r2 :
+  RR r1 r2 -> @pi_eqit_secure E R1 R2 Label priv RR b1 b2 l (Ret r1) (Ret r2).
+Proof.
+  intros; pfold; constructor; auto.
+Qed.
+
+Lemma pi_eqit_secure_bind E Label priv l b1 b2 R1 R2 S1 S2 (RR : R1 -> R2 -> Prop) (RS : S1 -> S2 -> Prop) k1 k2 :
+  forall (t1 : itree E R1) (t2 : itree E R2),
+    (forall (r1 : R1) (r2 : R2), RR r1 r2 -> pi_eqit_secure Label priv RS b1 b2 l (k1 r1) (k2 r2) ) ->
+    pi_eqit_secure Label priv RR b1 b2 l t1 t2 ->
+    pi_eqit_secure Label priv RS b1 b2 l (ITree.bind t1 k1) (ITree.bind t2 k2).
+Proof.
+  ginit. gcofix CIH. intros. pinversion H1.
+  - apply simpobs in H. apply simpobs in H2. rewrite H. rewrite H2.
+    repeat rewrite bind_ret_l. gfinal. right. eapply paco2_mon; try apply H0; auto.
+    intros; contradiction.
+  - apply simpobs in H. apply simpobs in H2. rewrite H. rewrite H2.
+    repeat rewrite bind_tau. gstep. constructor. gfinal. left. eapply CIH; eauto.
+  - apply simpobs in H. apply simpobs in H2.  rewrite H2. rewrite H. rewrite bind_tau.
+    gstep. constructor; auto. gfinal. left. eapply CIH; eauto.
+    pfold. red. cbn. pstep_reverse.
+  - apply simpobs in H. apply simpobs in H2.  rewrite H2. rewrite H. rewrite bind_tau.
+    gstep. constructor; auto. gfinal. left. eapply CIH; eauto.
+    pfold. red. cbn. pstep_reverse.
+  - apply simpobs in H. apply simpobs in H2. rewrite H. rewrite H2.
+    repeat rewrite bind_vis. gstep. constructor; auto.
+    gfinal. left. eapply CIH; eauto. apply H3.
+  - apply simpobs in H. apply simpobs in H2. rewrite H. rewrite H2.
+    rewrite bind_vis. rewrite bind_tau. gstep. red. cbn. unpriv_pi.
+    gfinal. left. eapply CIH; eauto. apply H3.
+  - apply simpobs in H. apply simpobs in H2. rewrite H. rewrite H2.
+    rewrite bind_vis. rewrite bind_tau. gstep. red. cbn. unpriv_pi.
+    gfinal. left. eapply CIH; eauto. apply H3.
+  - apply simpobs in H. apply simpobs in H2. rewrite H. rewrite H2.
+    repeat rewrite bind_vis. gstep. red. cbn. unpriv_pi.
+    gfinal. left. eapply CIH; eauto. apply H3.
+  - apply simpobs in H. apply simpobs in H2. rewrite H. rewrite H2.
+    rewrite bind_vis. gstep. red. unpriv_pi.
+    gfinal. left. eapply CIH; eauto. pfold. red. cbn. pstep_reverse.
+  - apply simpobs in H. apply simpobs in H2. rewrite H. rewrite H2.
+    rewrite bind_vis. gstep. red. unpriv_pi.
+    gfinal. left. eapply CIH; eauto. pfold. red. cbn. pstep_reverse.
+Qed.
+
+Lemma pi_eqit_secure_iter_bind_aux:
+  forall (E : Type -> Type) (B2 B1 A1 A2 : Type) (RA : A1 -> A2 -> Prop)
+    (RB : B1 -> B2 -> Prop) (b1 b2 : bool) (Label : Preorder)
+    (priv : forall A : Type, E A -> L) (l : L) (body1 : A1 -> itree E (A1 + B1))
+    (body2 : A2 -> itree E (A2 + B2)) (r : itree E B1 -> itree E B2 -> Prop),
+    (forall (a1 : A1) (a2 : A2), RA a1 a2 -> r (ITree.iter body1 a1) (ITree.iter body2 a2)) ->
+    forall (t1 : itree E (A1 + B1)) (t2 : itree E (A2 + B2)),
+      paco2 (pi_secure_eqit_ Label priv (HeterogeneousRelations.sum_rel RA RB) b1 b2 l id) bot2 t1
+            t2 ->
+      gpaco2 (pi_secure_eqit_ Label priv RB b1 b2 l id) (eqitC RB b1 b2) r r
+             (ITree.bind t1
+                         (fun lr : A1 + B1 =>
+                            match lr with
+                            | inl l0 => Tau (ITree.iter body1 l0)
+                            | inr r0 => Ret r0
+                            end))
+             (ITree.bind t2
+                         (fun lr : A2 + B2 =>
+                            match lr with
+                            | inl l0 => Tau (ITree.iter body2 l0)
+                            | inr r0 => Ret r0
+                            end)).
+Proof.
+  intros E B2 B1 A1 A2 RA RB b1 b2 Label priv l body1 body2 r CIH t1 t2 H2.
+  generalize dependent t2. revert t1. gcofix CIH'. intros t1 t2 Ht12.
+  pinversion Ht12; apply simpobs in H; apply simpobs in H0.
+  - rewrite H, H0. repeat rewrite bind_ret_l. inv H1.
+    + gstep. constructor. gfinal. left. apply CIH'0. eapply CIH; eauto.
+    + gstep. constructor; auto.
+  - rewrite H, H0. repeat rewrite bind_tau. gstep. constructor.
+    gfinal. left. eapply CIH'; eauto.
+  - rewrite H. rewrite <- itree_eta in H0. rewrite H0. rewrite bind_tau. gstep.
+    constructor; auto. gfinal.
+    left. eapply CIH'; eauto.
+  - rewrite H0. rewrite <- itree_eta in H. rewrite H. rewrite bind_tau. gstep.
+    constructor; auto. gfinal.
+    left. eapply CIH'; eauto.
+  - rewrite H, H0. repeat rewrite bind_vis. gstep. constructor; auto.
+    intros. gfinal. left. eauto.
+  - rewrite H, H0. rewrite bind_vis, bind_tau.  gstep. unpriv_pi; auto.
+    intros. gfinal. left. eauto.
+  - rewrite H, H0. rewrite bind_vis, bind_tau.  gstep. unpriv_pi; auto.
+    intros. gfinal. left. eauto.
+  - rewrite H, H0. repeat rewrite bind_vis. gstep. unpriv_pi.
+    gfinal. left. eauto.
+  - rewrite H. rewrite <- itree_eta in H0. rewrite H0. rewrite bind_vis.
+    gstep. unpriv_pi. gfinal. left. eauto.
+  - rewrite H0. rewrite <- itree_eta in H. rewrite H. rewrite bind_vis.
+    gstep. unpriv_pi. gfinal. left. eauto.
+Qed.
+
+Lemma secure_eqit_iter E A1 A2 B1 B2 (RA : A1 -> A2 -> Prop) (RB : B1 -> B2 -> Prop)
+                           b1 b2 Label priv l
+                           (body1 : A1 -> itree E (A1 + B1) ) (body2 : A2 -> itree E (A2 + B2) ):
+  (forall a1 a2, RA a1 a2 -> pi_eqit_secure Label priv (HeterogeneousRelations.sum_rel RA RB) b1 b2 l (body1 a1) (body2 a2) ) ->
+                           forall (a1 : A1) (a2 : A2), RA a1 a2 ->
+    pi_eqit_secure Label priv RB b1 b2 l (ITree.iter body1 a1) (ITree.iter body2 a2).
+Proof.
+  intro Hbody. ginit. gcofix CIH. intros. rewrite unfold_iter. rewrite unfold_iter.
+  apply Hbody in H0. pinversion H0; apply simpobs in H; apply simpobs in H1.
+  - rewrite H. rewrite H1. repeat rewrite bind_ret_l. inv H2.
+    + gstep. constructor. gfinal. left. eapply CIH; eauto.
+    + gstep. constructor; auto.
+  - rewrite H. rewrite H1. repeat rewrite bind_tau. gstep.
+    constructor. eapply pi_eqit_secure_iter_bind_aux; eauto.
+  - rewrite H. rewrite bind_tau. gstep. constructor; auto.
+    eapply pi_eqit_secure_iter_bind_aux; eauto.
+    assert (t1 ≈ body1 a1).
+    { rewrite H. rewrite tau_eutt. reflexivity. }
+    inv CHECK. rewrite <- itree_eta in H1. rewrite H1. auto.
+  - rewrite H1. rewrite bind_tau. gstep. constructor; auto.
+    eapply pi_eqit_secure_iter_bind_aux; eauto. rewrite H.
+    rewrite <- itree_eta. apply H2.
+  - rewrite H, H1. repeat rewrite bind_vis. gstep. constructor; auto.
+    intros. red.
+    eapply pi_eqit_secure_iter_bind_aux; eauto.
+  - rewrite H, H1. rewrite bind_vis, bind_tau. gstep. unpriv_pi.
+    eapply pi_eqit_secure_iter_bind_aux; eauto.
+  - rewrite H, H1. rewrite bind_vis, bind_tau. gstep. unpriv_pi.
+    eapply pi_eqit_secure_iter_bind_aux; eauto.
+  - rewrite H, H1. repeat rewrite bind_vis. gstep. unpriv_pi.
+    eapply pi_eqit_secure_iter_bind_aux; eauto.
+  - rewrite H. rewrite bind_vis. gstep. unpriv_pi.
+    eapply pi_eqit_secure_iter_bind_aux; eauto.
+    rewrite H1. rewrite <- itree_eta. apply H2.
+  - rewrite H1. rewrite bind_vis. gstep. unpriv_pi. red.
+    rewrite H. rewrite <- itree_eta.
+    eapply pi_eqit_secure_iter_bind_aux; eauto.
+Qed.

--- a/theories/Secure/SecureEqProgInsensFacts.v
+++ b/theories/Secure/SecureEqProgInsensFacts.v
@@ -1,0 +1,161 @@
+From ITree Require Import
+     Axioms
+     ITree
+     ITreeFacts
+     Secure.SecureEqHalt
+     Secure.SecureEqProgInsens
+.
+
+From Paco Require Import paco.
+
+Import Monads.
+Import MonadNotation.
+Local Open Scope monad_scope.
+
+Variant case_rel {A1 A2 B : Type} (R1 : A1 -> B -> Prop) (R2 : A2 -> B -> Prop) : (A1 + A2) -> B -> Prop :=
+  | crl a1 b : R1 a1 b -> case_rel R1 R2 (inl a1) b
+  | crr a2 b : R2 a2 b -> case_rel R1 R2 (inr a2) b.
+
+Lemma pi_eqit_secure_iter_ret E R S1 S2 Label priv l b2 s body
+      (Rinv : R -> S2 -> Prop) (RS : S1 -> S2 -> Prop)
+  (HRinv : (forall r', Rinv r' s ->
+            pi_eqit_secure Label priv (case_rel Rinv RS) true b2 l (body r') (Ret s) )) :
+  forall r,
+  Rinv r s ->
+  @pi_eqit_secure E S1 S2 Label priv RS true b2 l (ITree.iter body r) (Ret s).
+Proof.
+  ginit. gcofix CIH. intros r0 Hr0. setoid_rewrite unfold_iter.
+  assert (pi_eqit_secure Label priv (case_rel Rinv RS) true b2 l (body r0) (Ret s)).
+  auto. remember (body r0) as t. clear Heqt. generalize dependent t.
+  gcofix CIH'. intros t Ht.
+  destruct (observe t) eqn : Heq; symmetry in Heq; apply simpobs in Heq.
+  - rewrite Heq.
+    assert (pi_eqit_secure Label priv (case_rel Rinv RS) true b2 l (Ret r1) (Ret s) ).
+    rewrite <- Heq. auto.
+    pinversion H. subst. inv H2.
+    + rewrite bind_ret_l. gstep. constructor; auto.
+      gfinal. left. eapply CIH; eauto.
+    + rewrite bind_ret_l. gstep. constructor. auto.
+  - rewrite Heq. rewrite bind_tau. gstep. constructor; auto.
+    gfinal. left. eapply CIH'.
+    assert (pi_eqit_secure Label priv (case_rel Rinv RS) true b2 l (Tau t0) (Ret s)).
+    rewrite <- Heq. auto. pinversion H. rewrite <- itree_eta. auto.
+  - destruct (classic (leq (priv _ e) l ) ).
+    + exfalso. apply HRinv in Hr0.
+      assert (pi_eqit_secure Label priv (case_rel Rinv RS) true b2 l (Vis e k) (Ret s) ).
+      { rewrite <- Heq. auto. }
+      pinversion H0; subst. ddestruction. subst. contradiction.
+    + rewrite Heq. rewrite bind_vis.
+      gstep. constructor; auto. intros x. gfinal. left. eapply CIH'.
+      assert ( pi_eqit_secure Label priv (case_rel Rinv RS) true b2 l (Vis e k) (Ret s)) .
+      rewrite <- Heq. auto. pinversion H0; subst; ddestruction; subst.
+      rewrite <- itree_eta. apply H2.
+Qed.
+
+Ltac use_simpobs :=
+  repeat match goal with
+         | H : TauF _ = observe ?t |- _ => apply simpobs in H
+         | H : RetF _ = observe ?t |- _ => apply simpobs in H
+         | H : VisF _ _ = observe ?t |- _ => apply simpobs in H
+  end.
+
+(* I believe we could generalize this lemma for any t2 that converges along all paths *)
+Lemma pi_eqit_secure_trans_ret E R1 R2 R3 Label priv l b1 b2
+      (RR1 : R1 -> R2 -> Prop) (RR2 : R2 -> R3 -> Prop)
+      (t1 : itree E R1) (r : R2) (t3 : itree E R3) :
+  pi_eqit_secure Label priv RR1 b1 b2 l t1 (Ret r) ->
+  pi_eqit_secure Label priv RR2 b1 b2 l (Ret r) t3 ->
+  pi_eqit_secure Label priv (rcompose RR1 RR2) b1 b2 l t1 t3.
+Proof.
+  revert t1 t3. ginit. gcofix CIH.
+  intros. pinversion H0; subst; try inv CHECK; use_simpobs.
+  - rewrite H. generalize dependent t3. gcofix CIH'. intros t3 Ht3.
+    pinversion Ht3; use_simpobs.
+    + rewrite H2. gstep. constructor; auto. econstructor; eauto.
+    + rewrite H2. gstep. constructor; auto. gfinal. left. eapply CIH'.
+      symmetry in H1. use_simpobs. rewrite H1 in H4. auto.
+    + rewrite H2. gstep. constructor; auto. intros. gfinal. left.
+      eapply CIH'. symmetry in H1. use_simpobs. setoid_rewrite H1 in H4. apply H4.
+  - symmetry in H2. use_simpobs. rewrite H. gstep. constructor; auto.
+    gfinal. left. eapply CIH; auto. rewrite <- H2. auto.
+  - symmetry in H2. use_simpobs. rewrite H. gstep. constructor; auto.
+    intros. gfinal. left. apply CIH; auto. rewrite <- H2. apply H3.
+Qed.
+
+Lemma pi_eqit_secure_pub_vis E R1 R2 RR Label priv l b1 b2 A (e : E A)
+      (k1 : A -> itree E R1) (k2 : A -> itree E R2) :
+  leq (priv _ e) l ->
+  (forall a, pi_eqit_secure Label priv RR b1 b2 l (k1 a) (k2 a) ) ->
+  pi_eqit_secure Label priv RR b1 b2 l (Vis e k1) (Vis e k2).
+Proof.
+  intros. pfold. constructor; auto. left. apply H0.
+Qed.
+
+Lemma pi_eqit_secure_priv_vislr E R1 R2 RR Label priv l b1 b2 A B (e1 : E A) (e2 : E B)
+      (k1 : A -> itree E R1) (k2 : B -> itree E R2) :
+  ~ leq (priv _ e1) l -> ~ leq (priv _ e2) l ->
+  (forall a b, pi_eqit_secure Label priv RR b1 b2 l (k1 a) (k2 b) ) ->
+  pi_eqit_secure Label priv RR b1 b2 l (Vis e1 k1) (Vis e2 k2).
+Proof.
+  intros. pfold. constructor; auto. left. apply H1.
+Qed.
+
+Lemma pi_eqit_secure_priv_visl E R1 R2 RR Label priv l b2 A (e1 : E A)
+      (k1 : A -> itree E R1) (t2 : itree E R2) :
+  ~ leq (priv _ e1) l ->
+  (forall a, pi_eqit_secure Label priv RR true b2 l (k1 a) t2 ) ->
+  pi_eqit_secure Label priv RR true b2 l (Vis e1 k1) t2.
+Proof.
+  intros. pfold. constructor; auto. left. apply H0.
+Qed.
+
+Lemma pi_eqit_secure_priv_visr E R1 R2 RR Label priv l b1 A (e1 : E A)
+      (t1 : itree E R1) (k2 : A -> itree E R2) :
+  ~ leq (priv _ e1) l ->
+  (forall a, pi_eqit_secure Label priv RR b1 true l t1 (k2 a) ) ->
+  pi_eqit_secure Label priv RR b1 true l t1 (Vis e1 k2).
+Proof.
+  intros. pfold. constructor; auto. left. apply H0.
+Qed.
+
+Lemma pi_secure_eqit_bind'
+     : forall (E : Type -> Type) (R1 R2 S1 S2 : Type) (RR : R1 -> R2 -> Prop)
+         (RS : S1 -> S2 -> Prop) (b1 b2 : bool) (Label : Preorder)
+         (priv : forall A : Type, E A -> L) (l : L)
+         r
+         (t1 : itree E R1) (t2 : itree E R2) (k1 : R1 -> itree E S1)
+         (k2 : R2 -> itree E S2),
+       (forall (r1 : R1) (r2 : R2),
+        RR r1 r2 -> paco2 (pi_secure_eqit_ Label priv RS b1 b2 l id) r (k1 r1) (k2 r2)) ->
+       pi_eqit_secure Label priv RR b1 b2 l t1 t2 ->
+       gpaco2 (pi_secure_eqit_ Label priv RS b1 b2 l id) (eqitC RS b1 b2) bot2 r
+              (ITree.bind t1 k1) (ITree.bind t2 k2).
+Proof.
+  intros. revert H0. generalize dependent t2. generalize dependent t1.
+  gcofix CIH. intros t1 t2 Ht12.
+  pinversion Ht12; use_simpobs.
+  - rewrite H0, H1. repeat rewrite bind_ret_l. gfinal. right. eapply paco2_mon; try apply CIH0.
+    auto.
+  - rewrite H0, H1. repeat rewrite bind_tau. gstep. constructor. gfinal. left. eapply CIH.
+    auto.
+  - rewrite H0. rewrite bind_tau. gstep. constructor; auto.
+    gfinal. left. eapply CIH. apply simpobs in H1. rewrite <- itree_eta in H1.
+    rewrite H1. auto.
+  - rewrite H1. rewrite bind_tau. gstep. constructor; auto.
+    gfinal. left. eapply CIH. apply simpobs in H0. rewrite <- itree_eta in H0.
+    rewrite H0. auto.
+  - rewrite H0, H1. repeat rewrite bind_vis. gstep. constructor; auto.
+    intros. gfinal. left. eapply CIH; eauto. apply H2.
+  - rewrite H0, H1. rewrite bind_vis, bind_tau. gstep. red. cbn. unpriv_pi.
+    gfinal. left. eapply CIH; eauto. apply H2.
+  - rewrite H0, H1. rewrite bind_vis, bind_tau. gstep. red. cbn. unpriv_pi.
+    gfinal. left. eapply CIH; eauto. apply H2.
+  - rewrite H0, H1. repeat rewrite bind_vis. gstep. red. cbn. unpriv_pi.
+    gfinal. left. eapply CIH. apply H2.
+  - rewrite H0. rewrite bind_vis. gstep. constructor; auto. gfinal.
+    left. eapply CIH. apply simpobs in H1. rewrite <- itree_eta in H1. rewrite H1.
+    apply H2.
+  - rewrite H1. rewrite bind_vis. gstep. constructor; auto. gfinal.
+    left. eapply CIH. apply simpobs in H0. rewrite <- itree_eta in H0. rewrite H0.
+    apply H2.
+Qed.

--- a/theories/Secure/SecureEqWcompat.v
+++ b/theories/Secure/SecureEqWcompat.v
@@ -1,0 +1,396 @@
+From Coq Require Import Morphisms.
+
+From ITree Require Import
+     Axioms
+     ITree
+     ITreeFacts
+     Secure.SecureEqHalt
+.
+
+From Paco Require Import paco.
+
+Import Monads.
+Import MonadNotation.
+Local Open Scope monad_scope.
+
+
+Lemma eqit_secureC_wcompat_id :  forall b1 b2 E R1 R2 (RR : R1 -> R2 -> Prop )
+      Label priv l
+, wcompatible2 (@secure_eqit_ E R1 R2 Label priv RR b1 b2 l id)
+                                         (eqitC RR b1 b2) .
+Proof.
+  econstructor. pmonauto_itree.
+  intros. destruct PR.
+  punfold EQVl. punfold EQVr. unfold_eqit. red in REL. red.
+  hinduction REL before r; intros; clear t1' t2'; try inv CHECK.
+  - genobs_clear t1 ot1. genobs_clear t2 ot2.
+    remember (RetF r1) as x.
+    hinduction EQVl before r; intros; inv Heqx; eauto with itree.
+    remember (RetF r3) as y.
+    hinduction EQVr before r; intros; inv Heqy; eauto with itree.
+  - remember (TauF t1) as y.
+    hinduction EQVl before r; intros; inv Heqy; try inv CHECK; subst; eauto with itree.
+    remember (TauF t2) as x.
+    hinduction EQVr before r; intros; inv Heqx; try inv CHECK; subst; eauto with itree.
+    pclearbot. constructor. gclo. econstructor; eauto with paco.
+  - eapply IHREL; eauto.
+    remember (TauF t1) as x.
+    hinduction EQVl before r; intros; inv Heqx; try inv CHECK; eauto with itree.
+    constructor; auto. pclearbot. pstep_reverse.
+  - eapply IHREL; eauto.
+    remember (TauF t2) as x.
+    hinduction EQVr before r; intros; inv Heqx; try inv CHECK; eauto with itree.
+    constructor; auto. pclearbot. pstep_reverse.
+  - remember (VisF e k1) as x.
+    hinduction EQVl before r; intros; inv Heqx; try inv CHECK; eauto with itree.
+    ddestruction. subst. remember (VisF e0 k3) as y.
+    hinduction EQVr before r; intros; inv Heqy; try inv CHECK; eauto with itree.
+    ddestruction. subst. constructor; auto.
+    intros. apply gpaco2_clo. pclearbot. econstructor; eauto with itree. apply H.
+  - remember (VisF e k1) as x.
+    hinduction EQVl before r; intros; inv Heqx; try inv CHECK; subst; eauto with itree.
+    ddestruction. subst. pclearbot. remember (TauF t2) as y.
+    hinduction EQVr before r; intros; inv Heqy; try inv CHECK; subst; eauto with itree.
+    pclearbot.
+    unpriv_co. gclo. econstructor; eauto with paco itree. gfinal.
+    left. apply H.
+  - remember (TauF t1) as x.
+    hinduction EQVl before r; intros; inv Heqx; try inv CHECK; subst; eauto with itree.
+    remember (VisF e k2) as y.
+    hinduction EQVr before r; intros; inv Heqy; try inv CHECK; subst; eauto with itree.
+    ddestruction. subst.
+    pclearbot. unpriv_co. gclo. econstructor; eauto with paco itree.
+    gfinal. left. apply H.
+  - remember (VisF e1 k1) as x.
+    hinduction EQVl before r; intros; inv Heqx; try inv CHECK; subst; eauto with itree.
+    ddestruction. subst. remember (VisF e2 k3) as y.
+    hinduction EQVr before r; intros; inv Heqy; try inv CHECK; subst; eauto with itree.
+    ddestruction. subst. unpriv_co. gclo. pclearbot.
+    econstructor; eauto with itree paco. gfinal. left. apply H.
+  - remember (VisF e k1) as x.
+    hinduction EQVl before r; intros; inv Heqx; try inv CHECK; eauto with itree.
+    ddestruction. subst. pclearbot. unpriv_ind.
+    eapply H0; eauto. pstep_reverse.
+  - remember (VisF e k2) as x.
+    hinduction EQVr before r; intros; inv Heqx; try inv CHECK; eauto with itree.
+    ddestruction. subst. pclearbot. unpriv_ind.
+    eapply H0; eauto. pstep_reverse.
+  - remember (VisF e k1) as x.
+    hinduction EQVl before r; intros; inv Heqx; try inv CHECK; eauto with itree.
+    ddestruction. subst. remember (TauF t2) as y.
+    hinduction EQVr before r; intros; inv Heqy; try inv CHECK; eauto with itree.
+    pclearbot. unpriv_halt. gclo. econstructor; eauto with paco.
+    pfold. constructor. red; auto.
+  - remember (VisF e k2) as x.
+    hinduction EQVr before r; intros; inv Heqx; try inv CHECK; eauto with itree.
+    ddestruction. subst. remember (TauF t1) as y.
+    hinduction EQVl before r; intros; inv Heqy; try inv CHECK; eauto with itree.
+    pclearbot. unpriv_halt. gclo. econstructor; eauto with paco.
+    pfold. constructor. red; auto.
+  - remember (VisF e1 k1) as x.
+    hinduction EQVl before r; intros; inv Heqx; try inv CHECK; try contra_size; eauto with itree.
+    ddestruction. subst. remember (VisF e2 k3) as y.
+    hinduction EQVr before r; intros; inv Heqy; try inv CHECK; eauto with itree.
+    ddestruction. subst. unpriv_halt. pclearbot.
+    gclo. econstructor 1 with (t1' := Vis e1 k0); eauto with paco itree.
+    + pfold. constructor; left; auto.
+    + gfinal. left. apply H.
+  - remember (VisF e1 k1) as x.
+    hinduction EQVl before r; intros; inv Heqx; try inv CHECK; try contra_size; eauto with itree.
+    ddestruction. subst. remember (VisF e2 k3) as y.
+    hinduction EQVr before r; intros; inv Heqy; try inv CHECK; eauto with itree.
+    ddestruction. subst. unpriv_halt. pclearbot.
+    gclo. econstructor 1 with (t2' := Vis e2 k4); eauto with paco itree.
+    + pfold. constructor. left. auto.
+    + gfinal. left. apply H.
+Qed.
+
+#[export] Hint Resolve eqit_secureC_mon : paco.
+
+Lemma eqit_secure_shalt_refl : forall E R1 R2 b1 b2 (RR : R1 -> R2 -> Prop) Label priv l A (e : E A) k1 k2,
+    (~ leq (priv _ e) l) -> empty A ->
+    eqit_secure Label priv RR b1 b2 l (Vis e k1) (Vis e k2).
+Proof.
+  intros. pfold. red. cbn. unpriv_halt. contra_size.
+Qed.
+
+Ltac inv_vis_secure := ddestruction; subst;
+   try contradiction; try contra_size.
+Ltac clear_trivial :=
+  repeat match goal with
+  | H : empty ?A, H' : forall a : ?A, ?P |- _ => clear H' end.
+Ltac eqit_secureC_halt_cases E := repeat (pclearbot; clear_trivial; match goal with
+     | |- _ (TauF _ ) (TauF _) => constructor; gclo; pclearbot
+     | |- eqit_secureC ?RR ?Label ?priv ?l ?b1 ?b2 _ ?t1 ?t2 => econstructor; clear_trivial; eauto with paco
+     | H : secure_eqitF ?Label ?priv ?RR ?b1 ?b2 ?l _ _ (observe ?t1) _ |- eqit_secure ?Label ?priv ?RR ?b1 ?b2 ?l ?t1 ?t2 => pfold; eauto with itree
+     |  H : nonempty ?A |- _ _ (@VisF _ _ _ ?A ?e _ ) => unpriv_co; gclo ; pclearbot
+     |  H : nonempty ?A |- _  (@VisF _ _ _ ?A ?e _ ) _ => unpriv_co; gclo ; pclearbot
+     |  H : empty ?A |- _ _ (@VisF _ _ _ ?A ?e _ ) => unpriv_halt; gclo ; pclearbot
+     |  H : empty ?A |- _ (@VisF _ _ _ ?A ?e _ ) _ => unpriv_halt; gclo ; pclearbot
+     | |- eqit_secureC ?RR ?Label ?priv ?l ?b1 ?b2 _ ?t1 ?t2 => econstructor; eauto with paco
+
+     | H : forall a, secure_eqitF ?Label ?priv ?RR ?b1 ?b2 ?l _ _ _ (observe ?t2),
+       H1 : observe ?t2 = VisF ?e ?k |- eqit_secure _ _ _ _ _ _ _ (Vis ?e ?k) =>
+       rewrite H1 in H; pfold; apply H
+     |  HA : empty ?A, HB : empty ?B, ev1 : E ?A |-
+                       eqit_secure _ _ _ _ _ _ (go (@VisF _ _ _ ?A _ _ )) (go (@VisF _ _ _ ?B _ _ ))
+                       => pfold; red; cbn; unpriv_halt; try contra_size
+     |  H : forall a : ?A, paco2 _ bot2 (?k a) ?t |- eqit_secure _ _ _ _ _ _ (?k ?a) (?t)  => red; eauto with itree
+     |  H : forall a : ?A, paco2 _ bot2 ?t (?k a) |- eqit_secure _ _ _ _ _ _ ?t (?k ?a)   => red; eauto with itree
+     |  H : forall (a : ?A) (b : ?B), paco2 _ bot2 (?k1 a) (?k2 b) |-
+                                                                        eqit_secure _ _ _ _ _ _ (?k1 ?a) (?k2 ?b)   => red; eauto with itree
+     | H : _ (observe ?t) (VisF ?e1 ?k1) |- _ ?t ?t1 => rewrite itree_eta' in H; apply H
+     | a : ?A, H : empty ?A |- _ => contra_size
+     | a : ?A |- nonempty ?A => constructor; auto
+     | HA : empty ?A, HB : empty ?B, Heq : observe ?t = (@VisF _ _ _ ?A _ _)   |-
+         gpaco2 _ _ _ _ (?t ) (go (@VisF _ _ _ ?B _ _))  => gfinal; right; pstep; red; cbn; rewrite Heq; unpriv_halt
+     | HA : empty ?A, HB : empty ?B |-
+         gpaco2 _ _ _ _ (go (@VisF _ _ _ ?A _ _) ) (go (@VisF _ _ _ ?B _ _))  => gfinal; right; pstep; red; cbn; unpriv_halt
+     | H : forall (a : ?A), _ (observe (?k a) ) observe (?t), Heq : observe ?t = VisF ?e ?k1 |-
+        eqit_secure _ _ _ _ _ _ (?k ?a) _ => rewrite itree_eta' in Heq; rewrite Heq in H; pfold; apply H
+     | H : forall a : ?A, ?P (observe (?k a) ) (observe ?t), Heq : observe ?t = VisF ?e ?k2 |-
+                                                        eqit_secure _ _ _ _ _ _ (?k ?a) _ =>
+                                          rewrite itree_eta' in Heq; rewrite Heq in H; pfold; apply H
+  end;
+  clear_trivial)
+.
+
+Ltac find_size A :=
+  match goal with
+  | H : nonempty A |- _ => idtac
+  | H : empty A |- _ => idtac
+  | |- _ => destruct (classic_empty A); try contra_size end.
+
+
+Ltac produce_elem H A := inv H; assert (nonempty A); try (constructor; auto with itree; fail).
+
+Ltac fold_secure :=
+  change (paco2 (_ ?LB ?priv ?RR ?b ?fls ?l _) ?a) with (eqit_secure LB priv RR b fls l) in *.
+
+(* Specialize some hypothesis with the assumption x *)
+Ltac spew x :=
+  let T := type of x in
+  repeat lazymatch goal with
+  | [ H0 : forall (_ : T), _ |- _ ] => specialize (H0 x)
+  end.
+
+Lemma eqit_secureC_wcompat_id' :  forall b1 b2 E R1 R2 (RR : R1 -> R2 -> Prop )
+      Label priv l,
+    wcompatible2 (@secure_eqit_ E R1 R2 Label priv RR b1 b2 l id)
+                                         (eqit_secureC RR Label priv l b1 b2) .
+Proof.
+  econstructor.
+  { red. intros. eauto with paco. }
+  intros. dependent destruction PR.
+  punfold EQVl. punfold EQVr. red in EQVl. red in EQVr. red in REL. red.
+  hinduction REL before r; intros; clear t1' t2'; try inv CHECK.
+  - remember (RetF r1) as x. hinduction EQVl before r; intros; subst; try inv Heqx; eauto with itree.
+    remember (RetF r3) as y. hinduction EQVr before r; intros; subst; try inv Heqy; eauto with itree.
+    rewrite itree_eta' at 1. unpriv_ind. eapply H0; eauto.
+  - remember (TauF t1) as x. hinduction EQVl before r; intros; subst; try inv Heqx;
+    try inv CHECK; eauto with itree.
+    + remember (TauF t4) as y. pclearbot.
+      (* think I might have a lead on the problem, should H0 have vclo not id here?*)
+      hinduction EQVr before r; intros; subst; try inv Heqy;
+      try inv CHECK; pclearbot; try fold_secure; eauto with itree.
+      * constructor. gclo. econstructor; eauto. gfinal; eauto.
+      * unpriv_co. gclo. econstructor; eauto. gfinal; eauto.
+      * rewrite itree_eta' at 1. unpriv_ind. eauto.
+      * unpriv_halt. gclo. econstructor; eauto. gfinal; eauto.
+    + remember (TauF t3) as y. pclearbot.
+      hinduction EQVr before r; intros; subst; try inv Heqy;
+      try inv CHECK; pclearbot; repeat fold_secure; eauto with itree.
+      * unpriv_co. gclo. econstructor; eauto. gfinal; eauto.
+      * unpriv_co. gclo. econstructor; eauto. gfinal; eauto.
+      * rewrite itree_eta' at 1. unpriv_ind. eauto.
+      * unpriv_halt. gclo. econstructor; eauto. gfinal; eauto.
+   + remember (TauF t3) as y. pclearbot.
+      hinduction EQVr before r; intros; subst; try inv Heqy;
+      try inv CHECK; pclearbot; repeat fold_secure; eauto with itree.
+      * unpriv_halt. gclo. econstructor; eauto. gfinal; eauto.
+      * unpriv_halt. gclo. econstructor; eauto. gfinal; eauto.
+      * rewrite itree_eta' at 1. unpriv_ind. eauto.
+      * unpriv_halt. contra_size.
+ - eapply IHREL; eauto.
+   remember (TauF t1) as y. hinduction EQVl before r; intros; inv Heqy; try inv CHECK; eauto with itree.
+   + constructor; auto. pclearbot. pstep_reverse.
+   + unpriv_ind. pclearbot. pstep_reverse.
+   + pclearbot. punfold H.
+ - eapply IHREL; eauto.
+   remember (TauF t2) as y. hinduction EQVr before r; intros; inv Heqy; try inv CHECL; eauto with itree.
+   + constructor; auto. pclearbot. pstep_reverse.
+   + unpriv_ind. pclearbot. pstep_reverse.
+   + pclearbot. punfold H.
+ - remember (VisF e k1) as x.
+   hinduction EQVl before r; intros; inv Heqx; try inv CHECK; inv_vis_secure; eauto with itree.
+   remember (VisF e0 k3) as y.
+   hinduction EQVr before r; intros; inv Heqy; try inv CHECK; inv_vis_secure; eauto with itree.
+   + pclearbot. constructor; auto. intros. gclo. econstructor; eauto.
+     apply H0. apply H. gfinal; left; apply H1.
+   + rewrite itree_eta' at 1. unpriv_ind. eapply H0; eauto.
+ - unfold id in H. remember (VisF e k1) as x.
+   hinduction EQVl before r; intros; inv Heqx; try inv CHECK; inv_vis_secure; eauto with itree.
+   + pclearbot. remember (TauF t2) as y.
+     hinduction EQVr before r; intros; inv Heqy; try inv CHECK; repeat fold_secure; eauto with itree.
+     * constructor. gclo. pclearbot. inv SIZECHECK. spew a. econstructor; eauto. gfinal; eauto.
+     * unpriv_co. gclo. pclearbot. inv SIZECHECK0. spew a0; spew a. econstructor; eauto.
+       gfinal; eauto.
+     * rewrite itree_eta' at 1. unpriv_ind. eauto.
+     * unpriv_halt. pclearbot. inv SIZECHECK0.
+       gclo. spew a. econstructor; eauto. gfinal; eauto.
+   + pclearbot. pclearbot. inv SIZECHECK. remember (TauF t2) as y.
+     hinduction EQVr before r; intros; inv Heqy; try inv CHECK; repeat fold_secure; eauto with itree.
+     * unpriv_co. gclo. pclearbot. spew a0. spew a. econstructor; eauto. gfinal; eauto.
+     * unpriv_co. gclo. pclearbot. fold_secure. spew a0; spew a. econstructor; eauto. gfinal; eauto.
+     * rewrite itree_eta' at 1. unpriv_ind. eauto.
+     * pclearbot. unpriv_halt. gclo. spew a0. spew a. econstructor; eauto. gfinal; eauto.
+  + pclearbot. inv SIZECHECK0. remember (TauF t2) as y.
+     hinduction EQVr before r; intros; inv Heqy; try inv CHECK; repeat fold_secure; eauto with itree.
+     * unpriv_halt. gclo. pclearbot. spew a; econstructor; eauto.
+       gfinal; eauto.
+     * unpriv_halt. gclo. pclearbot. fold_secure. spew a. econstructor; eauto. gfinal; eauto.
+     * rewrite itree_eta' at 1. unpriv_ind. eauto.
+     * pclearbot. unpriv_halt. contra_size.
+ - unfold id in H. remember (VisF e k2) as x.
+   hinduction EQVr before r; intros; inv Heqx; try inv CHECK; inv_vis_secure; eauto with itree.
+   + pclearbot. remember (TauF t0) as y.
+     hinduction EQVl before r; intros; inv Heqy; try inv CHECK; eauto with itree; repeat fold_secure.
+     * constructor. gclo. pclearbot. fold_secure. inv SIZECHECK.
+       spew a; econstructor; eauto. gfinal; eauto.
+     * unpriv_co. gclo. pclearbot. fold_secure. inv SIZECHECK0. spew a; spew a0. econstructor; eauto.
+       gfinal; eauto.
+     * rewrite itree_eta'. unpriv_ind. eauto.
+     * unpriv_halt. pclearbot. inv SIZECHECK0.
+       gclo. spew a; econstructor; eauto. gfinal; eauto.
+   + pclearbot. pclearbot. inv SIZECHECK. remember (TauF t1) as y.
+     hinduction EQVl before r; intros; inv Heqy; try inv CHECK; repeat fold_secure; eauto with itree.
+     * unpriv_co. gclo. pclearbot. spew a0; spew a. econstructor; eauto. gfinal; eauto.
+     * unpriv_co. gclo. pclearbot. spew b; spew a; spew a0; econstructor; eauto.
+       gfinal; eauto.
+     * rewrite itree_eta'. unpriv_ind. eauto.
+     * pclearbot. unpriv_halt. gclo. spew a. econstructor; eauto. gfinal; eauto.
+  + pclearbot. inv SIZECHECK0. remember (TauF t1) as y.
+     hinduction EQVl before r; intros; inv Heqy; try inv CHECK; eauto with itree.
+     * unpriv_halt. gclo. pclearbot. fold_secure. spew a. econstructor; eauto.
+       gfinal; eauto.
+     * unpriv_halt. gclo. pclearbot. fold_secure. spew a. econstructor; eauto.
+       gfinal; eauto.
+     * rewrite itree_eta'. unpriv_ind. eauto.
+     * pclearbot. unpriv_halt. contra_size.
+ - unfold id in H. remember (VisF e2 k2) as x.
+   hinduction EQVr before r; intros; inv Heqx; try inv CHECK; inv_vis_secure; eauto with itree; pclearbot; fold_secure.
+   1: inv SIZECHECK1; inv SIZECHECK2; remember (VisF e1 k1) as y.
+   2: inv SIZECHECK0; inv SIZECHECK3; remember (VisF e0 k0) as y.
+   3: inv SIZECHECK1; inv SIZECHECK2; remember (VisF e0 k0) as y.
+   all: spew a; spew a0.
+   all: hinduction EQVl before r; intros; inv Heqy; try inv CHECK; inv_vis_secure; subst;
+     eauto with itree; try (eqit_secureC_halt_cases E; fail).
+   all: rewrite itree_eta'; unpriv_ind; auto with itree; eauto.
+ - inv SIZECHECK. eapply H0; eauto. Unshelve. all : auto.
+   remember (VisF e k1) as x. clear H0.
+   hinduction EQVl before r; intros; inv Heqx; inv_vis_secure; try inv CHECK; pclearbot; eauto with itree.
+   + constructor; auto. pstep_reverse.
+   + unpriv_ind. pstep_reverse.
+   + rewrite itree_eta' at 1 . pstep_reverse.
+ - inv SIZECHECK. eapply (H0 a); eauto.
+   remember (VisF e k2) as x. clear H0.
+   hinduction EQVr before r; intros; inv Heqx; inv_vis_secure; try inv CHECK; pclearbot; eauto with itree.
+   + constructor; auto. pstep_reverse.
+   + unpriv_ind. pstep_reverse.
+   + rewrite itree_eta' at 1 . pstep_reverse.
+ - remember (TauF t2) as x.
+   hinduction EQVr before r; intros; inv Heqx; try inv CHECK; pclearbot; eauto with itree;
+   inv EQVl; inv_vis_secure; eqit_secureC_halt_cases E.
+   + pclearbot. find_size A0; eqit_secureC_halt_cases E.
+   + pclearbot. find_size A1; eqit_secureC_halt_cases E.
+ - remember (TauF t1) as x.
+   hinduction  EQVl before r; intros; inv Heqx; try inv CHECK; pclearbot; eauto with itree;
+   inv EQVr; inv_vis_secure;
+   eqit_secureC_halt_cases E.
+   + find_size A0; eqit_secureC_halt_cases E.
+   + find_size A1; eqit_secureC_halt_cases E.
+ - unfold id in H. remember (VisF e2 k2) as x.
+   hinduction EQVr before r; intros; inv Heqx; try inv CHECK; inv_vis_secure;  pclearbot; eauto with itree;
+   inv EQVl; inv_vis_secure;
+   (* maybe I should just write a new one *)
+   do 2 (
+   repeat match goal with | H : nonempty ?A |- _ => inv H end;
+   match goal with
+   | e1 : E ?A, e2 : E ?B, e3 : E ?C, e4 : E ?D |- _ =>
+     find_size A ; find_size B; find_size C ; find_size D ; try contra_size
+   | e1 : E ?A, e2 : E ?B, e3 : E ?C |- _ =>
+     find_size A ; find_size B; find_size C ; try contra_size
+   | e1 : E ?A, e2 : E ?B |- _ =>
+      find_size A ; find_size B; try contra_size
+   | e1 : E ?A |- _ =>
+     find_size A ; try contra_size
+   end);
+   eqit_secureC_halt_cases E; try (eapply eqit_secure_shalt_refl; eauto); eqit_secureC_halt_cases E;
+   try apply H3; try apply H; eqit_secureC_halt_cases E.
+   Unshelve. all : auto.
+ - unfold id in H. remember (VisF e1 k1) as x.
+   hinduction EQVl before r; intros; inv Heqx; try inv CHECK; inv_vis_secure; pclearbot; eauto with itree;
+     inv EQVr; inv_vis_secure;
+       do 2 (
+            repeat match goal with | H : nonempty ?A |- _ => inv H end;
+            match goal with
+            | e1 : E ?A, e2 : E ?B, e3 : E ?C, e4 : E ?D |- _ =>
+              find_size A ; find_size B; find_size C ; find_size D ; try contra_size
+            | e1 : E ?A, e2 : E ?B, e3 : E ?C |- _ =>
+              find_size A ; find_size B; find_size C ; try contra_size
+            | e1 : E ?A, e2 : E ?B |- _ =>
+              find_size A ; find_size B; try contra_size
+            | e1 : E ?A |- _ =>
+              find_size A ; try contra_size
+            end);
+       eqit_secureC_halt_cases E; try (eapply eqit_secure_shalt_refl; eauto); eqit_secureC_halt_cases E;
+   try apply H3; try apply H; eqit_secureC_halt_cases E.
+   Unshelve. all: auto.
+Qed.
+
+#[export] Hint Resolve eqit_secureC_wcompat_id : paco.
+
+#[global] Instance geuttgen_cong_secure_eqit {E} {Label priv l} {R1 R2 : Type} {RR1 : R1 -> R1 -> Prop}
+    {RR2 : R2 -> R2 -> Prop} {RS : R1 -> R2 -> Prop} (b1 b2 : bool) {r rg} :
+    (forall (x x' : R1) (y : R2), (RR1 x x' : Prop) -> (RS x' y : Prop) -> RS x y) ->
+    (forall (x : R1) (y y' : R2), (RR2 y y' : Prop) -> RS x y' -> RS x y) ->
+    Proper (@eq_itree E R1 R1 RR1 ==> eq_itree RR2 ==> flip impl)
+           (gpaco2 (secure_eqit_ Label priv RS b1 b2 l id) (eqitC RS b1 b2) r rg ).
+Proof.
+  repeat intro. gclo. econstructor; eauto.
+  - eapply eqit_mon, H1; eauto; discriminate.
+  - eapply eqit_mon, H2; eauto; discriminate.
+Qed.
+
+#[global] Instance geuttgen_cong_secure_eqit' {E} {Label priv l} {R1 R2 : Type} {RR1 : R1 -> R1 -> Prop}
+    {RR2 : R2 -> R2 -> Prop} {RS : R1 -> R2 -> Prop} (b1 b2 : bool) {r rg} :
+    (forall (x x' : R1) (y : R2), (RR1 x x' : Prop) -> (RS x' y : Prop) -> RS x y) ->
+    (forall (x : R1) (y y' : R2), (RR2 y y' : Prop) -> RS x y' -> RS x y) ->
+    Proper (@eqit_secure E R1 R1 Label priv RR1 false false l ==>
+             eqit_secure Label priv RR2 false false l ==> flip impl)
+           (gpaco2 (secure_eqit_ Label priv RS b1 b2 l id) (eqit_secureC RS Label priv l b1 b2) r rg ).
+Proof.
+  repeat intro. gclo. econstructor; eauto.
+  - eapply secure_eqit_mon, H1; eauto. intros; discriminate.
+  - eapply secure_eqit_mon, H2; eauto. intros; discriminate.
+Qed.
+
+#[global] Instance geutt_cong_euttge:
+  forall {E : Type -> Type} Label priv l b1 b2 {R1 R2 : Type} {RR1 : R1 -> R1 -> Prop}
+    {RR2 : R2 -> R2 -> Prop} {RS : R1 -> R2 -> Prop}
+    (r rg : forall x : itree E R1, (fun _ : itree E R1 => itree E R2) x -> Prop),
+  (forall (x x' : R1) (y : R2), (RR1 x x' : Prop) -> (RS x' y : Prop) -> RS x y) ->
+  (forall (x : R1) (y y' : R2), (RR2 y y' : Prop) -> RS x y' -> RS x y) ->
+  Proper (euttge RR1 ==> euttge RR2 ==> flip impl)
+    (gpaco2 (secure_eqit_ Label priv RS b1 b2 l id) (eqitC RS true true) r rg).
+Proof.
+  repeat intro. gclo. econstructor; eauto.
+Qed.
+
+#[global] Instance geutt_eq_cong_euttge:
+  forall {E : Type -> Type} Label priv l b1 b2 {R1 R2 : Type} r rg RS ,
+    Proper ( @euttge E R1 R1 eq ==> @euttge E R2 R2 eq ==> flip impl)
+           (gpaco2 (secure_eqit_ Label priv RS b1 b2 l id) (eqitC RS true true) r rg ).
+Proof.
+  repeat intro. eapply geutt_cong_euttge; eauto; intros; subst; auto.
+Qed.

--- a/theories/Secure/SecureStateHandler.v
+++ b/theories/Secure/SecureStateHandler.v
@@ -1,0 +1,397 @@
+From Coq Require Import Morphisms.
+
+From ITree Require Import
+     Basics.HeterogeneousRelations
+     Axioms
+     ITree
+     ITreeFacts
+     EqAxiom
+     Events.State
+     Events.StateFacts
+     Secure.SecureEqHalt
+     Secure.SecureEqBind
+     Secure.SecureEqEuttHalt
+     Secure.StrongBisimProper
+.
+
+From Paco Require Import paco.
+
+Import Monads.
+Import MonadNotation.
+Local Open Scope monad_scope.
+
+Ltac use_simpobs :=
+  repeat match goal with
+         | H : TauF _ = observe ?t |- _ => apply simpobs in H
+         | H : RetF _ = observe ?t |- _ => apply simpobs in H
+         | H : VisF _ _ = observe ?t |- _ => apply simpobs in H
+  end.
+
+Section GeneralStateHandler.
+
+Context (S : Type).
+Context (RS : S -> S -> Prop).
+Context (RS_Eq: Equivalence RS).
+
+Context (E1 E2 : Type -> Type).
+
+Context (handler : E1 ~> stateT S (itree E2) ).
+
+Context (Label : Preorder).
+Context (priv1 : forall A, E1 A -> L).
+Context (priv2 : forall A, E2 A -> L).
+Context (l : L).
+
+Definition state_eqit_secure {R1 R2 : Type} (b1 b2 : bool) (RR : R1 -> R2 -> Prop)
+           (m1 : stateT S (itree E2) R1) (m2 : stateT S (itree E2) R2) :=
+  forall s1 s2, RS s1 s2 -> eqit_secure Label priv2 (prod_rel RS RR) b1 b2 l (m1 s1) (m2 s2).
+
+Definition top2 {R1 R2} (r1 : R1) (r2 : R2) : Prop := True.
+
+
+Definition secure_in_nonempty_context {R} (m : stateT S (itree E2) R) :=
+   forall r' : R, state_eqit_secure true true top2 m (ret r').
+
+Definition secure_in_empty_context  {R} (m : stateT S (itree E2) R) :=
+   state_eqit_secure true true (@top2 R R) m (fun s => ITree.spin).
+
+Inductive terminates (s1 : S) (P : forall A, E2 A -> Prop) : forall {A : Type}, itree E2 (S * A) -> Prop :=
+| terminates_ret {R : Type} : forall (r : R) (s2 : S), RS s1 s2 -> terminates s1 P (Ret (s2, r))
+| terminates_tau : forall A (t : itree E2 (S * A)) , terminates s1 P t -> terminates s1 P (Tau t)
+| terminates_vis {A R : Type} : forall (e : E2 A) (k : A -> itree E2 (S * R)) , (forall v, terminates s1 P (k v)) -> P A e -> terminates s1 P (Vis e k)
+.
+
+Variant diverges_with' {E : Type -> Type} (P : forall A, E A -> Prop) (A : Type) (F : itree E A -> Prop) : itree' E A -> Prop :=
+  | diverges_tau (t : itree E A): F t -> diverges_with' P A F (TauF t)
+  | diverges_vis {B : Type} (e : E B) (k : B -> itree E A) : (forall a, F (k a)) -> P _ e -> diverges_with' P A F (VisF e k).
+
+Definition diverges_with_  {E} (P : forall A, E A -> Prop) {A : Type} (F : itree E A -> Prop) :  itree E A -> Prop :=
+  fun t => diverges_with' P A F (observe t).
+
+Definition diverges_with {E} (P : forall A, E A -> Prop) {A : Type} : itree E A -> Prop := paco1 (@diverges_with_ E P A) bot1.
+
+Hint Constructors diverges_with' : itree.
+Hint Unfold diverges_with_ : itree.
+
+Lemma mono_diverges_with (E : Type -> Type) P A : monotone1 (@diverges_with_ E P A).
+Proof.
+  red. intros. red. inversion IN; auto with itree.
+Qed.
+
+Hint Resolve mono_diverges_with : paco.
+
+#[global] Instance proper_diverges_with {E A} {P : forall A, E A -> Prop} : Proper (eq_itree eq ==> iff ) (@diverges_with E P A).
+Proof.
+  do 2 red. intros t1 t2 Heq. apply EqAxiom.bisimulation_is_eq in Heq. subst; tauto.
+Qed.
+
+#[global] Instance proper_diverges_with_r  {E A r} {P : forall A, E A -> Prop} : Proper (eq_itree eq ==> iff ) (paco1 (@diverges_with_ E P A) r ).
+Proof.
+  do 2 red. intros t1 t2 Heq. apply EqAxiom.bisimulation_is_eq in Heq. subst; tauto.
+Qed.
+
+#[global] Instance proper_terminate {R s} {P : forall A, E2 A -> Prop} : Proper (eq_itree (@eq (S *R )) ==> iff) (terminates s P).
+Proof.
+  red. intros t1 t2 Heq. apply EqAxiom.bisimulation_is_eq in Heq. subst; tauto.
+Qed.
+
+
+Lemma diverges_with_bind : forall E (P : forall A, E A -> Prop) (A B : Type) (k : A -> itree E B) (t : itree E A) ,
+    diverges_with P t -> diverges_with P (ITree.bind t k).
+Proof.
+  intros P A B k. pcofix CIH. intros.
+  pfold. red. unfold observe. cbn.
+  pinversion H0; cbn.
+  - constructor; eauto.
+  - constructor; intros; eauto. right. eapply CIH; eauto. apply H1.
+Qed.
+
+Lemma diverges_with_halt : forall E (A B : Type) (e : E A) (k : A -> itree E B) (P : forall A, E A -> Prop),
+    P A e -> empty A -> diverges_with P (Vis e k).
+Proof.
+  intros. pfold. constructor; auto. intros; contra_size.
+Qed.
+
+Lemma diverges_secure_equiv_halt_r : forall A R1 R2 RR (e : E1 A) (k : A -> itree E1 R1) (t : itree E1 R2),
+    empty A ->
+    ~ leq (priv1 _ e) l ->
+    eqit_secure Label priv1 RR true true l (Vis e k) t ->
+    diverges_with (fun _ e => ~ leq (priv1 _ e) l) t.
+Proof.
+  intros A R1 R2 RR e k t Hemp Hsec. revert t. pcofix CIH.
+  intros. punfold H0. red in H0.
+  cbn in *. remember (VisF e k) as ov. remember (observe t) as ot.
+  hinduction H0 before r; intros; inv Heqov; subst; ddestruction; subst; try discriminate;  try contradiction;
+    try contra_size; use_simpobs.
+  - rewrite Heqot. pfold. constructor. left. eapply IHsecure_eqitF; eauto.
+  - pclearbot. rewrite Heqot. pfold. constructor; eauto.
+  - rewrite Heqot. pfold. constructor. right. pclearbot. eapply CIH; eauto.
+  - pclearbot. rewrite Heqot. pfold. constructor; auto. right. eapply CIH; eauto. apply H.
+  - rewrite Heqot. pfold. constructor; auto. right. eapply CIH; eauto. contra_size.
+Qed.
+
+Lemma diverges_secure_equiv_halt_l : forall A R1 R2 RR (e : E1 A) (k : A -> itree E1 R1) (t : itree E1 R2),
+    empty A ->
+    ~ leq (priv1 _ e) l ->
+    eqit_secure Label priv1 RR true true l t (Vis e k) ->
+    diverges_with (fun _ e => ~ leq (priv1 _ e) l) t.
+Proof.
+  intros A R1 R2 RR e k t Hemp Hsec. revert t. pcofix CIH.
+  intros. punfold H0. red in H0.
+  cbn in *. remember (VisF e k) as ov. remember (observe t) as ot.
+  hinduction H0 before r; intros; inv Heqov; subst; ddestruction; subst; try discriminate;  try contradiction;
+    try contra_size; use_simpobs.
+  - rewrite Heqot. pfold. constructor. left. eapply IHsecure_eqitF; eauto.
+  - pclearbot. rewrite Heqot. pfold. constructor; eauto.
+  - rewrite Heqot. pfold. constructor. right. pclearbot. eapply CIH; eauto.
+  - pclearbot. rewrite Heqot. pfold. constructor; auto. right. eapply CIH; eauto. contra_size.
+  - pclearbot. rewrite Heqot. pfold. constructor; auto. right. eapply CIH; eauto. apply H.
+Qed.
+
+Lemma diverges_with_spin : forall E A P,
+    diverges_with P (@ITree.spin E A).
+Proof.
+  intros. pcofix CIH. pfold. red. cbn. constructor.
+  right; auto.
+Qed.
+
+Lemma eqit_secure_silent_diverge : forall A B RR (t1 : itree E2 A) (t2 : itree E2 B),
+    diverges_with (fun _ e => ~ leq (priv2 _ e) l) t1 ->
+    diverges_with (fun _ e => ~ leq (priv2 _ e) l) t2 ->
+    eqit_secure Label priv2 RR true true l t1 t2.
+Proof.
+  intros A B RR. pcofix CIH. intros.
+  punfold H0. red in H0. punfold H1. red in H1.
+  inversion H0; inversion H1; use_simpobs; try rewrite H; try rewrite H3.
+  - pfold. constructor. right. pclearbot. eapply CIH; eauto.
+  - destruct (classic_empty B0).
+    + pclearbot. pfold. constructor; auto. pstep_reverse. clear H. clear CIH.
+      generalize dependent t. pcofix CIH. intros.
+      pinversion H2; use_simpobs.
+      * rewrite H. pfold. red. cbn. unpriv_halt.
+      * rewrite H. pfold. red. cbn. unpriv_halt.
+    + pfold. red. cbn. unpriv_co. right. pclearbot. eapply CIH; eauto. apply H4.
+  - pclearbot. destruct (classic_empty B0).
+    + pclearbot. clear H4. clear CIH.
+      generalize dependent t2. pcofix CIH. intros.
+      inversion H4; use_simpobs.
+      * rewrite H1. pfold. red. cbn. pclearbot. unpriv_halt. right. eapply CIH; eauto. punfold H7.
+      * rewrite H1. pfold. red. cbn. unpriv_halt. right. pclearbot. eapply CIH; eauto. pstep_reverse.
+    + rewrite H4. pfold. red. cbn. unpriv_co. right. pclearbot. eapply CIH; eauto. apply H2.
+  - pclearbot. rewrite H4.
+    destruct (classic_empty B0); destruct (classic_empty B1).
+    + pfold. red. cbn. unpriv_halt. contra_size.
+    + assert (diverges_with (fun _ e => ~ leq (priv2 _ e) l) (Vis e0 k0)).
+      { pfold. constructor; auto. }
+      rewrite <- H4. rewrite <- H4 in H9. clear H4. clear H1 CIH. generalize dependent t2.
+      pcofix CIH. intros. pinversion H9; use_simpobs.
+      * rewrite H1. pfold. red. cbn. unpriv_halt.
+      * rewrite H1. pfold. red. cbn. unpriv_halt. right. eapply CIH; eauto. apply H4.
+    + assert (diverges_with (fun _ e => ~ leq (priv2 _ e) l) (Vis e k)).
+      { pfold. constructor; auto. }
+      rewrite <- H. rewrite <- H in H9. clear H. clear H0 CIH. generalize dependent t1.
+      pcofix CIH. intros. pinversion H9; use_simpobs.
+      * rewrite H. pfold. red. cbn. unpriv_halt.
+      * rewrite H. pfold. red. cbn. unpriv_halt. right. eapply CIH; eauto. apply H0.
+    + pfold. red. cbn. unpriv_co. right. eapply CIH; eauto. apply H2. apply H5.
+Qed.
+
+Lemma silent_diverges_eqit_secure_spin : forall A B (RR : A -> B -> Prop) (t : itree E2 A),
+    diverges_with (fun _ e => ~ leq (priv2 _ e) l) t <-> eqit_secure Label priv2 RR true true l t (ITree.spin).
+Proof.
+  intros. split.
+  { intros. eapply eqit_secure_silent_diverge; eauto. apply diverges_with_spin. }
+  revert t. pcofix CIH.
+  intros t Ht. punfold Ht. red in Ht. remember (observe t) as ot.
+  remember (observe ITree.spin) as otspin.
+  hinduction Ht before r; intros; subst; try discriminate; use_simpobs.
+  - pclearbot. rewrite Heqot. pfold. constructor. right. eapply CIH; eauto. rewrite Heqotspin.
+    pfold; constructor; auto. pstep_reverse.
+  - rewrite Heqot. pfold; constructor. left. eapply IHHt; eauto.
+  - eapply IHHt; eauto. assert (ITree.spin ≅ t2).
+    { clear IHHt Ht. generalize dependent t2. pcofix CIH'.
+      intros. punfold Heqotspin. red in Heqotspin.  cbn in *. inversion Heqotspin; try inv CHECK0.
+      subst. pclearbot. eapply paco2_mon; eauto; intros; try contradiction. }
+    apply EqAxiom.bisimulation_is_eq in H. subst; auto.
+  - rewrite Heqot. pfold. constructor; auto. right. eapply CIH; eauto. pclearbot. rewrite Heqotspin.
+    pfold; constructor; auto. pstep_reverse.
+  - rewrite Heqot. pfold. constructor; auto. left. eapply H0; eauto.
+  - rewrite Heqot. pclearbot. pfold; constructor; auto. right. eapply CIH; eauto.
+    rewrite Heqotspin. pfold; constructor; auto. pstep_reverse.  eapply unpriv_e_eqit_secure; eauto.
+Qed.
+
+
+Lemma silent_terminates_eqit_secure_ret : forall R (m : stateT S (itree E2) R), nonempty R ->
+      (forall s, terminates s (fun B e => ~ leq (priv2 _ e) l /\ nonempty B) (m s) ) <-> forall r' : R, state_eqit_secure true true top2 m (ret r').
+Proof.
+  split; intros.
+  - red. intros. specialize (H0 s1).
+    cbn. induction H0.
+    + pfold; constructor. split; try constructor. cbn. etransitivity; eauto. symmetry. auto.
+    + pfold; constructor; auto. pstep_reverse. eapply IHterminates; eauto.
+    + destruct H3. pfold. red. cbn. timeout 10 setoid_rewrite itree_eta' at 2.  unpriv_ind.
+      pstep_reverse. eapply H2; eauto.
+  - cbn in *. red in H0. assert (RS s s). reflexivity.
+    inv H.
+    specialize (H0 a s s H1). remember (m s) as t. clear Heqt.
+    punfold H0. red in H0. cbn in H0. remember (RetF (s,a) ) as oret. remember (observe t) as ot.
+    hinduction H0 before E1; intros; try discriminate; use_simpobs.
+    + rewrite Heqot. injection Heqoret; intros; subst. destruct r1, H. cbn in *.
+      constructor. symmetry. auto.
+    + rewrite Heqot. constructor. eapply IHsecure_eqitF; eauto.
+    + rewrite Heqot. constructor; eauto.
+Qed.
+
+Variant handler_respects_priv (A : Type) (e : E1 A) : Prop :=
+| respect_private (SECCHECK : ~ leq (priv1 _ e) l)
+                  (FINCHECK : forall s, terminates s (fun _ e' => ~ leq (priv2 _ e') l) (handler A e s))
+| respect_public (SECCHECK : leq (priv1 _ e) l)
+                 (RESCHECK : state_eqit_secure true true eq (handler A e) (handler A e))
+.
+
+Variant handler_respects_priv' (A : Type) (e : E1 A) : Prop :=
+| respect_private_ne (SECCHECK : ~ leq (priv1 _ e) l) (SIZECHECK : nonempty A)
+                  (FINCHECK :  forall s, terminates s (fun B e' => ~ leq (priv2 _ e') l /\ nonempty B ) (handler A e s) )
+| respect_private_e (SECCHECK : ~ leq (priv1 _ e) l) (SIZECHECK : empty A)
+                  (DIVCHECK : forall s, diverges_with (fun _ e' => ~ leq (priv2 _ e') l ) (handler A e s) )
+| respect_public' (SECCHECK : leq (priv1 _ e) l)
+                 (RESCHECK : state_eqit_secure true true eq (handler A e) (handler A e))
+.
+
+Context (Hhandler : forall A (e : E1 A), handler_respects_priv' A e).
+
+Lemma diverge_with_respectful_handler : forall (R : Type) (t : itree E1 R),
+    diverges_with (fun _ e => ~ leq (priv1 _ e) l ) t ->
+    forall s, diverges_with (fun _ e => ~ leq (priv2 _ e) l) (interp_state handler t s).
+Proof.
+  intro R. pcofix CIH. intros t Hdiv s. pinversion Hdiv; use_simpobs.
+  - rewrite H. rewrite interp_state_tau. pfold. constructor. right. eapply CIH; eauto.
+  - rewrite H. rewrite interp_state_vis.
+    destruct (classic_empty B).
+    + specialize (Hhandler _ e). destruct Hhandler; try contradiction; try contra_size.
+      specialize (DIVCHECK s). eapply paco1_mon with (r:= bot1). eapply diverges_with_bind; eauto.
+      intros; contradiction.
+    + specialize (Hhandler _ e). destruct Hhandler; try contradiction; try contra_size.
+      specialize (FINCHECK s). induction FINCHECK.
+      * rewrite bind_ret_l. cbn. pfold. constructor. right. eapply CIH; eauto. apply H0.
+      * rewrite bind_tau. pfold. constructor. left. eapply IHFINCHECK; eauto.
+      * destruct H5. rewrite bind_vis. pfold. constructor; auto. left. eapply H4; eauto.
+Qed.
+
+
+
+Lemma interp_eqit_secure_state : forall (R1 R2 : Type) (RR : R1 -> R2 -> Prop) (t1 : itree E1 R1) (t2 : itree E1 R2),
+    eqit_secure Label priv1 RR true true l t1 t2 ->
+    state_eqit_secure true true RR (interp_state handler t1) (interp_state handler t2).
+Proof.
+  intros R1 R2 RR. pcofix CIH. intros t1 t2 Ht s1 s2 Hs. punfold Ht.
+  red in Ht. remember (observe t1) as ot1. remember (observe t2) as ot2.
+  hinduction Ht before r; intros; use_simpobs.
+  - rewrite Heqot1. rewrite Heqot2. repeat rewrite interp_state_ret. pfold. constructor. auto.
+  - rewrite Heqot1. rewrite Heqot2. repeat rewrite interp_state_tau. pfold. constructor.
+    pclearbot. right. apply CIH; auto.
+  - rewrite Heqot1. rewrite interp_state_tau. pfold. constructor; auto. pstep_reverse.
+  - rewrite Heqot2. rewrite interp_state_tau. pfold. constructor; auto. pstep_reverse.
+  - rewrite Heqot1. rewrite Heqot2. repeat rewrite interp_state_vis.
+    specialize (Hhandler A e). pclearbot. repeat rewrite bind_tau.
+    (* could use the bind closure here, but maybe we can do manually for now*)
+    repeat setoid_rewrite <- interp_state_tau. inv Hhandler; try contradiction.
+    specialize (RESCHECK s1 s2 Hs).
+    eapply secure_eqit_bind'; eauto. intros [] [] []. simpl in *. subst.
+    repeat rewrite interp_state_tau.
+    pfold. constructor. right. eapply CIH; eauto. apply H.
+  - pclearbot. rewrite Heqot1. rewrite Heqot2.
+    rewrite interp_state_tau. rewrite interp_state_vis.
+    specialize (Hhandler A e). inv Hhandler; try contradiction; try contra_size.
+    specialize (FINCHECK s1). induction FINCHECK.
+    + rewrite bind_ret_l. pstep. constructor. right.
+      apply CIH. apply H. etransitivity; [symmetry |]; eauto.
+    + rewrite bind_tau. pstep. constructor 3; auto. pstep_reverse.
+    + rewrite bind_vis. pstep. destruct H2. constructor 9; auto. intros. pstep_reverse.
+  - pclearbot. rewrite Heqot1. rewrite Heqot2.
+    rewrite interp_state_tau. rewrite interp_state_vis.
+    specialize (Hhandler A e). inv Hhandler; try contradiction; try contra_size.
+    specialize (FINCHECK s2). induction FINCHECK.
+    + rewrite bind_ret_l. pstep. constructor. right.
+      apply CIH. apply H. etransitivity; eauto.
+    + rewrite bind_tau. pstep. constructor 4; auto. pstep_reverse.
+    + rewrite bind_vis. pstep. destruct H2. constructor 10; auto. intros. pstep_reverse.
+  - pclearbot. rewrite Heqot1. rewrite Heqot2. repeat rewrite interp_state_vis.
+    specialize (Hhandler _ e1) as He1. specialize (Hhandler _ e2) as He2.
+    inv He1; inv He2; try contradiction; try contra_size.
+    eapply secure_eqit_bind' with (RR := prod_rel RS (fun _ _ => True)).
+    + intros [] [] ?. pstep. constructor. right.
+      apply CIH. apply H. simpl. apply H0.
+    + specialize (FINCHECK s1). specialize (FINCHECK0 s2).
+      induction FINCHECK.
+      * induction FINCHECK0.
+        -- simpl. pstep. constructor. split; auto. simpl.
+           transitivity s2; eauto. etransitivity; [symmetry |]; eauto.
+        -- pstep. constructor; auto. pstep_reverse. eapply IHFINCHECK0; eauto.
+        -- pstep. destruct H3. constructor; auto. intros. pstep_reverse. eapply H2; eauto.
+      * pstep. constructor; auto. pstep_reverse. eapply IHFINCHECK; eauto.
+      * pstep. destruct H2. constructor; auto. intros. pstep_reverse. eapply H1; eauto.
+  - rewrite Heqot1. rewrite interp_state_vis. specialize (Hhandler _ e).
+    inv Hhandler; try contradiction; try contra_size.
+    specialize (FINCHECK s1). induction FINCHECK.
+    + rewrite bind_ret_l. pstep. constructor; auto. pstep_reverse.
+      eapply H0; eauto. simpl. etransitivity; [symmetry |]; eauto.
+    + rewrite bind_tau. pstep. constructor 3; auto. pstep_reverse.
+    + rewrite bind_vis. pstep. destruct H3. constructor 9; auto. intros. pstep_reverse.
+  - rewrite Heqot2. rewrite interp_state_vis. specialize (Hhandler _ e).
+    inv Hhandler; try contradiction; try contra_size.
+    specialize (FINCHECK s2). induction FINCHECK.
+    + rewrite bind_ret_l. pstep. constructor 4; auto. pstep_reverse.
+      eapply H0; eauto. simpl. etransitivity; eauto.
+    + rewrite bind_tau. pstep. constructor 4; auto. pstep_reverse.
+    + rewrite bind_vis. pstep. destruct H3. constructor 10; auto. intros. pstep_reverse.
+  - pclearbot.
+    rewrite Heqot1. rewrite interp_state_vis.
+    rewrite Heqot2. rewrite interp_state_tau.
+    pose proof Hhandler as Hhandler'.
+    specialize (Hhandler' _ e). inv Hhandler'; try contradiction; try contra_size.
+    eapply paco2_mon with (r:= bot2); intros; try contradiction. eapply eqit_secure_silent_diverge.
+    + eapply diverges_with_bind; eauto.
+    + pfold. constructor. left. eapply diverge_with_respectful_handler; eauto.
+      eapply diverges_secure_equiv_halt_r; eauto.
+  - pclearbot.
+    rewrite Heqot1. rewrite interp_state_tau.
+    rewrite Heqot2. rewrite interp_state_vis.
+    pose proof Hhandler as Hhandler'.
+    specialize (Hhandler' _ e). inv Hhandler'; try contradiction; try contra_size.
+    eapply paco2_mon with (r:= bot2); intros; try contradiction. eapply eqit_secure_silent_diverge.
+    + pfold. constructor. left. eapply diverge_with_respectful_handler; eauto.
+      eapply diverges_secure_equiv_halt_l; eauto.
+    + eapply diverges_with_bind; eauto.
+  - pclearbot. rewrite Heqot1. rewrite Heqot2. repeat rewrite interp_state_vis.
+    pose proof Hhandler as Hhandler'.
+    pose proof Hhandler as Hhandler''.
+    specialize (Hhandler'' _ e2). inv Hhandler''; try contradiction; try contra_size.
+    specialize (Hhandler' _ e1). inv Hhandler'; try contradiction; try contra_size.
+    eapply paco2_mon with (r:= bot2); intros; try contradiction. eapply eqit_secure_silent_diverge.
+    + eapply diverges_with_bind; eauto.
+    + specialize (FINCHECK s2). induction FINCHECK.
+      * rewrite bind_ret_l. pfold; constructor. left. cbn.
+        eapply diverge_with_respectful_handler; eauto. eapply diverges_secure_equiv_halt_r; eauto.
+        apply H.
+      * rewrite bind_tau. pfold; constructor. left. eapply IHFINCHECK; eauto.
+      * rewrite bind_vis. pfold. constructor. left. eapply H1; eauto. destruct H2; auto.
+    + eapply paco2_mon with (r:= bot2); intros; try contradiction. eapply eqit_secure_silent_diverge.
+      * apply diverges_with_bind. specialize (Hhandler _ e1). inv Hhandler; try contradiction; try contra_size; auto.
+      * apply diverges_with_bind; auto.
+  - pclearbot. rewrite Heqot1. rewrite Heqot2. repeat rewrite interp_state_vis.
+    pose proof Hhandler as Hhandler'.
+    pose proof Hhandler as Hhandler''.
+    eapply paco2_mon with (r:= bot2); intros; try contradiction. eapply eqit_secure_silent_diverge.
+    + specialize (Hhandler'' _ e1). inv Hhandler''; try contradiction; try contra_size.
+      * specialize (FINCHECK s1). induction FINCHECK.
+        ++ rewrite bind_ret_l. pfold; constructor. cbn. left.
+           eapply diverge_with_respectful_handler. eapply diverges_secure_equiv_halt_l; eauto. apply H.
+        ++ rewrite bind_tau. pfold. constructor. left. eapply IHFINCHECK; eauto.
+        ++ destruct H2. rewrite bind_vis. pfold. constructor; auto. left. eapply H1; eauto.
+      * apply diverges_with_bind; auto.
+    + specialize (Hhandler'' _ e2). inv Hhandler''; try contradiction; try contra_size.
+      apply diverges_with_bind; auto.
+Qed.
+
+End GeneralStateHandler.

--- a/theories/Secure/SecureStateHandlerPi.v
+++ b/theories/Secure/SecureStateHandlerPi.v
@@ -1,0 +1,240 @@
+From Coq Require Import Morphisms.
+From ITree Require Import
+     Axioms
+     ITree
+     ITreeFacts
+     Basics.HeterogeneousRelations
+     Events.State
+     Events.StateFacts
+     Secure.SecureEqHalt
+     Secure.SecureEqEuttHalt
+     Secure.SecureEqWcompat
+     Secure.SecureEqBind
+     Secure.SecureEqProgInsens
+     Secure.SecureEqProgInsensFacts
+     Secure.StrongBisimProper
+     Secure.SecureStateHandler
+.
+
+Import Monads.
+Import MonadNotation.
+Local Open Scope monad_scope.
+
+From Paco Require Import paco.
+
+Section GeneralStateHandler.
+
+Context (S : Type).
+Context (RS : S -> S -> Prop).
+Context (RS_Eq: Equivalence RS).
+
+Context (E1 E2 : Type -> Type).
+
+Context (handler : E1 ~> stateT S (itree E2) ).
+
+Context (Label : Preorder).
+Context (priv1 : forall A, E1 A -> L).
+Context (priv2 : forall A, E2 A -> L).
+Context (l : L).
+
+Definition state_pi_eqit_secure {R1 R2 : Type} (b1 b2 : bool) (RR : R1 -> R2 -> Prop)
+           (m1 : stateT S (itree E2) R1) (m2 : stateT S (itree E2) R2) :=
+  forall s1 s2, RS s1 s2 -> pi_eqit_secure Label priv2 (prod_rel RS RR) b1 b2 l (m1 s1) (m2 s2).
+
+Definition top2 {R1 R2} (r1 : R1) (r2 : R2) : Prop := True.
+
+Definition secure_in_nonempty_context {R} (m : stateT S (itree E2) R) :=
+   forall r' : R, state_pi_eqit_secure true true top2 m (ret r').
+
+Definition secure_in_empty_context  {R} (m : stateT S (itree E2) R) :=
+   state_pi_eqit_secure true true (@top2 R R) m (fun s => ITree.spin).
+
+Lemma diverges_with_spin : forall E A P,
+    diverges_with P (@ITree.spin E A).
+Proof.
+  intros. pcofix CIH. pfold. red. cbn. constructor.
+  right; auto.
+Qed.
+
+Lemma pi_eqit_secure_silent_divergel : forall A B RR (t1 : itree E2 A) (t2 : itree E2 B),
+    diverges_with (fun _ e => ~ leq (priv2 _ e) l) t1 ->
+    pi_eqit_secure Label priv2 RR true true l t1 t2.
+Proof.
+  intros A B RR. pcofix CIH. intros.
+  punfold H0. all : try apply mono_diverges_with. red in H0.
+  inversion H0; use_simpobs; try rewrite H; try rewrite H3.
+  - pfold. constructor; auto. right. pclearbot. eapply CIH; eauto.
+  - destruct (classic_empty B0).
+    + eapply paco2_mon with (r := bot2); intros; try contradiction.
+      apply pi_eqit_secure_sym.
+      apply pi_eqit_secure_private_halt; auto.
+    + pfold. red. cbn. constructor; auto. right. pclearbot. eapply CIH; eauto.
+      apply H1.
+ Qed.
+
+Lemma pi_eqit_secure_silent_diverger : forall A B RR (t1 : itree E2 A) (t2 : itree E2 B),
+    diverges_with (fun _ e => ~ leq (priv2 _ e) l) t2 ->
+    pi_eqit_secure Label priv2 RR true true l t1 t2.
+Proof.
+  intros. apply pi_eqit_secure_sym. apply pi_eqit_secure_silent_divergel; auto.
+Qed.
+
+
+Lemma silent_terminates_eqit_secure_ret : forall R (m : stateT S (itree E2) R), nonempty R ->
+      (forall s, terminates S RS E2 s (fun B e => ~ leq (priv2 _ e) l /\ nonempty B) (m s) ) -> forall r' : R, state_pi_eqit_secure true true top2 m (ret r').
+Proof.
+  red. intros. specialize (H0 s1).
+  cbn. induction H0.
+  - pfold; constructor. split; try constructor. cbn. etransitivity; eauto. symmetry. auto.
+  - pfold; constructor; auto.
+    left. eapply IHterminates; auto.
+  - apply pi_eqit_secure_priv_visl; auto. destruct H3. auto.
+Qed.
+
+
+Variant handler_respects_priv (A : Type) (e : E1 A) : Prop :=
+| respect_private' (SECCHECK : ~ leq (priv1 _ e) l)
+                 (RESCHECK : state_pi_eqit_secure true true top2 (handler A e) (ret tt) )
+| respect_public'' (SECCHECK : leq (priv1 _ e) l)
+                 (RESCHECK : state_pi_eqit_secure true true eq (handler A e) (handler A e))
+.
+
+Context (Hhandler : forall A (e : E1 A), handler_respects_priv A e).
+
+Hint Resolve mono_diverges_with : paco.
+(*
+Lemma diverge_with_respectful_handler : forall (R : Type) (t : itree E1 R),
+    diverges_with (fun _ e => ~ leq (priv1 _ e) l ) t ->
+    forall s, diverges_with (fun _ e => ~ leq (priv2 _ e) l) (interp_state handler t s).
+Proof.
+  intro R. pcofix CIH. intros t Hdiv s. pinversion Hdiv; use_simpobs.
+  - rewrite H. rewrite interp_state_tau. pfold. constructor. right. eapply CIH; eauto.
+  - rewrite H. rewrite interp_state_vis.
+    destruct (classic_empty B).
+    + specialize (Hhandler _ e). destruct Hhandler; try contradiction; try contra_size.
+      specialize (DIVCHECK s). eapply paco1_mon with (r:= bot1). eapply diverges_with_bind; eauto.
+      intros; contradiction.
+    + specialize (Hhandler _ e). destruct Hhandler; try contradiction; try contra_size.
+      specialize (FINCHECK s). induction FINCHECK.
+      * rewrite bind_ret_l. cbn. pfold. constructor. right. eapply CIH; eauto. apply H0.
+      * rewrite bind_tau. pfold. constructor. left. eapply IHFINCHECK; eauto.
+      * destruct H5. rewrite bind_vis. pfold. constructor; auto. left. eapply H4; eauto.
+Qed.
+*)
+Lemma diverges_with_bind : forall E R S P (t : itree E R) (k : R -> itree E S),
+    diverges_with P t -> diverges_with P (ITree.bind t k).
+Proof.
+  intros E R1 R2 P. pcofix CIH.
+  intros t k Ht. punfold Ht. pfold. red.
+  unfold observe. cbn. red in Ht. inv Ht.
+  - cbn. constructor. right. pclearbot. eapply CIH; eauto.
+  - pclearbot. cbn. constructor; auto. right. eapply CIH; eauto. apply H0.
+Qed.
+
+Lemma interp_pi_eqit_secure_state : forall (R1 R2 : Type) (RR : R1 -> R2 -> Prop) (t1 : itree E1 R1) (t2 : itree E1 R2),
+    pi_eqit_secure Label priv1 RR true true l t1 t2 ->
+    state_pi_eqit_secure true true RR (interp_state handler t1) (interp_state handler t2).
+Proof.
+  intros R1 R2 RR. ginit. gcofix CIH. intros t1 t2 Ht s1 s2 Hs. punfold Ht.
+  red in Ht.
+  inv Ht; intros; use_simpobs.
+  - rewrite H, H0. repeat rewrite interp_state_ret. gstep. constructor.
+    split; auto.
+  - rewrite H, H0. repeat rewrite interp_state_tau. gstep. constructor.
+    gfinal. left. pclearbot. apply CIH; auto.
+  - pclearbot. rewrite H. rewrite interp_state_tau. gstep. constructor; auto.
+    gfinal. left. eapply CIH; eauto. apply simpobs in H0. rewrite <- itree_eta in H0.
+    rewrite H0. auto.
+  - pclearbot. rewrite H0. rewrite interp_state_tau. gstep. constructor; auto.
+    gfinal. left. eapply CIH; eauto. apply simpobs in H. rewrite <- itree_eta in H.
+    rewrite H. auto.
+  - pclearbot. rewrite H, H0.
+    repeat rewrite interp_state_vis.
+    specialize (Hhandler A e). inv Hhandler; try contradiction.
+    eapply pi_secure_eqit_bind'; eauto.
+    intros. destruct H2; destruct r1; destruct r2; cbn in *; subst.
+    pfold. constructor. right. eapply CIH; eauto. apply H1.
+  - rewrite H, H0. pclearbot. rewrite interp_state_tau.
+    gstep. constructor; auto. rewrite interp_state_vis.
+    specialize (Hhandler A e). inv Hhandler; try contradiction.
+    red in RESCHECK. apply RESCHECK in Hs as He.
+    remember (handler A e s1) as t3. clear Heqt3.
+    cbn in He. generalize dependent t3. gcofix CIH'.
+    intros t3 Ht3. pinversion Ht3; use_simpobs; subst.
+    + destruct H4. cbn in *. destruct r1. cbn in *.
+      rewrite H2. rewrite bind_ret_l. gstep. constructor; auto.
+      gfinal. left. eapply CIH'0. eapply CIH; eauto. cbn. apply H1.
+    + rewrite H2. rewrite bind_tau. gstep; constructor; auto.
+      gfinal. left. eapply CIH'; eauto. symmetry in H3. use_simpobs.
+      rewrite <- H3. auto.
+    + rewrite H2. rewrite bind_vis. gstep. constructor; auto.
+      intros. gfinal. left. eapply CIH'; eauto. symmetry in H3.
+      use_simpobs. rewrite <- H3. apply H4.
+ - rewrite H, H0. pclearbot. rewrite interp_state_tau.
+    gstep. constructor; auto. rewrite interp_state_vis.
+    specialize (Hhandler A e). inv Hhandler; try contradiction.
+    red in RESCHECK. symmetry in Hs. apply RESCHECK in Hs as He.
+    remember (handler A e s2) as t3. clear Heqt3.
+    cbn in He. generalize dependent t3. gcofix CIH'.
+    intros t3 Ht3. pinversion Ht3; use_simpobs; subst.
+    + destruct H4. cbn in *. destruct r1. cbn in *.
+      rewrite H2. rewrite bind_ret_l. gstep. constructor; auto.
+      gfinal. left. eapply CIH'0. eapply CIH; eauto. cbn. apply H1.
+      symmetry. auto.
+    + rewrite H2. rewrite bind_tau. gstep; constructor; auto.
+      gfinal. left. eapply CIH'; eauto. symmetry in H3. use_simpobs.
+      rewrite <- H3. auto.
+    + rewrite H2. rewrite bind_vis. gstep. constructor; auto.
+      intros. gfinal. left. eapply CIH'; eauto. symmetry in H3.
+      use_simpobs. rewrite <- H3. apply H4.
+ - pclearbot. rewrite H, H0. repeat rewrite interp_state_vis.
+   specialize (Hhandler A e1) as He1. specialize (Hhandler B e2) as He2.
+   inv He1; inv He2; try contradiction.
+   eapply pi_secure_eqit_bind' with (RR := prod_rel RS top2); eauto.
+   + intros [? ?] [? ?] [? ?]. cbn in *. pstep. constructor.
+     right. eapply CIH; eauto. apply H1.
+   + cbn in *. apply pi_eqit_secure_RR_imp with
+                   (RR1 := rcompose (prod_rel RS (@top2 A unit)) (prod_rel RS top2) ).
+     { intros. inv H2. destruct REL1. destruct REL2. split; auto.
+       etransitivity; eauto. }
+     eapply pi_eqit_secure_trans_ret; eauto.
+     apply pi_eqit_secure_sym. apply pi_eqit_secure_RR_imp with
+                                   (RR1 := prod_rel RS top2).
+     { intros. inv H2. split; auto. symmetry. auto.  }
+     eapply RESCHECK0. reflexivity.
+ - apply simpobs in H0. rewrite <- itree_eta in H0. rewrite H0.
+   rewrite H. rewrite interp_state_vis.
+   specialize (Hhandler A e). inv Hhandler; try contradiction.
+   red in RESCHECK. apply RESCHECK in Hs as He.
+    remember (handler A e s1) as t3. clear Heqt3.
+    cbn in He. generalize dependent t3. gcofix CIH'.
+    intros t3 Ht3. pinversion Ht3; use_simpobs; subst.
+    + destruct H4. cbn in *. destruct r1. cbn in *.
+      rewrite H2. rewrite bind_ret_l. gstep. constructor; auto.
+      gfinal. left. eapply CIH; eauto. cbn. apply H1.
+    + rewrite H2. rewrite bind_tau. gstep; constructor; auto.
+      gfinal. left. eapply CIH'; eauto. symmetry in H3. use_simpobs.
+      rewrite <- H3. auto.
+    + rewrite H2. rewrite bind_vis. gstep. constructor; auto.
+      intros. gfinal. left. eapply CIH'; eauto. symmetry in H3.
+      use_simpobs. rewrite <- H3. apply H4.
+ - apply simpobs in H. rewrite <- itree_eta in H. rewrite H.
+   pclearbot. rewrite H0. rewrite interp_state_vis.
+   specialize (Hhandler A e). inv Hhandler; try contradiction.
+    red in RESCHECK. symmetry in Hs. apply RESCHECK in Hs as He.
+    remember (handler A e s2) as t3. clear Heqt3.
+    cbn in He. generalize dependent t3. gcofix CIH'.
+    intros t3 Ht3. pinversion Ht3; use_simpobs; subst.
+    + destruct H4. cbn in *. destruct r1. cbn in *.
+      rewrite H2. rewrite bind_ret_l. gstep. constructor; auto.
+      gfinal. left. cbn. eapply CIH; eauto. cbn. apply H1.
+      symmetry. auto.
+    + rewrite H2. rewrite bind_tau. gstep; constructor; auto.
+      gfinal. left. eapply CIH'; eauto. symmetry in H3. use_simpobs.
+      rewrite <- H3. auto.
+    + rewrite H2. rewrite bind_vis. gstep. constructor; auto.
+      intros. gfinal. left. eapply CIH'; eauto. symmetry in H3.
+      use_simpobs. rewrite <- H3. apply H4.
+Qed.
+
+End GeneralStateHandler.

--- a/theories/Secure/StrongBisimProper.v
+++ b/theories/Secure/StrongBisimProper.v
@@ -1,0 +1,20 @@
+From Coq Require Import Morphisms.
+
+From ITree Require Import
+     ITree
+     ITreeFacts
+     Eq.EqAxiom
+.
+
+From Paco Require Import paco.
+
+(* Tau t ≈ t*)
+(* eqit_secure (Vis e k)  (k a) *)
+
+(* r => fun (f g : A -> B) => f = g*)
+Global Instance strong_bisim_proper_paco {E R1 R2 F r} :
+       Proper (@eq_itree E R1 R1 eq ==> @eq_itree E R2 R2 eq ==> flip impl) (paco2 F r).
+Proof.
+  repeat intro. apply bisimulation_is_eq in H. apply bisimulation_is_eq in H0.
+  subst. auto.
+Qed.

--- a/tutorial/AsmOptimization.v
+++ b/tutorial/AsmOptimization.v
@@ -143,13 +143,13 @@ Proof.
     reflexivity.
   }
   intros.
-  inversion H; subst.
-  inversion H3; subst.
+  destruct H as [J1 [J2 J3]]; subst.
   unfold interp_asm.
   unfold interp_map.
+  destruct u2 as [? [? []]].
   rewrite interp_ret.
   do 2 rewrite interp_state_ret.
-  apply eqit_Ret. destruct b3. auto.
+  apply eqit_Ret. auto.
 Qed.
 
 Lemma interp_asm_ret {E A} (x:A) mem reg :
@@ -333,7 +333,8 @@ Section Correctness.
     eapply eutt_clo_bind.
     apply H2; auto.
     intros.
-    inversion H0; subst. inversion H3; subst.
+    destruct H0 as [J1 [J2 J3]].
+    destruct u1 as [? [? []]], u2 as [? [? []]]. cbn in *.
     apply HP; auto.
   Qed.
 
@@ -411,41 +412,40 @@ Proof.
        repeat rewrite interp_ret.
        repeat rewrite interp_state_ret.
        apply eqit_Ret. constructor; auto. 
-    -  intros. inversion H0.
+    -  intros. destruct H0 as [J1 [J2 J3]].
        subst. cbn.
        unfold CategorySub.from_bif, FromBifunctor_ktree_fin.
        repeat rewrite interp_ret.
        repeat rewrite interp_state_ret.
        apply eqit_Ret.
-       inversion H4; subst.
-       constructor; auto. }
+       constructor; cbn; auto. constructor; cbn; auto.
+       rewrite J3. reflexivity. }
 
   intros.
-  inversion H0; subst.
+  destruct H0 as [J1 [J2 J3]]; subst.
   simpl in *.
   unfold denote_bks.
   unfold iter, CategorySub.Iter_sub.
   repeat rewrite interp_iter.
   unfold iter, Iter_Kleisli.
   cbn.
-  pose proof @interp_state_iter'.
-  red in H5.
+  assert (JJ := @interp_state_iter').
+  red in JJ.
   unfold Basics.iter, MonadIter_stateT0, Basics.iter, MonadIter_itree in *.
   cbn in *.
-  repeat rewrite H5.
+  repeat rewrite JJ.
 
-  eapply eutt_iter' with (RI := rel_asm); cbn.
-  2: destruct H4; auto.
-  intros j1 j2 [ ? ? ? ? ? [? ? ? ? ? []]]; cbn.
+  eapply eutt_iter' with (RI := rel_asm); cbn; auto.
+  intros j1 j2 [K1 [K2 ->]]; cbn.
   rewrite !interp_bind, !interp_state_bind, !bind_bind. (* Slow! *)
 
   apply (@eutt_clo_bind _ _ _ _ _ _ rel_asm);
-    [|intros ? ? [? ? ? ? ? [? ? ? ? ? []]]]; cbn.
+    [|intros ? ? [? [? ->]]]; cbn.
   { eapply @peephole_block_correct; eauto. }
 
   unfold CategorySub.to_bif, ToBifunctor_ktree_fin.
   apply (@eutt_clo_bind _ _ _ _ _ _ rel_asm);
-    [|intros ? ? [? ? ? ? ? [? ? ? ? ? []]]]; cbn.
+    [|intros ? ? [? [? ->]]]; cbn.
   {
     rewrite bind_ret_l.
     unfold case_, Case_sum1, Case_Kleisli, case_sum.
@@ -537,7 +537,7 @@ Proof.
       rewrite tau_eutt, 2 interp_state_ret.
       apply eqit_Ret.
       constructor; auto; constructor; auto.
-      auto using EQ_registers_add.
+      cbn; auto using EQ_registers_add.
     * apply Nat.eqb_neq in n.
       rewrite n.
       apply interp_asm_ret_tt; auto.


### PR DESCRIPTION
The final of three pull requests intended to bring the secure branch into master. This pull request contains all of the code included in the trace and dijkstra_pull_request branches, but it focuses on a mechanization of two information flow indistinguishability relations over ITrees, eqit_secure and pi_eqit_secure. The former formalizes progress sensitive indistinguishability and the latter formalizes progress insensitive indistinguishability.

This pull request also formalizes a bunch of meta theory about these relations, for instance progress sensitive indistinguishability lifts PERs over return types to PER's over ITrees. It also includes two verified information flow type systems for Imp (with print + exceptions) and a proof that a compiler from Imp to Asm preserves noninterference.