### PR TITLE
rutt: swapping order of constructors and couple of simplifications

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,20 +67,17 @@ workflows:
   build:
     jobs:
     - test:
-        name: "Coq 8.10"
-        coq: "8.10"
-    - test:
-        name: "Coq 8.11"
-        coq: "8.11"
-    - test:
         name: "Coq 8.12"
         coq: "8.12"
     - test:
         name: "Coq 8.13"
         coq: "8.13"
     - test:
+        name: "Coq 8.14"
+        coq: "8.14"
+    - test:
         name: "Coq dev"
         coq: "dev"
     - test-with-make:
-        name: "Coq 8.13 + make"
-        coq: "8.13"
+        name: "Coq 8.14 + make"
+        coq: "8.14"

--- a/theories/Eq/Rutt.v
+++ b/theories/Eq/Rutt.v
@@ -25,7 +25,6 @@ From ITree Require Import
      ITreeFacts
 .
 
-
 From Paco Require Import paco.
 
 Import Monads.
@@ -34,56 +33,51 @@ Local Open Scope monad_scope.
 
 Section RuttF.
 
-Context {E1 E2 : Type -> Type}.
-Context {R1 R2 : Type}.
-(* From the point of view of relational parametricity, it would be more fitting
+  Context {E1 E2 : Type -> Type}.
+  Context {R1 R2 : Type}.
+  (* From the point of view of relational parametricity, it would be more fitting
   to replace [(REv, RAns)] with one [REv : forall A1 A2, (A1 -> A2 -> Prop) -> (E1 A1 -> E2 A2 -> Prop)].
   Contributions to that effect are welcome. *)
-Context (REv : forall (A B : Type), E1 A -> E2 B -> Prop ).
-Context (RAns : forall (A B : Type), E1 A -> A -> E2 B -> B -> Prop ).
-Context (RR : R1 -> R2 -> Prop).
-Arguments REv {A} {B}.
-Arguments RAns {A} {B}.
+  Context (REv : forall (A B : Type), E1 A -> E2 B -> Prop ).
+  Context (RAns : forall (A B : Type), E1 A -> A -> E2 B -> B -> Prop ).
+  Context (RR : R1 -> R2 -> Prop).
+  Arguments REv {A} {B}.
+  Arguments RAns {A} {B}.
 
-Inductive ruttF
-          (vclo : (itree E1 R1 -> itree E2 R2 -> Prop) -> itree E1 R1 -> itree E2 R2 -> Prop)
-          (sim : itree E1 R1 -> itree E2 R2 -> Prop) : itree' E1 R1 -> itree' E2 R2 -> Prop :=
-  | EqRet : forall (r1 : R1) (r2 : R2), RR r1 r2 -> ruttF vclo sim (RetF r1) (RetF r2)
-  | EqTau : forall (m1 : itree E1 R1) (m2 : itree E2 R2), sim m1 m2 -> ruttF vclo sim (TauF m1) (TauF m2)
-  | EqTauL : forall (t1 : itree E1 R1) (ot2 : itree' E2 R2),
-      ruttF vclo sim (observe t1) ot2 -> ruttF vclo sim (TauF t1) ot2
-  | EqTauR : forall (ot1 : itree' E1 R1) (t2 : itree E2 R2),
-      ruttF vclo sim ot1 (observe t2) -> ruttF vclo sim ot1 (TauF t2)
+  Inductive ruttF (sim : itree E1 R1 -> itree E2 R2 -> Prop) : itree' E1 R1 -> itree' E2 R2 -> Prop :=
+  | EqRet : forall (r1 : R1) (r2 : R2),
+      RR r1 r2 ->
+      ruttF sim (RetF r1) (RetF r2)
+  | EqTau : forall (m1 : itree E1 R1) (m2 : itree E2 R2),
+      sim m1 m2 ->
+      ruttF sim (TauF m1) (TauF m2)
   | EqVis : forall (A B : Type) (e1 : E1 A) (e2 : E2 B ) (k1 : A -> itree E1 R1) (k2 : B -> itree E2 R2),
       REv e1 e2 ->
-      (forall (a : A) (b : B), RAns e1 a e2 b -> vclo sim (k1 a) (k2 b) : Prop) -> ruttF vclo sim (VisF e1 k1) (VisF e2 k2).
-Hint Constructors ruttF.
+      (forall (a : A) (b : B), RAns e1 a e2 b -> sim (k1 a) (k2 b)) ->
+      ruttF sim (VisF e1 k1) (VisF e2 k2)
+  | EqTauL : forall (t1 : itree E1 R1) (ot2 : itree' E2 R2),
+      ruttF sim (observe t1) ot2 ->
+      ruttF sim (TauF t1) ot2
+  | EqTauR : forall (ot1 : itree' E1 R1) (t2 : itree E2 R2),
+      ruttF sim ot1 (observe t2) ->
+      ruttF sim ot1 (TauF t2).
+  Hint Constructors ruttF : core.
 
-Definition rutt_ (vclo : (itree E1 R1 -> itree E2 R2 -> Prop) -> itree E1 R1 -> itree E2 R2 -> Prop )
-           (sim : itree E1 R1 -> itree E2 R2 -> Prop) (t1 : itree E1 R1) (t2 : itree E2 R2) :=
-  ruttF vclo sim (observe t1) (observe t2).
-Hint Unfold rutt_.
-Lemma rutt_monot (vclo : (itree E1 R1 -> itree E2 R2 -> Prop) -> itree E1 R1 -> itree E2 R2 -> Prop):
-  (monotone2 vclo) -> monotone2 (rutt_ vclo).
-Proof.
-  intros. red in H. red. intros. red. red in IN. induction IN; eauto.
-Qed.
+  Definition rutt_ (sim : itree E1 R1 -> itree E2 R2 -> Prop)
+             (t1 : itree E1 R1) (t2 : itree E2 R2) :=
+    ruttF sim (observe t1) (observe t2).
+  Hint Unfold rutt_ : core.
 
+  Lemma rutt_monot : monotone2 rutt_.
+  Proof.
+    red. intros. red; induction IN; eauto.
+  Qed.
 
-
-Lemma rutt_id_monot : monotone2 (@id (itree E1 R1 -> itree E2 R2 -> Prop) ).
-Proof. auto. Qed.
-
-
-
-Definition rutt : itree E1 R1 -> itree E2 R2 -> Prop := paco2 (rutt_ id) bot2.
+  Definition rutt : itree E1 R1 -> itree E2 R2 -> Prop := paco2 rutt_ bot2.
 
 End RuttF.
 
-
-Hint Resolve rutt_monot : paco.
-
-Hint Resolve rutt_id_monot : paco.
+#[export] Hint Resolve rutt_monot : paco.
 
 Lemma rutt_inv_tauL {E1 E2 R1 R2 REv RAns RR} t1 t2 :
   @rutt E1 E2 R1 R2 REv RAns RR (Tau t1) t2 -> rutt REv RAns RR t1 t2.
@@ -119,53 +113,55 @@ Proof.
 Qed.
 
 Lemma rutt_inv_tauLR  {E1 E2 R1 R2 REv RAns RR} t1 t2 :
-   @rutt E1 E2 R1 R2 REv RAns RR (Tau t1) (Tau t2) -> rutt REv RAns RR t1 t2.
+  @rutt E1 E2 R1 R2 REv RAns RR (Tau t1) (Tau t2) -> rutt REv RAns RR t1 t2.
 Proof.
   intros; apply rutt_inv_tauR, rutt_inv_tauL; assumption.
 Qed.
 
-Section eqitC_rutt.
+Section euttge_trans_clo.
+
   Context {E1 E2 : Type -> Type} {R1 R2 : Type} (RR : R1 -> R2 -> Prop).
-  (* Question, is it a problem that I don't have the booleans, is that necessary?
-     Would be simple to add but would necessitate some busy work *)
+
+  (* Closing a relation over itrees under [euttge].
+     Essentially the same closure as [eqit_trans_clo], but heterogeneous
+     in the interface argument [E].
+     We only define the closure under [euttge] as opposed to [eqit_trans_clo]
+     capturing closure under [eq_itree] and [eutt] at the same time, since it's
+     the only one we need.
+   *)
 
   (* A transitivity functor *)
-  Variant eqit_trans_clo  (b1 b2 b1' b2' : bool)  (r : itree E1 R1 -> itree E2 R2 -> Prop) :
+  Variant euttge_trans_clo (r : itree E1 R1 -> itree E2 R2 -> Prop) :
     itree E1 R1 -> itree E2 R2 -> Prop :=
     eqit_trans_clo_intro t1 t2 t1' t2' RR1 RR2
-      (EQVl: eqit RR1 b1 b1' t1 t1')
-      (EQVr: eqit RR2 b2 b2' t2 t2')
-      (REL: r t1' t2')
-      (LERR1: forall x x' y, RR1 x x' -> RR x' y -> RR x y)
-      (LERR2: forall x y y', RR2 y y' -> RR x y' -> RR x y) :
-      eqit_trans_clo b1 b2 b1' b2' r t1 t2.
-  Hint Constructors eqit_trans_clo : core.
-  (* sets directionality *)
-  Definition eqitC_rutt b1 b2 := eqit_trans_clo b1 b2 false false.
-  Hint Unfold eqitC_rutt : core.
+                         (EQVl: euttge RR1 t1 t1')
+                         (EQVr: euttge RR2 t2 t2')
+                         (REL: r t1' t2')
+                         (LERR1: forall x x' y, RR1 x x' -> RR x' y -> RR x y)
+                         (LERR2: forall x y y', RR2 y y' -> RR x y' -> RR x y) :
+      euttge_trans_clo r t1 t2.
+  Hint Constructors euttge_trans_clo : core.
 
-  Lemma eqitC_rutt_mon b1 b2 r1 r2 t1 t2
-    (IN : eqitC_rutt b1 b2 r1 t1 t2)
-    (LE : r1 <2= r2) :
-    eqitC_rutt b1 b2 r2 t1 t2.
+  Lemma euttge_trans_clo_mon r1 r2 t1 t2
+        (IN : euttge_trans_clo r1 t1 t2)
+        (LE : r1 <2= r2) :
+    euttge_trans_clo r2 t1 t2.
   Proof.
     destruct IN; econstructor; eauto.
   Qed.
 
-  Hint Resolve eqitC_rutt_mon : paco.
+  Hint Resolve euttge_trans_clo_mon : paco.
 
-End eqitC_rutt.
+End euttge_trans_clo.
 
 (*replicate this proof for the models functor*)
-Lemma eqitC_rutt_wcompat (b1 b2 : bool) E1 E2 R1 R2 (REv : forall A B, E1 A -> E2 B -> Prop)
-      (RAns : forall A B, E1 A -> A -> E2 B -> B -> Prop ) (RR : R1 -> R2 -> Prop)
-     (vclo: (itree E1 R1 -> itree E2 R2 -> Prop) -> (itree E1 R1 -> itree E2 R2 -> Prop) )
-     (MON: monotone2 vclo)
-      (CMP: compose (eqitC_rutt RR b1 b2) vclo <3= compose vclo (eqitC_rutt RR b1 b2)) :
-  wcompatible2 (Rutt.rutt_ REv RAns RR vclo) (eqitC_rutt RR b1 b2).
+(* Validity of the up-to [euttge] principle *)
+Lemma euttge_trans_clo_wcompat E1 E2 R1 R2 (REv : forall A B, E1 A -> E2 B -> Prop)
+      (RAns : forall A B, E1 A -> A -> E2 B -> B -> Prop ) (RR : R1 -> R2 -> Prop) :
+  wcompatible2 (rutt_ REv RAns RR) (euttge_trans_clo RR).
 Proof.
   constructor; eauto with paco.
-  { red. intros. eapply eqitC_rutt_mon; eauto. }
+  { red. intros. eapply euttge_trans_clo_mon; eauto. }
   intros.
   destruct PR. punfold EQVl. punfold EQVr. unfold_eqit.
   hinduction REL before r; intros; clear t1' t2'.
@@ -177,44 +173,46 @@ Proof.
     remember (TauF m3) as y.
     hinduction EQVr before r; intros; subst; try inv Heqy; try inv CHECK; (try (constructor; eauto; fail)).
     pclearbot. constructor. gclo. econstructor; eauto with paco.
-  - remember (TauF t1) as x. red.
-    hinduction EQVl before r; intros; subst; try inv Heqx; try inv CHECK; (try (constructor; eauto; fail)).
-    pclearbot. punfold REL. constructor. eapply IHREL; eauto.
-  - remember (TauF t2) as y. red.
-    hinduction EQVr before r; intros; subst; try inv Heqy; try inv CHECK; (try (constructor; eauto; fail)).
-    pclearbot. punfold REL. constructor. eapply IHREL; eauto.
   - remember (VisF e1 k1) as x. red.
     hinduction EQVl before r; intros; subst; try discriminate; try (constructor; eauto; fail).
     remember (VisF e2 k3) as y.
     hinduction EQVr before r; intros; subst; try discriminate; try (constructor; eauto; fail).
     dependent destruction Heqx.
     dependent destruction Heqy.
-    constructor; auto. intros. apply H0 in H1. pclearbot. eapply MON.
-    + eapply CMP. red. econstructor; eauto.
-    + intros. apply gpaco2_clo; auto.
+    constructor; auto. intros. apply H0 in H1. pclearbot.
+    apply gpaco2_clo.
+    econstructor; eauto.
+  - remember (TauF t1) as x. red.
+    hinduction EQVl before r; intros; subst; try inv Heqx; try inv CHECK; (try (constructor; eauto; fail)).
+    pclearbot. punfold REL. constructor. eapply IHREL; eauto.
+  - remember (TauF t2) as y. red.
+    hinduction EQVr before r; intros; subst; try inv Heqy; try inv CHECK; (try (constructor; eauto; fail)).
+    pclearbot. punfold REL. constructor. eapply IHREL; eauto.
 Qed.
 
-Definition eqitC_rutt_wcompat' := eqitC_rutt_wcompat true true.
+#[export] Hint Resolve euttge_trans_clo_wcompat : paco.
 
-Hint Resolve (eqitC_rutt_wcompat') : paco.
-
-Global Instance grutt_cong_eqit {R1 R2 : Type} {E1 E2 : Type -> Type} {REv : forall A B, E1 A -> E2 B -> Prop}
-      {RAns : forall A B, E1 A -> A -> E2 B -> B -> Prop} {RR1 RR2} {RS : R1 -> R2 -> Prop} r rg
-      (LERR1: forall x x' y, (RR1 x x': Prop) -> (RS x' y: Prop) -> RS x y)
+(* The validity of the up-to [euttge] entails we can rewrite under [euttge]
+   and hence also [eq_itree] during coinductive proofs of [rutt]
+*)
+#[global] Instance grutt_cong_eqit {R1 R2 : Type} {E1 E2 : Type -> Type} {REv : forall A B, E1 A -> E2 B -> Prop}
+       {RAns : forall A B, E1 A -> A -> E2 B -> B -> Prop} {RR1 RR2} {RS : R1 -> R2 -> Prop} r rg
+       (LERR1: forall x x' y, (RR1 x x': Prop) -> (RS x' y: Prop) -> RS x y)
        (LERR2: forall x y y', (RR2 y y': Prop) -> RS x y' -> RS x y) :
-    Proper (eq_itree RR1 ==> eq_itree RR2 ==> flip impl)
-         (gpaco2 (Rutt.rutt_ REv RAns RS id) (eqitC_rutt RS true true) r rg).
+  Proper (eq_itree RR1 ==> eq_itree RR2 ==> flip impl)
+         (gpaco2 (rutt_ REv RAns RS) (euttge_trans_clo RS) r rg).
 Proof.
   repeat intro. gclo. econstructor; eauto;
-  try eapply eqit_mon; try apply H; try apply H0; auto.
+    try eapply eqit_mon; try apply H; try apply H0; auto.
 Qed.
 
 Global Instance grutt_cong_euttge {R1 R2 : Type} {E1 E2 : Type -> Type} {REv : forall A B, E1 A -> E2 B -> Prop}
-      {RAns : forall A B, E1 A -> A -> E2 B -> B -> Prop} {RR1 RR2} {RS : R1 -> R2 -> Prop} r rg
-      (LERR1: forall x x' y, (RR1 x x': Prop) -> (RS x' y: Prop) -> RS x y)
+       {RAns : forall A B, E1 A -> A -> E2 B -> B -> Prop} {RR1 RR2} {RS : R1 -> R2 -> Prop} r rg
+       (LERR1: forall x x' y, (RR1 x x': Prop) -> (RS x' y: Prop) -> RS x y)
        (LERR2: forall x y y', (RR2 y y': Prop) -> RS x y' -> RS x y) :
-    Proper (euttge RR1 ==> euttge RR2 ==> flip impl)
-         (gpaco2 (Rutt.rutt_ REv RAns RS id) (eqitC_rutt RS true true) r rg).
+  Proper (euttge RR1 ==> euttge RR2 ==> flip impl)
+         (gpaco2 (rutt_ REv RAns RS) (euttge_trans_clo RS) r rg).
 Proof.
   repeat intro. gclo. econstructor; eauto.
 Qed.
+ 

--- a/theories/ITrace/ITraceBind.v
+++ b/theories/ITrace/ITraceBind.v
@@ -21,7 +21,7 @@ Import Monads.
 Import MonadNotation.
 Local Open Scope monad_scope.
 
-(* Contains the proof of peel_lemma which allows us 
+(* Contains the proof of peel_lemma which allows us
    to decompose a trace of bind t f into a head that refines t and a tail
    that refines f *)
 
@@ -35,12 +35,12 @@ Proof.
 Qed.
 
 Definition peel_vis {E R S A B} (e0 : E A) (a : A) (k0 : unit -> itrace E R)
-           (e1 : E B) (k1 : B -> itree E S) 
+           (e1 : E B) (k1 : B -> itree E S)
            (peel : itrace' E R -> itree' E S -> itrace E S) : itrace E S.
 Proof.
-destruct (classicT (A = B) ).
-- subst. apply (Vis (evans _ e0 a) (fun _ => peel (observe (k0 tt)) (observe (k1 a) ) ) ).
-- apply ITree.spin.
+  destruct (classicT (A = B) ).
+  - subst. apply (Vis (evans _ e0 a) (fun _ => peel (observe (k0 tt)) (observe (k1 a) ) ) ).
+  - apply ITree.spin.
 Defined.
 
 CoFixpoint peel_ {E R S} (ob : itrace' E R) (ot : itree' E S) : itrace E S :=
@@ -52,39 +52,39 @@ CoFixpoint peel_ {E R S} (ob : itrace' E R) (ot : itree' E S) : itrace E S :=
   | VisF (evempty _ Hempty e) _ , _ => Vis (evempty _ Hempty e) (fun v : void => match v with end)
   (* The type of this is problematic need some tricky dependently typed programming
      in order to have this work
-  *)
+   *)
 
   | VisF (evans _ e0 a) k0, VisF e1 k1 => peel_vis e0 a k0 e1 k1 peel_
-  | _, _ => ITree.spin 
+  | _, _ => ITree.spin
   end.
 
 Definition peel {E R S} (b : itrace E R) (t : itree E S) : itrace E S :=
   peel_ (observe b) (observe t).
 (* here is a sketchy axiom use *)
 Definition peel_cont_vis {E R S A B} (e0 : E A) (a : A) (k0 : unit -> itrace E R)
-           (e1 : E B) (k1 : B -> itree E S) 
+           (e1 : E B) (k1 : B -> itree E S)
            (peel : itrace' E R -> itree' E S -> itrace E R) : itrace E R.
 Proof.
-destruct (classicT (A = B) ).
-- subst. apply (Tau (peel (observe (k0 tt)) (observe (k1 a) ) ) ).
-- apply ITree.spin.
+  destruct (classicT (A = B) ).
+  - subst. apply (Tau (peel (observe (k0 tt)) (observe (k1 a) ) ) ).
+  - apply ITree.spin.
 Defined.
 
 (*Actually I may be able to remove this ugly bs. I think I really only use peel*)
 CoFixpoint peel_cont_ {E R S} (ob : itrace' E R) (ot : itree' E S) : itrace E R :=
   match ot with
   | RetF _ => go ob
-  | TauF t => match ob with 
-                   | TauF b => Tau (peel_cont_ (observe b) (observe t))
-                   | ob => Tau (peel_cont_ ob (observe t)  )
-                   end
-  | VisF e1 k1 => match ob with 
-                       | TauF b => Tau (peel_cont_ (observe b) ot)
-                       | VisF (evempty _ Hempty e) _ => 
-                         ITree.spin
-                       | VisF (evans _ e0 a) k0 => peel_cont_vis e0 a k0 e1 k1 peel_cont_
-                       | _ => ITree.spin
-                       end
+  | TauF t => match ob with
+             | TauF b => Tau (peel_cont_ (observe b) (observe t))
+             | ob => Tau (peel_cont_ ob (observe t)  )
+             end
+  | VisF e1 k1 => match ob with
+                 | TauF b => Tau (peel_cont_ (observe b) ot)
+                 | VisF (evempty _ Hempty e) _ =>
+                     ITree.spin
+                 | VisF (evans _ e0 a) k0 => peel_cont_vis e0 a k0 e1 k1 peel_cont_
+                 | _ => ITree.spin
+                 end
   end.
 
 Definition peel_cont {E R S} (b : itrace E R) (t : itree E S) : S -> itrace E R :=
@@ -92,7 +92,7 @@ Definition peel_cont {E R S} (b : itrace E R) (t : itree E S) : S -> itrace E R 
 
 
 Lemma refine_ret_vis_contra : forall (E: Type -> Type) (R A: Type)
-                     (r : R) (e : E A) (k : A -> itree E R),
+                                (r : R) (e : E A) (k : A -> itree E R),
     ~ (Ret r ⊑ Vis e k).
 Proof.
   intros. intro Hcontra. pinversion Hcontra.
@@ -107,7 +107,7 @@ Lemma peel_t_ret : forall E R S (b : itrace E S) (t : itree E R) r, t ≅ Ret r 
 Proof.
   intros.  unfold peel.
   pinversion H; subst; try inv CHECK.
-  destruct (observe b); cbn; auto. 
+  destruct (observe b); cbn; auto.
   - pfold. red. cbn. constructor. auto.
   - pfold. red. cbn. constructor; auto.
   - pfold. red. cbn. simpl. destruct e.
@@ -119,8 +119,8 @@ Qed.
 (*doing these proofs, may require some techniques you don't really know*)
 
 Lemma peel_refine_t : forall (E : Type -> Type) (R S : Type)
-                  (b : itrace E S) (t : itree E R) (f : R -> itree E S)
-     (Hrutt : b ⊑ ITree.bind t f),
+                        (b : itrace E S) (t : itree E R) (f : R -> itree E S)
+                        (Hrutt : b ⊑ ITree.bind t f),
     peel b t ⊑ t.
 Proof.
   intros E R S b t f. generalize dependent b. generalize dependent t.
@@ -140,12 +140,16 @@ Proof.
       apply eq_sub_eutt in x0. apply eq_sub_eutt in Heq.
       rewrite tau_eutt in Heq. rewrite tau_eutt in x0.
       rewrite <- Heq. rewrite x. rewrite tau_eutt. auto.
+    + exfalso. symmetry in Heq. apply simpobs in Heq.
+      apply simpobs in x.
+      rewrite Heq in x. rewrite bind_tau in x. pinversion x.
+      inv CHECK.
     + rewrite <- x. cbn. constructor. right. eapply CIH.
       clear IHHrutt. symmetry in Heq. apply simpobs in Heq.
       apply eq_sub_eutt in Heq. rewrite tau_eutt in Heq.
       rewrite <- Heq. pfold. auto.
     + cbn. destruct (observe b) eqn : Heq'.
-      * cbn. rewrite <- Heq'. constructor. right. eapply CIH. 
+      * cbn. rewrite <- Heq'. constructor. right. eapply CIH.
         symmetry in Heq'.
         apply simpobs in Heq'. rewrite Heq'.
         symmetry in Heq. apply simpobs in Heq.
@@ -153,43 +157,35 @@ Proof.
         rewrite <- Heq. apply simpobs in x. rewrite x.
         rewrite tau_eutt. pfold. auto.
       * cbn. clear IHHrutt.
-        constructor. right. eapply CIH. 
+        constructor. right. eapply CIH.
         symmetry in Heq. apply simpobs in Heq.
         apply eq_sub_eutt in Heq. rewrite tau_eutt in Heq.
         rewrite <- Heq.
         apply simpobs in x. apply eq_sub_eutt in x.
         rewrite tau_eutt in x. rewrite x.
-        enough (Tau t1 ⊑ t2). 
+        enough (Tau t1 ⊑ t2).
         { rewrite tau_eutt in H. auto. }
         pfold. auto.
       * destruct e; cbn.
         ++ constructor. right. rewrite <- Heq'. clear IHHrutt.
            eapply CIH. symmetry in Heq.
-           apply simpobs in Heq. apply eq_sub_eutt in Heq. 
+           apply simpobs in Heq. apply eq_sub_eutt in Heq.
            rewrite tau_eutt in Heq. apply simpobs in x.
            apply eq_sub_eutt in x. rewrite tau_eutt in x.
            rewrite <- Heq. rewrite x. pfold. red.
            rewrite Heq'. auto.
         ++ constructor. right. rewrite <- Heq'. clear IHHrutt.
            eapply CIH. symmetry in Heq.
-           apply simpobs in Heq. apply eq_sub_eutt in Heq. 
+           apply simpobs in Heq. apply eq_sub_eutt in Heq.
            rewrite tau_eutt in Heq. apply simpobs in x.
            apply eq_sub_eutt in x. rewrite tau_eutt in x.
            rewrite <- Heq. rewrite x. pfold. red.
            rewrite Heq'. auto.
-    + exfalso. symmetry in Heq. apply simpobs in Heq.
-      apply simpobs in x.
-      rewrite Heq in x. rewrite bind_tau in x. pinversion x.
-      inv CHECK.
   - dependent induction Hrutt.
     + exfalso. symmetry in Heq. apply simpobs in Heq. apply simpobs in x.
       rewrite Heq in x. rewrite bind_vis in x.
       pinversion x.
     + exfalso. symmetry in Heq. apply simpobs in Heq. apply simpobs in x.
-      rewrite Heq in x. rewrite bind_vis in x.
-      pinversion x; inv CHECK.
-    + rewrite <- x. cbn. constructor. eapply IHHrutt; eauto.
-    + exfalso. symmetry in Heq. apply simpobs in x. apply simpobs in Heq.
       rewrite Heq in x. rewrite bind_vis in x.
       pinversion x; inv CHECK.
     + rewrite <- x0.
@@ -198,7 +194,7 @@ Proof.
       ddestruction. inversion H; ddestruction.
       * unfold observe. cbn. unfold peel_vis.
         destruct (classicT (B = B) ); try contradiction.
-        unfold eq_rect_r, eq_rect. 
+        unfold eq_rect_r, eq_rect.
         remember (eq_sym _) as He. clear HeqHe.
         dependent destruction He. cbn. constructor; eauto.
         intros. inversion H1. ddestruction.
@@ -208,45 +204,49 @@ Proof.
         specialize (REL0 a). pclearbot.
         rewrite REL0. apply H0.
       * cbn. constructor; eauto. intros. contradiction.
+    + rewrite <- x. cbn. constructor. eapply IHHrutt; eauto.
+    + exfalso. symmetry in Heq. apply simpobs in x. apply simpobs in Heq.
+      rewrite Heq in x. rewrite bind_vis in x.
+      pinversion x; inv CHECK.
 Qed.
 
-Lemma not_spin_eutt_ret : forall E R (r : R), ~ (@ITree.spin E R ≈ Ret r). 
+Lemma not_spin_eutt_ret : forall E R (r : R), ~ (@ITree.spin E R ≈ Ret r).
 Proof.
   intros. intros Hcontra. specialize (@spin_diverge E R) as Hdiv.
   rewrite Hcontra in Hdiv. pinversion Hdiv.
 Qed.
 
 
-Lemma proper_peel_eutt_l : forall (E : Type -> Type) (R S : Type) 
-                             (b b': itrace E R) (t : itree E S),
+Lemma proper_peel_eutt_l : forall (E : Type -> Type) (R S : Type)
+                                  (b b': itrace E R) (t : itree E S),
     (b ≈ b') -> (peel b t ≈ peel b' t).
 Proof.
   intros E R S. pcofix CIH. intros. unfold peel.
   destruct (observe t).
   - pfold. red. destruct (observe b); destruct (observe b'); cbn;
-                  try (destruct e); try (destruct e0); cbn;
-                try (constructor; auto; fail).
+      try (destruct e); try (destruct e0); cbn;
+      try (constructor; auto; fail).
   - pfold. punfold H0. red in H0. dependent induction H0.
     + rewrite <- x0. rewrite <- x. red. cbn. constructor.
       right. rewrite x0. eapply CIH. reflexivity.
     + rewrite <- x0. rewrite <- x. red. cbn. constructor. right.
       pclearbot. eapply CIH. auto.
     + rewrite <- x0. rewrite <- x. destruct e; cbn.
-      * red. cbn. constructor. right. rewrite x. rewrite x0. 
+      * red. cbn. constructor. right. rewrite x. rewrite x0.
         eapply CIH. pfold. red. rewrite <- x. rewrite <- x0.
         constructor. auto.
       * red. cbn. constructor. right. rewrite x0. rewrite x.
         eapply CIH. pfold. red. rewrite <- x0. rewrite <- x.
         constructor. auto.
     + destruct (observe b); destruct (observe b'); dependent destruction x.
-      * red. cbn. constructor. right. remember (@go (EvAns E) _ (RetF r0)) as t1. 
-        assert (RetF r0 = observe t1). 
+      * red. cbn. constructor. right. remember (@go (EvAns E) _ (RetF r0)) as t1.
+        assert (RetF r0 = observe t1).
         { rewrite Heqt1. auto. }
         rewrite H. eapply CIH. rewrite Heqt1. pfold. auto.
-      * red. cbn. constructor. right. eapply CIH. 
+      * red. cbn. constructor. right. eapply CIH.
         enough (t2 ≈ Tau t3).
         { rewrite tau_eutt in H. auto. }
-         pfold. auto.
+        pfold. auto.
       * red. destruct e; cbn.
         ++ constructor. right.
            remember (@go (EvAns E) _ (VisF (evans A ev ans) k )  ) as t1.
@@ -259,8 +259,8 @@ Proof.
            { subst. auto. }
            rewrite H. eapply CIH. subst. pfold. auto.
     + destruct (observe b); destruct (observe b'); dependent destruction x.
-      * red. cbn. constructor. right. remember (@go (EvAns E) _ (RetF r0)) as t2. 
-        assert (RetF r0 = observe t2). 
+      * red. cbn. constructor. right. remember (@go (EvAns E) _ (RetF r0)) as t2.
+        assert (RetF r0 = observe t2).
         { subst. auto. }
         rewrite H. eapply CIH. rewrite Heqt2. pfold. auto.
       * red. cbn. constructor. right. eapply CIH.
@@ -298,36 +298,36 @@ Proof.
            enough (@ITree.spin (EvAns E) S ≈ ITree.spin ); auto.
            reflexivity.
       * constructor. left. contradiction.
-   + rewrite <- x. red. destruct (observe b') eqn : Heq.
-     * rewrite <- Heq. cbn. constructor; auto. eapply IHeqitF; eauto. rewrite Heq. auto.
-     * cbn. constructor. right.
-       remember (go (VisF e k) ) as t2.
-       assert (VisF e k = observe t2).
-       { subst. auto. }
-       rewrite H. eapply CIH.
-       enough (t1 ≈ Tau t0).
-       { rewrite tau_eutt in H1. auto. }
-       pfold; auto.
-     * cbn. constructor; eauto. rewrite <- Heq. eapply IHeqitF; eauto.
-       rewrite Heq. auto.
-  + rewrite <- x. red. destruct (observe b) eqn : Heq.
-     * rewrite <- Heq. cbn. constructor; auto. eapply IHeqitF; eauto. rewrite Heq. auto.
-     * cbn. constructor. right.
-       remember (go (VisF e k) ) as t1.
-       assert (VisF e k = observe t1).
-       { subst. auto. }
-       rewrite H. eapply CIH.
-       enough (Tau t0 ≈ t2).
-       { rewrite tau_eutt in H1. auto. }
-       pfold; auto.
-     * cbn. constructor; eauto. rewrite <- Heq. eapply IHeqitF; eauto.
-       rewrite Heq. auto.
+    + rewrite <- x. red. destruct (observe b') eqn : Heq.
+      * rewrite <- Heq. cbn. constructor; auto. eapply IHeqitF; eauto. rewrite Heq. auto.
+      * cbn. constructor. right.
+        remember (go (VisF e k) ) as t2.
+        assert (VisF e k = observe t2).
+        { subst. auto. }
+        rewrite H. eapply CIH.
+        enough (t1 ≈ Tau t0).
+        { rewrite tau_eutt in H1. auto. }
+        pfold; auto.
+      * cbn. constructor; eauto. rewrite <- Heq. eapply IHeqitF; eauto.
+        rewrite Heq. auto.
+    + rewrite <- x. red. destruct (observe b) eqn : Heq.
+      * rewrite <- Heq. cbn. constructor; auto. eapply IHeqitF; eauto. rewrite Heq. auto.
+      * cbn. constructor. right.
+        remember (go (VisF e k) ) as t1.
+        assert (VisF e k = observe t1).
+        { subst. auto. }
+        rewrite H. eapply CIH.
+        enough (Tau t0 ≈ t2).
+        { rewrite tau_eutt in H1. auto. }
+        pfold; auto.
+      * cbn. constructor; eauto. rewrite <- Heq. eapply IHeqitF; eauto.
+        rewrite Heq. auto.
 Qed.
 
 
 
-Lemma proper_peel_eutt_r : forall (E : Type -> Type) (R S : Type) 
-                             (b: itrace E R) (t t': itree E S),
+Lemma proper_peel_eutt_r : forall (E : Type -> Type) (R S : Type)
+                                  (b: itrace E R) (t t': itree E S),
     (t ≈ t') -> (peel b t ≈ peel b t').
 Proof.
   intros E R S. pcofix CIH. intros.
@@ -357,7 +357,7 @@ Proof.
            ** constructor; eauto. rewrite <- Heqt2.  eapply IHeqitF; eauto.
            ** constructor; auto. eapply IHeqitF; eauto.
            ** destruct e; cbn;
-              try (constructor; auto; rewrite <- Heqt2; eapply IHeqitF; eauto).
+                try (constructor; auto; rewrite <- Heqt2; eapply IHeqitF; eauto).
       * cbn. constructor. right. eapply CIH; eauto.
         enough (t1 ≈ Tau t2).
         { rewrite tau_eutt in H. auto. }
@@ -381,7 +381,7 @@ Proof.
   - punfold H0. red in H0. dependent induction H0.
     + rewrite <- x. rewrite <- x0. destruct e; cbn; constructor; auto.
     + rewrite <- x. rewrite <- x0. destruct e; cbn; constructor; right; rewrite <- Heqb;
-      eapply CIH; pclearbot; eauto.
+        eapply CIH; pclearbot; eauto.
     + rewrite <- x. rewrite <- x0. destruct e0; cbn.
       * unfold observe. cbn. unfold peel_vis.
         destruct (classicT (A = u) ).
@@ -401,11 +401,11 @@ Proof.
         setoid_rewrite <- tau_eutt at 2. pfold. auto.
       * rewrite <- Heqb. constructor. right. eapply CIH.
         setoid_rewrite <- tau_eutt at 2. pfold. auto.
-      * constructor; auto. clear IHeqitF. 
+      * constructor; auto. clear IHeqitF.
         dependent induction H0.
         ++ rewrite <- x. unfold observe. cbn.
            unfold peel_vis. destruct (classicT (A = X0) ).
-           ** unfold eq_rect_r, eq_rect. 
+           ** unfold eq_rect_r, eq_rect.
               remember (eq_sym e) as He. dependent destruction He.
               cbn. constructor. intros. right. pclearbot. eapply CIH; eauto.
            ** cbn. constructor. left. apply paco2_eqit_refl.
@@ -414,39 +414,39 @@ Proof.
         dependent induction H0.
         ++ rewrite <- x. cbn. constructor. intuition.
         ++ rewrite <- x. cbn. constructor; auto; eapply IHeqitF; eauto.
-   + rewrite <- x. cbn. destruct (observe t) eqn : Heqt; destruct e; cbn.
-     * constructor; auto. clear IHeqitF. dependent induction H0.
-       ++ rewrite <- x. cbn. constructor; auto.
-       ++ rewrite <- x. cbn. constructor; eauto.
-     * constructor; auto. clear IHeqitF. dependent induction H0.
-       ++ rewrite <- x. cbn. constructor; auto.
-       ++ rewrite <- x. cbn. constructor; eauto.
-     * constructor. right. rewrite <- Heqb. eapply CIH; eauto. rewrite <- tau_eutt.
-       pfold. auto.
-     * constructor. rewrite <- Heqb. right. eapply CIH; eauto. rewrite <- tau_eutt.
-       pfold. auto.
-     * constructor; auto. clear IHeqitF. dependent induction H0.
-       ++ rewrite <- x. unfold observe. cbn.
-          unfold peel_vis.
-          destruct (classicT (A = X0) ).
-          ** unfold eq_rect_r, eq_rect.
-             remember (eq_sym e) as He. dependent destruction He.
-             cbn. constructor. intros. right. pclearbot. eapply CIH; apply REL.
-          ** cbn. constructor. left. apply paco2_eqit_refl.
-       ++ rewrite <- x. cbn. constructor; eauto.
-     * constructor; auto. clear IHeqitF. dependent induction H0.
-       ++ rewrite <- x. cbn. constructor. intuition.
-       ++ rewrite <- x. cbn. constructor; eauto.
+    + rewrite <- x. cbn. destruct (observe t) eqn : Heqt; destruct e; cbn.
+      * constructor; auto. clear IHeqitF. dependent induction H0.
+        ++ rewrite <- x. cbn. constructor; auto.
+        ++ rewrite <- x. cbn. constructor; eauto.
+      * constructor; auto. clear IHeqitF. dependent induction H0.
+        ++ rewrite <- x. cbn. constructor; auto.
+        ++ rewrite <- x. cbn. constructor; eauto.
+      * constructor. right. rewrite <- Heqb. eapply CIH; eauto. rewrite <- tau_eutt.
+        pfold. auto.
+      * constructor. rewrite <- Heqb. right. eapply CIH; eauto. rewrite <- tau_eutt.
+        pfold. auto.
+      * constructor; auto. clear IHeqitF. dependent induction H0.
+        ++ rewrite <- x. unfold observe. cbn.
+           unfold peel_vis.
+           destruct (classicT (A = X0) ).
+           ** unfold eq_rect_r, eq_rect.
+              remember (eq_sym e) as He. dependent destruction He.
+              cbn. constructor. intros. right. pclearbot. eapply CIH; apply REL.
+           ** cbn. constructor. left. apply paco2_eqit_refl.
+        ++ rewrite <- x. cbn. constructor; eauto.
+      * constructor; auto. clear IHeqitF. dependent induction H0.
+        ++ rewrite <- x. cbn. constructor. intuition.
+        ++ rewrite <- x. cbn. constructor; eauto.
 Qed.
 
-Instance proper_eutt_peel {E R S} : Proper (eutt eq ==> eutt eq ==> eutt eq) (@peel E R S).
+#[global] Instance proper_eutt_peel {E R S} : Proper (eutt eq ==> eutt eq ==> eutt eq) (@peel E R S).
 Proof.
-  intros ? ? ? ? ? ?. rewrite proper_peel_eutt_l with (t := x0); eauto. 
+  intros ? ? ? ? ? ?. rewrite proper_peel_eutt_l with (t := x0); eauto.
   eapply proper_peel_eutt_r; eauto.
 Qed.
 
-Lemma not_peel_vis_ret: forall (R : Type) (E : Type -> Type) (S X : Type) (e : E X) (k : X -> itree E R) 
-                          (r : R) (t1 : itree (EvAns E) S),
+Lemma not_peel_vis_ret: forall (R : Type) (E : Type -> Type) (S X : Type) (e : E X) (k : X -> itree E R)
+                               (r : R) (t1 : itree (EvAns E) S),
     ~ (peel t1 (Vis e k) ≈ Ret r).
 Proof.
   intros R E S X e k r t1 Heutt.
@@ -459,7 +459,7 @@ Proof.
     unfold eq_rect_r, eq_rect in x. remember (eq_sym e0) as He.
     dependent destruction He. discriminate.
   - destruct (observe t1); cbn in x; try discriminate.
-    + injection x as Hspin. rewrite Hspin in Heutt. 
+    + injection x as Hspin. rewrite Hspin in Heutt.
       eapply not_spin_eutt_ret. pfold. eauto.
     + injection x as Ht0. eapply IHHeutt; eauto. rewrite Ht0. reflexivity.
     + destruct e0; cbn in *; try discriminate.
@@ -471,16 +471,15 @@ Proof.
         eapply not_spin_eutt_ret. pfold. eauto.
 Qed.
 
-
 Lemma peel_ret_inv:
-        forall (R : Type) (r : R) (E : Type -> Type) (S : Type) (b : itrace E S) (t : itree E R),
-          (peel b t ≈ Ret r) -> (t ≈ Ret r).
+  forall (R : Type) (r : R) (E : Type -> Type) (S : Type) (b : itrace E S) (t : itree E R),
+    (peel b t ≈ Ret r) -> (t ≈ Ret r).
 Proof.
   intros R r E S b t H. unfold peel in H.
   punfold H. red in H. cbn in H. pfold. red. cbn.
   dependent induction H.
   - unfold peel in x. destruct (observe b); destruct (observe t); cbn in *;
-                        dependent destruction x; try (constructor; auto; fail).
+      dependent destruction x; try (constructor; auto; fail).
     + destruct e; dependent destruction x; try (constructor; auto).
     + destruct e; dependent destruction x.
     + destruct e; dependent destruction x.
@@ -493,8 +492,8 @@ Proof.
     + constructor; auto. eapply IHeqitF with (b := Ret r0); eauto.
     + exfalso. eapply not_spin_eutt_ret. pfold. eauto.
     + constructor; auto. eapply IHeqitF; eauto.
-    + exfalso. destruct (observe t0).  
-      * cbn in H. eapply not_spin_eutt_ret. 
+    + exfalso. destruct (observe t0).
+      * cbn in H. eapply not_spin_eutt_ret.
         inv  H. pfold. eauto.
       * cbn in H. inv H. eapply not_peel_vis_ret.
         pfold. eauto.
@@ -515,18 +514,18 @@ Proof.
         dependent destruction He. discriminate.
       * injection x as Hspin. cbn in Hspin. exfalso.
         assert (t1 ≈ Ret r).
-        { pfold. auto. } 
+        { pfold. auto. }
         rewrite Hspin in H0. eapply not_spin_eutt_ret; eauto.
 Qed.
 
 Lemma eqitF_r_refl: forall (E : Type -> Type) (R: Type) r
-    (ot: itree' E R),
+                           (ot: itree' E R),
     eqitF eq true true id (upaco2 (eqit_ eq true true id) r)
           ot ot.
 Proof.
   intros E R r ot.
   destruct ot; constructor; auto.
-  - left. eapply paco2_mon with (r := bot2); intuition. 
+  - left. eapply paco2_mon with (r := bot2); intuition.
     apply Equivalence_eutt. apply eq_equivalence.
   - left. eapply paco2_mon with (r := bot2); intuition.
     apply Equivalence_eutt. apply eq_equivalence.
@@ -534,7 +533,7 @@ Qed.
 
 Lemma eqitF_mon:
   forall (E : Type -> Type) (R : Type) (r : itree (EvAns E) R -> itree (EvAns E) R -> Prop)
-    (t1 : itree' (EvAns E) R) (t0 : itree' (EvAns E) R),
+         (t1 : itree' (EvAns E) R) (t0 : itree' (EvAns E) R),
     eqitF eq true true id (upaco2 (eqit_ eq true true id) bot2) t1 t0 ->
     eqitF eq true true id (upaco2 (eqit_ eq true true id) r) t1 t0.
 Proof.
@@ -546,7 +545,7 @@ Qed.
 
 Lemma eqitF_observe_peel_cont_vis:
   forall (E : Type -> Type) (R S A : Type) (ev : E A) (ans : A)
-    (k1 k2 : unit -> itree (EvAns E) R),
+         (k1 k2 : unit -> itree (EvAns E) R),
     (forall v : unit, id (upaco2 (eqit_ eq true true id) bot2) (k1 v) (k2 v)) ->
     forall r : itree (EvAns E) R -> itree (EvAns E) R -> Prop,
       (forall (b b' : itrace E R) (t : itree E S),
@@ -567,23 +566,23 @@ Proof.
 Qed.
 
 
-Lemma proper_peel_cont_eutt_l : forall (E : Type -> Type) (R S : Type) 
-                             (b b': itrace E R) (t : itree E S) (s : S),
+Lemma proper_peel_cont_eutt_l : forall (E : Type -> Type) (R S : Type)
+                                       (b b': itrace E R) (t : itree E S) (s : S),
     (b ≈ b') -> (peel_cont b t s ≈ peel_cont b' t s).
 Proof.
   intros E R S. unfold peel_cont. intros b b' t _.
   revert b b' t. pcofix CIH. intros. pfold. punfold H0. red in H0.
   destruct (observe t) eqn : Heqt.
   - red. destruct (observe b') eqn : Hb; destruct (observe b) eqn : Hb'; inversion H0; cbn;
-    try (constructor; auto; fail);
-    try (constructor; auto; eapply eqitF_mon; eauto; fail);
-    try (destruct e; cbn);
-    try (constructor; auto; eapply eqitF_mon; eauto; fail).
+      try (constructor; auto; fail);
+      try (constructor; auto; eapply eqitF_mon; eauto; fail);
+      try (destruct e; cbn);
+      try (constructor; auto; eapply eqitF_mon; eauto; fail).
     + constructor. pclearbot. left. eapply paco2_mon; eauto; intuition.
     + subst. ddestruction. subst. cbn. constructor. intros. left. inv H0.
       ddestruction. subst. pclearbot. eapply paco2_mon; eauto; intuition.
     + ddestruction. subst. ddestruction. subst. cbn. constructor; auto. intuition.
-      (*looks like I didn't actually need to induct here ... *)
+  (*looks like I didn't actually need to induct here ... *)
   - dependent induction H0; try clear IHeqitF.
     + rewrite <- x0. rewrite <- x. red. cbn. constructor. right.
       rewrite x. eapply CIH; eauto. pfold. red. rewrite <- x. constructor; auto.
@@ -625,8 +624,8 @@ Proof.
   intros E R S. pcofix CIH. intros. punfold H0. red in H0. cbn in H0. dependent induction H0; subst.
   - rewrite <- x. cbn. pfold. red. cbn. apply eqitF_r_refl.
   - rewrite <- x. destruct (observe b) eqn : Hb.
-    + pfold. red. cbn. constructor; auto. 
-      
+    + pfold. red. cbn. constructor; auto.
+
       specialize (IHeqitF r CIH (Ret r0) t1 s ); auto.
       assert (S = S). auto. apply IHeqitF in H; auto. rewrite Hb.
       punfold H.
@@ -637,10 +636,10 @@ Proof.
       assert (S = S). auto. apply IHeqitF in H; auto. punfold H.
 Qed.
 
-Lemma proper_peel_cont_eutt_r : forall (E : Type -> Type) (R S : Type) 
-                             (b: itrace E R) (t t': itree E S) (s : S),
+Lemma proper_peel_cont_eutt_r : forall (E : Type -> Type) (R S : Type)
+                                       (b: itrace E R) (t t': itree E S) (s : S),
     (t ≈ t') -> (peel_cont b t s ≈ peel_cont b t' s).
-Proof. 
+Proof.
   intros E R S. unfold peel_cont. intros b t t' _.
   revert b t t'. pcofix CIH. intros. pfold. punfold H0. red in H0. dependent induction H0.
   - rewrite <- x. rewrite <- x0. red. cbn. apply eqitF_r_refl.
@@ -654,7 +653,7 @@ Proof.
       pfold. red. rewrite <- x. rewrite <- x0. constructor. intros.
       left. auto.
     + destruct e0; cbn.
-      * unfold observe. cbn. unfold peel_cont_vis. 
+      * unfold observe. cbn. unfold peel_cont_vis.
         destruct (classicT (A = u) ); try apply eqitF_r_refl.
         unfold eq_rect_r, eq_rect. remember (eq_sym e0) as He.
         dependent destruction He. cbn. constructor. intros. right.
@@ -670,20 +669,20 @@ Proof.
       * constructor. right. rewrite <- Heqt'. eapply CIH.
         pfold. red. rewrite Heqt'. auto.
     + rewrite <- Heqb. constructor; auto. eapply IHeqitF; eauto.
- - rewrite <- x. destruct (observe b) eqn : Heqb; red; cbn.
-   + constructor; auto. rewrite <- Heqb. eapply IHeqitF; eauto.
-   + destruct (observe t) eqn : Heqt; cbn.
-     * constructor. left. eapply paco2_mon with (r := bot2); intuition. 
-       enough (t0 ≈ peel_cont_ (observe t0) (observe t2) ). auto.
-       symmetry.
-       eapply peel_cont_ret_inv with (s := r0). symmetry. pfold. auto.
-     * constructor. right. eapply CIH. rewrite <- tau_eutt at 1. pfold. auto.
-     * constructor. right. rewrite <- Heqt. eapply CIH.
-       pfold. red. rewrite Heqt. auto.
-   + rewrite <- Heqb. constructor; auto. eapply IHeqitF; eauto.
+  - rewrite <- x. destruct (observe b) eqn : Heqb; red; cbn.
+    + constructor; auto. rewrite <- Heqb. eapply IHeqitF; eauto.
+    + destruct (observe t) eqn : Heqt; cbn.
+      * constructor. left. eapply paco2_mon with (r := bot2); intuition.
+        enough (t0 ≈ peel_cont_ (observe t0) (observe t2) ). auto.
+        symmetry.
+        eapply peel_cont_ret_inv with (s := r0). symmetry. pfold. auto.
+      * constructor. right. eapply CIH. rewrite <- tau_eutt at 1. pfold. auto.
+      * constructor. right. rewrite <- Heqt. eapply CIH.
+        pfold. red. rewrite Heqt. auto.
+    + rewrite <- Heqb. constructor; auto. eapply IHeqitF; eauto.
 Qed.
 
-Instance proper_eutt_peel_cont {E R S} : Proper (eutt eq ==> eutt eq ==> eq ==> eutt eq) (@peel_cont E R S).
+#[global] Instance proper_eutt_peel_cont {E R S} : Proper (eutt eq ==> eutt eq ==> eq ==> eutt eq) (@peel_cont E R S).
 Proof.
   repeat intro. subst. rewrite proper_peel_cont_eutt_l; eauto.
   rewrite proper_peel_cont_eutt_r; eauto. reflexivity.
@@ -695,12 +694,12 @@ Proof.
   intros E R S. pcofix CIH. intros. punfold H0. pfold. red. red in H0. cbn in *.
   unfold ITree.bind in H0. unfold ITree.bind. cbn in *.
   unfold observe at 1. cbn.
-*)
+ *)
 (*may need an analgous lemma for *)
 Lemma vis_refine_peel : forall (E : Type -> Type) (R S A : Type) (e : E A) (a : A)
-                   (k1: unit -> itrace E S) (k2 : A -> itree E R) (k3 : unit -> itrace E R),
-        (peel (Vis (evans _ e a) k1) (Vis e k2) ≈ Vis (evans _ e a) k3) -> 
-        (k3 tt ≈ peel (k1 tt) (k2 a)).
+                               (k1: unit -> itrace E S) (k2 : A -> itree E R) (k3 : unit -> itrace E R),
+    (peel (Vis (evans _ e a) k1) (Vis e k2) ≈ Vis (evans _ e a) k3) ->
+    (k3 tt ≈ peel (k1 tt) (k2 a)).
 Proof.
   intros E R S A. (* pcofix CIH. *) intros e a k1 k2 k3 Hpeel.
   unfold peel in *. cbn in *. punfold Hpeel.
@@ -717,9 +716,9 @@ Proof.
 Qed.
 
 Lemma vis_refine_peel_cont :  forall (E : Type -> Type) (R S A : Type) (e : E A) (a : A)
-                   (k1: unit -> itrace E S) (k2 : A -> itree E R) (t : itrace E S),
-        (peel_cont_ (VisF (evans _ e a) k1) (VisF e k2) ≈ t) -> 
-        (t ≈ peel_cont_ (observe (k1 tt)) (observe (k2 a))).
+                                     (k1: unit -> itrace E S) (k2 : A -> itree E R) (t : itrace E S),
+    (peel_cont_ (VisF (evans _ e a) k1) (VisF e k2) ≈ t) ->
+    (t ≈ peel_cont_ (observe (k1 tt)) (observe (k2 a))).
 Proof.
   intros E R S A e a k1 k2 t Hpeelcont. punfold Hpeelcont. red in Hpeelcont.
   unfold observe in Hpeelcont at 1. cbn in *. unfold peel_cont_vis in *.
@@ -732,7 +731,7 @@ Proof.
 Qed.
 
 Lemma spin_not_vis : forall (E : Type -> Type) (R A : Type)
-                       (e : E A) (k : A -> itree E R),
+                            (e : E A) (k : A -> itree E R),
     ~ ITree.spin ≈ Vis e k.
 Proof.
   intros E R A e k Hcontra. punfold Hcontra. red in Hcontra. cbn in *.
@@ -740,11 +739,11 @@ Proof.
   eapply IHHcontra; eauto.
 Qed.
 
-Lemma peel_vis_empty_contra: forall (R : Type) (E : Type -> Type) (S A0 : Type) (Hempty : A0 -> void) 
-                               (ev : E A0) (k0 : void -> itree (EvAns E) S) (t0 : itree E R) (A : Type) 
-                               (a : A) (e : E A) (k : unit -> itrace E R),
+Lemma peel_vis_empty_contra: forall (R : Type) (E : Type -> Type) (S A0 : Type) (Hempty : A0 -> void)
+                                    (ev : E A0) (k0 : void -> itree (EvAns E) S) (t0 : itree E R) (A : Type)
+                                    (a : A) (e : E A) (k : unit -> itrace E R),
     eqitF eq true true id (upaco2 (eqit_ eq true true id) bot2)
-          (observe (peel_ (VisF (evempty A0 Hempty ev) k0) (observe t0))) 
+          (observe (peel_ (VisF (evempty A0 Hempty ev) k0) (observe t0)))
           (VisF (evans A e a) k) -> False.
 Proof.
   intros R E S A0 Hempty ev k0 t0 A a e k Hpeel.
@@ -756,13 +755,13 @@ Qed.
 
 
 Lemma vis_peel_l : forall (E : Type -> Type) (R S A : Type) (e : E A) (a : A)
-  (b : itrace E S) (t : itree E R) (f : R -> itree E S) (k : unit -> itrace E R),
-  b ⊑ ITree.bind t f ->
-  (peel b t ≈ Vis (evans _ e a) k) -> exists k', (b ≈ Vis (evans _ e a) k').
+                          (b : itrace E S) (t : itree E R) (f : R -> itree E S) (k : unit -> itrace E R),
+    b ⊑ ITree.bind t f ->
+    (peel b t ≈ Vis (evans _ e a) k) -> exists k', (b ≈ Vis (evans _ e a) k').
 Proof.
-  intros E R S A e a b t f k Href Hpeel. 
+  intros E R S A e a b t f k Href Hpeel.
   punfold Hpeel. red in Hpeel. cbn in Hpeel. dependent induction Hpeel.
-  - unfold peel in x. 
+  - unfold peel in x.
     destruct (observe b) eqn : Heqb; destruct (observe t) eqn : Heqt; try destruct e0; cbn in *;
       dependent destruction x. unfold observe in x. cbn in x.
     unfold peel_vis in x.
@@ -774,14 +773,14 @@ Proof.
       rewrite bind_vis in Href.
       punfold Href. red in Href. cbn in *. inv Href.
       ddestruction. subst. inv H1. auto.
-    } 
+    }
     destruct (classicT (A0 = X0)); try (exfalso; auto; fail).
     unfold eq_rect_r, eq_rect in x. remember (eq_sym e0) as He.
     dependent destruction He. cbn in x. injection x as Hevans.
     ddestruction. subst. ddestruction. subst. exists k0.
     symmetry in Heqb. apply simpobs in Heqb. rewrite Heqb. reflexivity.
   - unfold peel in x. destruct (observe b) eqn : Heqb; destruct (observe t) eqn : Heqt;
-                        try destruct e0; cbn in *; dependent destruction x.
+      try destruct e0; cbn in *; dependent destruction x.
     + symmetry in Heqt. apply simpobs in Heqt. rewrite Heqt in Href.
       rewrite tau_eutt in Href. eapply IHHpeel in Href; eauto. unfold peel.
       rewrite Heqb. auto.
@@ -810,9 +809,9 @@ Proof.
 Qed.
 
 Lemma vis_peel_r : forall (E : Type -> Type) (R S A : Type) (e : E A) (a : A)
-  (b : itrace E S) (t : itree E R) (f : R -> itree E S) (k : unit -> itrace E R),
-  b ⊑ ITree.bind t f ->
-  (peel b t ≈ Vis (evans _ e a) k) -> exists k', (t ≈ Vis e k').
+                          (b : itrace E S) (t : itree E R) (f : R -> itree E S) (k : unit -> itrace E R),
+    b ⊑ ITree.bind t f ->
+    (peel b t ≈ Vis (evans _ e a) k) -> exists k', (t ≈ Vis e k').
 Proof.
   intros E R S A e a b t f k Href Hpeel.
   eapply vis_peel_l in Hpeel as Hpeell; eauto. destruct Hpeell as [k' Hb].
@@ -821,7 +820,7 @@ Proof.
   - destruct (observe t) eqn : Heqt; dependent destruction x.
     symmetry in Heqt. apply simpobs in Heqt. setoid_rewrite Heqt.
     unfold observe in x. cbn in *. unfold peel_vis in x. destruct (classicT (A = X));
-                                                           cbn in *; try discriminate.
+      cbn in *; try discriminate.
     unfold eq_rect_r, eq_rect in x. remember (eq_sym e1) as He.
     dependent destruction He. cbn in *. exists k0.
     rewrite Heqt in Href. rewrite bind_vis in Href. punfold Href. red in Href.
@@ -837,8 +836,8 @@ Proof.
         exfalso. eapply spin_not_vis. pfold. eauto.
 Qed.
 
-Lemma peel_cont_vis_eutt: forall (R : Type) (r : R) (E : Type -> Type) (S A : Type) (ev : E A) 
-                            (ans : A) (kb : unit -> itree (EvAns E) S) (kt : A -> itree E R),
+Lemma peel_cont_vis_eutt: forall (R : Type) (r : R) (E : Type -> Type) (S A : Type) (ev : E A)
+                                 (ans : A) (kb : unit -> itree (EvAns E) S) (kt : A -> itree E R),
     (peel_cont (Vis (evans A ev ans) kb) (Vis ev kt) r ≈ peel_cont (kb tt) (kt ans) r).
 Proof.
   intros R r E S A ev ans kb kt.
@@ -850,8 +849,8 @@ Proof.
 Qed.
 
 Lemma peel_cont_refine_t : forall (E : Type -> Type) (R S : Type)
-                  (b : itrace E S) (t : itree E R) (f : R -> itree E S) (r : R)
-     (Hrutt : b ⊑ ITree.bind t f),
+                                  (b : itrace E S) (t : itree E R) (f : R -> itree E S) (r : R)
+                                  (Hrutt : b ⊑ ITree.bind t f),
     may_converge r (peel b t) -> peel_cont b t r ⊑ f r.
 Proof.
   intros. remember (peel b t) as t'. assert (peel b t ≈ t').
@@ -861,7 +860,7 @@ Proof.
   - rewrite <- H0 in H. clear H0. apply peel_ret_inv in H as Ht.
     rewrite Ht in Hrutt.
     rewrite bind_ret_l in Hrutt.
-    rewrite Ht in H. 
+    rewrite Ht in H.
     unfold peel_cont. cbn. rewrite peel_cont_ret_inv; eauto.
   - rewrite H in H1. clear H.
     destruct e; try contradiction. eapply vis_peel_l in H1 as Hb; eauto.
@@ -879,16 +878,16 @@ Proof.
     + destruct b. symmetry. auto.
 Qed.
 
-Ltac fold_eutt := match goal with |- paco2 _ _ ?t1 ?t2 => 
-                                  eapply paco2_mon with (r := bot2); intuition; enough (t1 ≈ t2); auto end.
+Ltac fold_eutt := match goal with |- paco2 _ _ ?t1 ?t2 =>
+                                    eapply paco2_mon with (r := bot2); intuition; enough (t1 ≈ t2); auto end.
 
-Ltac fold_peel_cont r := match goal with |- context [peel_cont_ (observe ?b) (observe ?t) ] => 
-            assert (Hfpc : forall r, peel_cont_ (observe b) (observe t) = peel_cont b t r ); auto; rewrite (Hfpc r); 
-            clear Hfpc end.
+Ltac fold_peel_cont r := match goal with |- context [peel_cont_ (observe ?b) (observe ?t) ] =>
+                                           assert (Hfpc : forall r, peel_cont_ (observe b) (observe t) = peel_cont b t r ); auto; rewrite (Hfpc r);
+                                           clear Hfpc end.
 
 Lemma trace_prefix_tau_ret:
   forall (E : Type -> Type) (R S : Type) (r : itrace E S -> itrace E R -> Prop)
-    (b : itrace E R) (t : itree E S) (f : S -> itree E R) (r0 : R),
+         (b : itrace E R) (t : itree E S) (f : S -> itree E R) (r0 : R),
     b ⊑ ITree.bind t f ->
     observe b = RetF r0 ->
     forall t0 : itree E S,
@@ -920,21 +919,21 @@ Proof.
   - rewrite <- x. cbn. constructor. eapply IHHt0; eauto.
 Qed.
 
-Lemma trace_prefix_vis_evans: forall (E : Type -> Type) (R S : Type) (r : itrace E S -> itrace E R -> Prop) 
-                                 (A0 : Type) (ev : E A0) (ans : A0) (k : unit -> itree (EvAns E) R) 
-                                 (k' : A0 -> itree E S)
-                                 (t0 : itree E S) (f : S -> itree E R),
+Lemma trace_prefix_vis_evans: forall (E : Type -> Type) (R S : Type) (r : itrace E S -> itrace E R -> Prop)
+                                     (A0 : Type) (ev : E A0) (ans : A0) (k : unit -> itree (EvAns E) R)
+                                     (k' : A0 -> itree E S)
+                                     (t0 : itree E S) (f : S -> itree E R),
     (forall (a : unit) (b : A0),
-       RAnsRef E unit A0 (evans A0 ev ans) a ev b ->
-       id
-         (upaco2 (rutt_ (REvRef E) (RAnsRef E) eq id)
-            bot2) (k a) (ITree.bind (k' b) f)) ->
+        RAnsRef E unit A0 (evans A0 ev ans) a ev b ->
+        id
+          (upaco2 (rutt_ (REvRef E) (RAnsRef E) eq)
+                  bot2) (k a) (ITree.bind (k' b) f)) ->
     (t0 ≈ Vis ev k') ->
     (forall (b : itrace E R) (t : itree E S)
-          (f : S -> itree E R),
+            (f : S -> itree E R),
         b ⊑ ITree.bind t f -> r (peel b t) b) ->
-            trace_prefixF (upaco2 trace_prefix_ r)
-                           (observe (peel_ (VisF (evans A0 ev ans) k) (observe t0))) (VisF (evans A0 ev ans) k).
+    trace_prefixF (upaco2 trace_prefix_ r)
+                  (observe (peel_ (VisF (evans A0 ev ans) k) (observe t0))) (VisF (evans A0 ev ans) k).
 Proof.
   intros E R S r A0 ev ans k k' t0 f Hk' Ht0 CIH.
   punfold Ht0. red in Ht0. cbn in *. dependent induction Ht0.
@@ -949,17 +948,17 @@ Proof.
 Qed.
 
 Lemma trace_prefix_vis_evempty: forall (E : Type -> Type) (R S : Type)
-                                   (r : itrace E S -> itrace E R -> Prop) 
-                                   (A0 : Type) (Hempty : A0 -> void) (ev : E A0)
-                                   (k : void -> itree (EvAns E) R) (A : Type) 
-                                   (e0 : E A) (t0 : itree E S) (k' : A -> itree E S),
+                                       (r : itrace E S -> itrace E R -> Prop)
+                                       (A0 : Type) (Hempty : A0 -> void) (ev : E A0)
+                                       (k : void -> itree (EvAns E) R) (A : Type)
+                                       (e0 : E A) (t0 : itree E S) (k' : A -> itree E S),
     eqitF eq true true id
-          (upaco2 (eqit_ eq true true id) bot2) 
+          (upaco2 (eqit_ eq true true id) bot2)
           (observe t0) (VisF e0 k') ->
     trace_prefixF (upaco2 trace_prefix_ r)
-                   (observe
-                      (peel_ (VisF (evempty A0 Hempty ev) k) (TauF t0)))
-                   (VisF (evempty A0 Hempty ev) k).
+                  (observe
+                     (peel_ (VisF (evempty A0 Hempty ev) k) (TauF t0)))
+                  (VisF (evempty A0 Hempty ev) k).
 Proof.
   intros E R S r A0 Hempty ev k A e0 t0 k' Ht0.
   cbn. constructor.
@@ -970,35 +969,35 @@ Qed.
 
 
 Lemma trace_prefix_peel_ret_vis:  forall (E : Type -> Type) (R S : Type)
-                                     (r : itrace E S -> itrace E R -> Prop) 
-                                     (A0 : Type) (ev : E A0) (ans : A0)
-                                     (k : unit -> itree (EvAns E) R) (t0 : itree E S)
-                                     (s : S),
+                                         (r : itrace E S -> itrace E R -> Prop)
+                                         (A0 : Type) (ev : E A0) (ans : A0)
+                                         (k : unit -> itree (EvAns E) R) (t0 : itree E S)
+                                         (s : S),
     t0 ≈ Ret s ->
     trace_prefixF (upaco2 trace_prefix_ r)
-                           (observe
-                              (peel_ (VisF (evans A0 ev ans) k) (observe t0)))
-                           (VisF (evans A0 ev ans) k).
+                  (observe
+                     (peel_ (VisF (evans A0 ev ans) k) (observe t0)))
+                  (VisF (evans A0 ev ans) k).
 Proof.
   intros E R S r A0 ev ans k t0 s Ht0.
   punfold Ht0. red in Ht0. cbn in *. dependent induction Ht0.
   - rewrite <- x. cbn. remember (go (VisF (evans A0 ev ans) k ) ) as t.
     enough (trace_prefixF (upaco2 trace_prefix_ r) (RetF s) (observe t) ).
     { subst. auto. }
-     constructor.
+    constructor.
   - rewrite <- x. cbn. constructor. eapply IHHt0; eauto.
 Qed.
 
 Lemma trace_prefix_peel_ret_vis_empty: forall (E : Type -> Type) (R S : Type)
-                                          (r : itrace E S -> itrace E R -> Prop) 
-                                          (A0 : Type) (Hempty : A0 -> void) (ev : E A0)
-                                          (k : void -> itree (EvAns E) R) (t0 : itree E S)
-                                          (s : S),
+                                              (r : itrace E S -> itrace E R -> Prop)
+                                              (A0 : Type) (Hempty : A0 -> void) (ev : E A0)
+                                              (k : void -> itree (EvAns E) R) (t0 : itree E S)
+                                              (s : S),
     t0 ≈ Ret s ->
     trace_prefixF (upaco2 trace_prefix_ r)
-                   (observe
-                      (peel_ (VisF (evempty A0 Hempty ev) k) (observe t0)))
-                   (VisF (evempty A0 Hempty ev) k).
+                  (observe
+                     (peel_ (VisF (evempty A0 Hempty ev) k) (observe t0)))
+                  (VisF (evempty A0 Hempty ev) k).
 Proof.
   intros E R S r A0 Hempty ev k t0 s Ht0.
   punfold Ht0. red in Ht0. cbn in *. dependent induction Ht0.
@@ -1010,11 +1009,11 @@ Proof.
 Qed.
 
 Lemma trace_prefix_peel : forall (E : Type -> Type) (S R : Type) (b : itrace E R) (t : itree E S)
-  (f : S -> itree E R),
+                                 (f : S -> itree E R),
     b ⊑ ITree.bind t f ->
     trace_prefix (peel b t) b.
 Proof.
-  intros E S R. pcofix CIH. intros b t f Href. pfold. red. unfold peel. 
+  intros E S R. pcofix CIH. intros b t f Href. pfold. red. unfold peel.
   destruct (observe b) eqn : Heqb; destruct (observe t) eqn : Heqt; cbn.
   - rewrite <- Heqb. auto.
   - eapply trace_prefix_tau_ret; eauto.
@@ -1042,14 +1041,14 @@ Proof.
         + right. exists r0. pfold. red. cbn. rewrite Heqt0. auto.
         + cbn in x. left. exists X0. exists k2. exists e1. symmetry in Heqt0.
           apply simpobs in Heqt0. rewrite Heqt0. reflexivity.
-     - unfold observe in x. cbn in *. destruct (observe t0) eqn : Heqt0; try discriminate.
-       + right. exists r0. pfold. red. cbn. rewrite Heqt0. auto.
-       + injection x as Ht1. symmetry in Heqt0. apply simpobs in Heqt0.
-         setoid_rewrite Heqt0. setoid_rewrite tau_eutt. eapply IHHvis; eauto.
-         rewrite Ht1. auto.
+      - unfold observe in x. cbn in *. destruct (observe t0) eqn : Heqt0; try discriminate.
+        + right. exists r0. pfold. red. cbn. rewrite Heqt0. auto.
+        + injection x as Ht1. symmetry in Heqt0. apply simpobs in Heqt0.
+          setoid_rewrite Heqt0. setoid_rewrite tau_eutt. eapply IHHvis; eauto.
+          rewrite Ht1. auto.
     }
     destruct H as [ [B [k' [e1 Ht0] ] ] | [s Ht0] ].
-    + rewrite Heqt in Href. rewrite tau_eutt in Href. 
+    + rewrite Heqt in Href. rewrite tau_eutt in Href.
       rewrite Ht0 in Href. rewrite bind_vis in Href.
       pinversion Href. subst; ddestruction; subst.
       rewrite Ht0 in Hvis. rewrite bind_vis in Hvis. pinversion Hvis.
@@ -1057,7 +1056,7 @@ Proof.
       punfold Ht0. red in Ht0. cbn in *.
       destruct e.
       * inv H1. ddestruction; subst. cbn. constructor.
-        eapply trace_prefix_vis_evans; eauto. 
+        eapply trace_prefix_vis_evans; eauto.
       * eapply trace_prefix_vis_evempty; eauto.
     + rewrite Heqt in Href. rewrite Ht0 in Href.
       rewrite tau_eutt in Href. rewrite bind_ret_l in Href. clear Hvis.
@@ -1080,7 +1079,7 @@ Proof.
 Qed.
 
 Lemma peel_bind : forall (E : Type -> Type) (S R : Type) (b : itrace E R) (t : itree E S)
-  (f : S -> itree E R),
+                         (f : S -> itree E R),
     b ⊑ ITree.bind t f -> exists g, (ITree.bind (peel b t) g ≈ b).
 Proof.
   intros. apply trace_prefix_bind. eapply trace_prefix_peel; eauto.
@@ -1093,7 +1092,7 @@ Proof.
 Qed.
 
 Lemma bind_peel_ret_tau_aux:
-  forall (E : Type -> Type) (S R : Type) (f : R -> itree E S) 
+  forall (E : Type -> Type) (S R : Type) (f : R -> itree E S)
     (r0 : S) (t0 : itree E R),
     Ret r0 ⊑ ITree.bind t0 f -> exists r : R, t0 ≈ Ret r.
 Proof.
@@ -1111,18 +1110,18 @@ Qed.
 
 (* maybe this should be the axiom *)
 Lemma decompose_trace_refine_bind : forall (E : Type -> Type) (R S : Type)
-                                       (b : itrace E S) (t : itree E R) (f : R -> itree E S),
+                                      (b : itrace E S) (t : itree E R) (f : R -> itree E S),
     b ⊑ t >>= f -> exists b', exists g', (ITree.bind b' g' ≈ b) /\ b' ⊑ t.
 Proof.
   intros. exists (peel b t).
   apply peel_bind in H as Heutt. destruct Heutt as [g Heutt].
   exists g. split; auto; eapply peel_refine_t; apply H.
-Qed. 
+Qed.
 
-Lemma bind_trigger_refine : forall (E : Type -> Type) (A R : Type) (b : itree (EvAns E) R) 
+Lemma bind_trigger_refine : forall (E : Type -> Type) (A R : Type) (b : itree (EvAns E) R)
                               (e : E A) (k : A -> itree E R),
     (exists a : A, True) ->
-    b ⊑ ITree.bind (ITree.trigger e) k -> 
+    b ⊑ ITree.bind (ITree.trigger e) k ->
     exists a : A, exists (k' : unit -> itrace E R), b ≈ Vis (evans A e a) k' /\ k' tt ⊑ k a.
 Proof.
   intros. rewrite bind_trigger in H0. apply trace_refine_vis in H0 as Hvis.

--- a/theories/ITrace/ITraceDefinition.v
+++ b/theories/ITrace/ITraceDefinition.v
@@ -42,18 +42,18 @@ Definition append {E R} (s : itrace E unit) (b : itrace E R) :=
 
 Notation "s ++ b" := (append s b).
 
-Variant REvRef (E : Type -> Type) : forall (A B : Type), EvAns E A -> E B -> Prop := 
+Variant REvRef (E : Type -> Type) : forall (A B : Type), EvAns E A -> E B -> Prop :=
   | rer {A : Type} (e : E A) (a : A) : REvRef E unit A (evans A e a) e
   | ree {A : Type} (e : E A) (Hempty : A -> void) : REvRef E void A (evempty A Hempty e) e
 .
-Hint Constructors REvRef.
+#[global] Hint Constructors REvRef : core.
 
 (*shouldn't need an empty case*)
 Variant RAnsRef (E : Type -> Type) : forall (A B : Type), EvAns E A -> A -> E B -> B -> Prop :=
   | rar {A : Type} (e : E A) (a : A) : RAnsRef E unit A (evans A e a) tt e a.
-Hint Constructors RAnsRef.
+#[global] Hint Constructors RAnsRef : core.
 
-Definition trace_refine {E R}  (t : itree E R) (b : itrace E R)  := 
+Definition trace_refine {E R}  (t : itree E R) (b : itrace E R)  :=
    rutt (REvRef E) (RAnsRef E) eq b t.
 
 
@@ -61,4 +61,4 @@ Notation "b ⊑ t" := (trace_refine t b) (at level 70).
 
 Definition finite {E : Type -> Type} (s : ev_stream E) : Prop := may_converge tt s.
 
-Global Instance itrace_eq {E} : Eq1 (itrace E) := ITreeMonad.Eq1_ITree.
+#[global] Instance itrace_eq {E} : Eq1 (itrace E) := ITreeMonad.Eq1_ITree.

--- a/theories/ITrace/ITraceFacts.v
+++ b/theories/ITrace/ITraceFacts.v
@@ -27,27 +27,27 @@ Proof.
 Qed.
 
 Lemma may_converge_trace : forall (E : Type -> Type) (R : Type)
-                                   (b : itrace E R) (r1 r2 : R),
+                             (b : itrace E R) (r1 r2 : R),
     may_converge r1 b -> may_converge r2 b -> r1 = r2.
 Proof.
   intros. induction H; inversion H0; subst.
   - rewrite H in H1. pinversion H1. subst. auto.
   - rewrite H in H1. pinversion H1.
   - destruct e. destruct b. apply IHmay_converge. rewrite H in H0. inversion H0; subst;
-                                                                    contra_void.
+      contra_void.
     + pinversion H3.
     + destruct e; [ | contradiction ]. destruct b.
       pinversion H3. ddestruction.
       enough (k tt ≈ k0 tt); try apply REL.
       rewrite H5. auto.
     + contradiction.
- - destruct e. destruct e0. destruct b. destruct b0.
-   apply IHmay_converge. rewrite H in H2.
-   pinversion H2. ddestruction.
-   subst. enough (k tt ≈ k0 tt); try apply REL.
-   rewrite H4. auto; contra_void.
-   + destruct b0.
-   + destruct b.
+  - destruct e. destruct e0. destruct b. destruct b0.
+    apply IHmay_converge. rewrite H in H2.
+    pinversion H2. ddestruction.
+    subst. enough (k tt ≈ k0 tt); try apply REL.
+    rewrite H4. auto; contra_void.
+    + destruct b0.
+    + destruct b.
 Qed.
 
 Lemma finite_nil {E : Type -> Type} : finite (@Nil E).
@@ -78,8 +78,8 @@ Proof.
 Qed.
 
 Lemma append_vis : forall (E : Type -> Type) (R : Type)
-                          (e : EvAns E unit) (k : unit -> ev_stream E) (b : itrace E R),
-                          Vis e k ++ b ≈ Vis e (fun a => k a ++ b).
+                     (e : EvAns E unit) (k : unit -> ev_stream E) (b : itrace E R),
+    Vis e k ++ b ≈ Vis e (fun a => k a ++ b).
 Proof.
   intros E R. unfold append. intros.
   pfold. red. cbn. constructor. intros. left.
@@ -94,8 +94,8 @@ Proof.
 Qed.
 
 Lemma may_converge_append : forall (E : Type -> Type) (R : Type)
-                                   (log : ev_stream E) (r : R),
-      finite log -> may_converge r (log ++ Ret r).
+                              (log : ev_stream E) (r : R),
+    finite log -> may_converge r (log ++ Ret r).
 Proof.
   intros. induction H.
   - unfold append. rewrite H. rewrite bind_ret_l.
@@ -105,8 +105,8 @@ Proof.
     subst. contradiction.
 Qed.
 
-Lemma converge_itrace_ev_list : forall (E : Type -> Type) (R : Type) 
-                                        (b : itrace E R) (r : R),
+Lemma converge_itrace_ev_list : forall (E : Type -> Type) (R : Type)
+                                  (b : itrace E R) (r : R),
     may_converge r b -> (exists log, (ev_list_to_stream log) ++ Ret r ≈ b)%itree .
 Proof.
   intros. induction H.
@@ -135,8 +135,8 @@ Proof.
 Qed.
 
 Lemma append_assoc : forall (E : Type -> Type) (R : Type) (b : itrace E R)
-                            (log log' : ev_list E),
-    ev_list_to_stream (log ++ log')%list ++ b ≈ 
+                       (log log' : ev_list E),
+    ev_list_to_stream (log ++ log')%list ++ b ≈
                       (ev_list_to_stream log) ++ (ev_list_to_stream log') ++ b.
 Proof.
   intros E R b log. induction log.
@@ -146,7 +146,7 @@ Proof.
 Qed.
 
 Lemma append_div : forall (E : Type -> Type) (R : Type) (b : itrace E R)
-                          (log : ev_list E),
+                     (log : ev_list E),
     must_diverge b -> must_diverge ((ev_list_to_stream log) ++ b).
 Proof.
   intros. induction log.
@@ -156,8 +156,8 @@ Proof.
 Qed.
 
 Lemma inv_append_eutt : forall (E : Type -> Type) (R : Type) (r1 r2 : R)
-                               (log1 log2 : ev_list E),
-    ((ev_list_to_stream log1) ++ Ret r1 ≈ (ev_list_to_stream log2) ++ Ret r2)%itree -> 
+                          (log1 log2 : ev_list E),
+    ((ev_list_to_stream log1) ++ Ret r1 ≈ (ev_list_to_stream log2) ++ Ret r2)%itree ->
     log1 = log2 /\ r1 = r2.
 Proof.
   intros. generalize dependent log2. induction log1; intros.
@@ -175,9 +175,9 @@ Proof.
 Qed.
 
 Lemma trace_refine_proper_left' : forall (E : Type -> Type) (R : Type) (b1 b2 : itrace E R)
-                (t : itree E R), (b1 ≈ b2) -> rutt (REvRef E) (RAnsRef E) eq b1 t ->
-                                 rutt (REvRef E) (RAnsRef E) eq b2 t.
-Proof. 
+                                    (t : itree E R), (b1 ≈ b2) -> rutt (REvRef E) (RAnsRef E) eq b1 t ->
+                                                     rutt (REvRef E) (RAnsRef E) eq b2 t.
+Proof.
   intros E R. pcofix CIH. intros. pfold. red.
   punfold H1. red in H1.  punfold H0. red in H0.
   genobs_clear t ot3.
@@ -187,44 +187,43 @@ Proof.
     + constructor. eapply IHruttF; eauto.
   (* Tau Tau case causes the most problems, seems *)
   -  assert (DEC: (exists m3, ot3 = TauF m3) \/ (forall m3, ot3 <> TauF m3)).
-    { destruct ot3; eauto; right; red; intros; inv H. }
-    destruct DEC as [EQ | EQ].
-    + destruct EQ as [m3 ?]; subst. pclearbot.
-      constructor. right. eapply CIH; eauto.
-      apply rutt_inv_tauLR. pfold. auto.
-    + inv H1; try (exfalso; eapply EQ; eauto; fail). 
-      pclearbot. constructor.
-      punfold REL. red in REL.
-      hinduction H0 before CIH; intros; subst; try (exfalso; eapply EQ; eauto; fail). 
-      * dependent induction REL; rewrite <- x.
-        ++ constructor. auto.
-        ++ constructor. eapply IHREL; eauto.
-      * eapply IHruttF; eauto. clear IHruttF.
-        dependent induction REL; try (exfalso; eapply EQ; eauto; fail).  
-        ++ pclearbot. rewrite <- x. constructor; auto. pstep_reverse.
-        ++ auto. 
-        ++ rewrite <- x. constructor; auto. eapply IHREL; eauto.
-      * dependent induction REL; rewrite <- x.
-        ++ constructor; auto. intros. apply H0 in H1. right.
-           pclearbot. eapply CIH; eauto.
-        ++ constructor. eapply IHREL; eauto.
+     { destruct ot3; eauto; right; red; intros; inv H. }
+     destruct DEC as [EQ | EQ].
+     + destruct EQ as [m3 ?]; subst. pclearbot.
+       constructor. right. eapply CIH; eauto.
+       apply rutt_inv_tauLR. pfold. auto.
+     + inv H1; try (exfalso; eapply EQ; eauto; fail).
+       pclearbot. constructor.
+       punfold REL. red in REL.
+       hinduction H0 before CIH; intros; subst; try (exfalso; eapply EQ; eauto; fail).
+       * dependent induction REL; rewrite <- x.
+         ++ constructor. auto.
+         ++ constructor. eapply IHREL; eauto.
+       * dependent induction REL; rewrite <- x.
+         ++ constructor; auto. intros. apply H0 in H1. right.
+            pclearbot. eapply CIH; eauto.
+         ++ constructor. eapply IHREL; eauto.
+       * eapply IHruttF; eauto. clear IHruttF.
+         dependent induction REL; try (exfalso; eapply EQ; eauto; fail).
+         ++ pclearbot. rewrite <- x. constructor; auto. pstep_reverse.
+         ++ auto.
+         ++ rewrite <- x. constructor; auto. eapply IHREL; eauto.
   - remember (VisF e k1) as ot1.
     hinduction H1 before CIH; intros; dependent destruction Heqot1.
-    + constructor. eapply IHruttF; eauto.
-    + pclearbot. constructor; auto. intros. apply H0 in H1. 
+    + pclearbot. constructor; auto. intros. apply H0 in H1.
       pclearbot. right.
-      eapply CIH; eauto. 
-  - eapply IHeqitF. remember (TauF t1) as otf1. 
+      eapply CIH; eauto.
+    + constructor. eapply IHruttF; eauto.
+  - eapply IHeqitF. remember (TauF t1) as otf1.
     hinduction H1 before CIH; intros;  dependent destruction Heqotf1; eauto.
     + constructor. pclearbot. pstep_reverse.
     + constructor. eapply IHruttF; eauto.
   - constructor. eapply IHeqitF. eauto.
-
-Qed. 
+Qed.
 
 Lemma trace_refine_proper_right' : forall (E : Type -> Type) (R : Type) (b : itrace E R)
-                                   (t1 t2 : itree E R), t1 ≈ t2 -> rutt (REvRef E) (RAnsRef E) eq b t1 ->
-                                 rutt (REvRef E) (RAnsRef E) eq b t2.
+                                     (t1 t2 : itree E R), t1 ≈ t2 -> rutt (REvRef E) (RAnsRef E) eq b t1 ->
+                                                          rutt (REvRef E) (RAnsRef E) eq b t2.
 Proof.
   intros E R. pcofix CIH. intros. punfold H1. red in H1.
   punfold H0. red in H0. pfold. red.
@@ -238,7 +237,7 @@ Proof.
     + constructor. pclearbot. right. eapply CIH; eauto.
     + constructor. right. eapply CIH; eauto.
       apply rutt_inv_tauR. pfold. auto.
-    + punfold REL. red in REL. 
+    + punfold REL. red in REL.
       dependent induction REL; subst.
       * constructor. clear IHruttF.
         hinduction H1 before CIH; intros; dependent destruction x0.
@@ -249,15 +248,15 @@ Proof.
         punfold REL.
       * constructor. rewrite <- x.
         clear IHruttF. hinduction H1 before CIH; intros; dependent destruction x0.
-        ++ constructor. eapply IHruttF; eauto.
         ++ constructor; auto. intros. apply H0 in H1.
            pclearbot. right. eapply CIH; eauto.
+        ++ constructor. eapply IHruttF; eauto.
       * eapply IHruttF; eauto.
       * constructor. rewrite <- x. eapply IHREL; eauto.
   - remember (VisF e k1) as ot1. hinduction H1 before CIH; intros; inv Heqot1.
-    + constructor. eauto.
     + ddestruction. constructor; auto. intros. apply H0 in H1.
       right. pclearbot. eapply CIH; eauto; apply REL.
+    + constructor. eauto.
   - eapply IHeqitF; eauto. remember (TauF t0) as otf0.
     hinduction H1 before CIH; intros; dependent destruction Heqotf0; eauto.
     + constructor. pclearbot. pstep_reverse.
@@ -265,12 +264,12 @@ Proof.
   - constructor. eapply IHeqitF. eauto.
 Qed.
 
-Instance trace_refine_proper {E R} : Proper (@eutt E R R eq ==> eutt eq ==> iff) trace_refine.
+#[global] Instance trace_refine_proper {E R} : Proper (@eutt E R R eq ==> eutt eq ==> iff) trace_refine.
 Proof.
   intros b1 b2 Heuttb t1 t2 Heuttt.
   split; intros;
-  try (eapply trace_refine_proper_right'; [eauto | eapply trace_refine_proper_left'; eauto]);
-  auto; symmetry; auto.
+    try (eapply trace_refine_proper_right'; [eauto | eapply trace_refine_proper_left'; eauto]);
+    auto; symmetry; auto.
 Qed.
 
 Lemma trace_refine_ret : forall (E : Type -> Type) (R : Type) (r : R),
@@ -280,7 +279,7 @@ Proof.
 Qed.
 
 Lemma trace_refine_ret_inv_r : forall (E : Type -> Type) (R : Type) (r : R)
-                                     (t : itree E R),
+                                 (t : itree E R),
     Ret r ⊑ t -> t ≈ Ret r.
 Proof.
   intros. pfold. red. punfold H. red in H. cbn in *.
@@ -290,7 +289,7 @@ Proof.
 Qed.
 
 Lemma trace_refine_ret_inv_l : forall (E : Type -> Type) (R : Type) (r : R)
-                                     (b : itrace E R),
+                                 (b : itrace E R),
     b ⊑ Ret r -> (b ≈ Ret r)%itree.
 Proof.
   intros. pfold. red. punfold H. red in H. cbn in *.
@@ -300,18 +299,18 @@ Proof.
 Qed.
 
 Lemma trace_refine_vis_inv : forall (E : Type -> Type) (R A: Type) (e : E A) (a : A)
-                                     (b :itrace E R) (k : A -> itree E R),
+                               (b :itrace E R) (k : A -> itree E R),
     trace_refine (Vis e k) (Vis (evans A e a) (fun _ => b))  -> trace_refine (k a) b .
 Proof.
   intros E R A e a. intros.
   red in H. red. punfold H. red in H. inversion H. ddestruction.
-  subst. 
+  subst.
   assert (RAnsRef E unit A (evans A e a) tt e a); eauto.
   apply H7 in H0. pclearbot. auto.
 Qed.
 
 Lemma trace_refine_vis_add : forall (E : Type -> Type) (R A: Type) (e : E A) (a : A)
-                                     (b :itrace E R) (k : A -> itree E R),
+                               (b :itrace E R) (k : A -> itree E R),
     b ⊑ k a -> Vis (evans A e a) (fun _ => b) ⊑ Vis e k.
 Proof.
   intros. pfold. red. cbn. constructor; eauto.
@@ -320,7 +319,7 @@ Proof.
 Qed.
 
 Lemma event_ans_constr : forall (E : Type -> Type) (R : Type) (e : E R),
-    exists (A : Type), exists e' : EvAns E A, REvRef E A R e' e.
+  exists (A : Type), exists e' : EvAns E A, REvRef E A R e' e.
 Proof.
   intros.
   destruct (classic_empty R) as  [ [a | Hempty]  _ ] .
@@ -333,47 +332,47 @@ Qed.
 CoFixpoint determinize_ (E : Type -> Type) (R : Type) (ot : itree' E R) : itrace E R.
 Proof.
   destruct ot.
-- apply (Ret r).
-- apply (Tau (determinize_ E R (observe t) ) ).
-- specialize (classic_empty X) as H. 
-  apply constructive_indefinite_description in H. destruct H as [ [x | f] _].
-  + apply (Vis (evans X e x) (fun _ =>  (determinize_ E R (observe (k x)) ) )) .
-  + apply (Vis (evempty X f e) (fun v : void => match v return itrace E R with end)  ).
+  - apply (Ret r).
+  - apply (Tau (determinize_ E R (observe t) ) ).
+  - specialize (classic_empty X) as H.
+    apply constructive_indefinite_description in H. destruct H as [ [x | f] _].
+    + apply (Vis (evans X e x) (fun _ =>  (determinize_ E R (observe (k x)) ) )) .
+    + apply (Vis (evempty X f e) (fun v : void => match v return itrace E R with end)  ).
 Defined.
 
 Definition determinize {E R} t := determinize_ E R (observe t).
 
 (* may be a better idea to make this an axiom *)
 Lemma itree_refine_nonempty : forall (E : Type -> Type) (R : Type) (t : itree E R),
-    exists b : itrace E R, b ⊑ t.
+  exists b : itrace E R, b ⊑ t.
 Proof.
   intros. exists (determinize t). generalize dependent t.
   pcofix CIH. intros. pfold. red. unfold determinize. destruct (observe t).
   - cbn. constructor. auto.
   - cbn. constructor. right. apply CIH.
   - unfold observe. cbn. cbn. destruct (constructive_indefinite_description (fun _ : X + (X -> void) => True)
-                   (classic_empty X)).
+                                                                            (classic_empty X)).
     destruct x as [x | f]; cbn.
-    + constructor; eauto. intros. right. 
+    + constructor; eauto. intros. right.
       inversion H. ddestruction.
       subst. apply CIH.
-    + constructor; auto. intros. contradiction. 
+    + constructor; auto. intros. contradiction.
 Qed.
 
 
 Lemma refine_set_eq_to_eutt_vis_aux : forall (E : Type -> Type) (R : Type) (r : itree E R -> itree E R -> Prop)
-      (CIH : forall t1 t2 : itree E R, (forall b : itrace E R, b ⊑ t1 <-> b ⊑ t2) -> r t1 t2)
-      (t1 t2 : itree E R)
-      (H0 : forall b : itrace E R, b ⊑ t1 <-> b ⊑ t2)
-      (A B : Type) (e : E A) (e0 : E B)
-      (k : A -> itree E R) (k0 : B -> itree E R)
-      (Ht1 : t1 ≅ Vis e k) (Ht2 : t2 ≅ Vis e0 k0 ),
-      eqitF eq true true id (upaco2 (eqit_ eq true true id) r) (VisF e k) (VisF e0 k0).
+                                             (CIH : forall t1 t2 : itree E R, (forall b : itrace E R, b ⊑ t1 <-> b ⊑ t2) -> r t1 t2)
+                                             (t1 t2 : itree E R)
+                                             (H0 : forall b : itrace E R, b ⊑ t1 <-> b ⊑ t2)
+                                             (A B : Type) (e : E A) (e0 : E B)
+                                             (k : A -> itree E R) (k0 : B -> itree E R)
+                                             (Ht1 : t1 ≅ Vis e k) (Ht2 : t2 ≅ Vis e0 k0 ),
+    eqitF eq true true id (upaco2 (eqit_ eq true true id) r) (VisF e k) (VisF e0 k0).
 Proof.
   intros.
   destruct (classic_empty A) as [ [a | Ha] _ ].
   - specialize  trace_refine_vis_add with (e := e) (k := k) (a := a) as Hbrv.
-    assert (exists b, b ⊑ (k a) ). 
+    assert (exists b, b ⊑ (k a) ).
     { apply itree_refine_nonempty. }
     destruct H as [b Hbk]. apply trace_refine_vis_add with (e := e) in Hbk.
     rewrite <- Ht1 in Hbk.
@@ -409,12 +408,15 @@ Proof.
 Qed.
 
 Lemma trace_refine_vis : forall (E : Type -> Type) (R A : Type) (b : itrace E R)
-                                 (e : E A) (k : A -> itree E R),
+                           (e : E A) (k : A -> itree E R),
     b ⊑ Vis e k -> exists X, exists e0 : EvAns E X, exists k0, (b ≈ Vis e0 k0)%itree.
 Proof.
   intros. punfold H. red in H. cbn in H.
   dependent induction H.
-  - enough 
+  - exists A0. exists e1. exists k1.
+    specialize (itree_eta b) as Hb. rewrite <- x in Hb.
+    rewrite Hb. reflexivity.
+  - enough
       (exists (X : Type) (e0 : EvAns E X) (k0 : X -> itree (EvAns E) R), (t1 ≈ Vis e0 k0)%itree).
     {
       destruct H0 as [ X [e0 [k0 Ht1] ] ].
@@ -423,29 +425,26 @@ Proof.
       rewrite tau_eutt. auto.
     }
     eapply IHruttF; eauto.
-  - exists A0. exists e1. exists k1.
-    specialize (itree_eta b) as Hb. rewrite <- x in Hb.
-    rewrite Hb. reflexivity.
 Qed.
 
 Lemma trace_refine_vis_l : forall (E : Type -> Type) (R A: Type) (t : itree E R)
-                                   (e : EvAns E A) (k : A -> itrace E R),
+                                  (e : EvAns E A) (k : A -> itrace E R),
     Vis e k ⊑ t -> exists X, exists e0 : E X, exists k0 : X -> itree E R, t ≈ Vis e0 k0.
 Proof.
   intros. punfold H. red in H. cbn in *.
   dependent induction H.
+  - exists B. exists e2.  exists k2. specialize (itree_eta t) as Ht.
+    rewrite <- x in Ht. rewrite Ht. reflexivity.
   - assert (t2 ≈ t).
     {
       specialize (itree_eta t). rewrite <- x. intros.
       rewrite H0. rewrite tau_eutt. reflexivity.
     }
     setoid_rewrite <- H0. eapply IHruttF; eauto.
-  - exists B. exists e2.  exists k2. specialize (itree_eta t) as Ht.
-      rewrite <- x in Ht. rewrite Ht. reflexivity.
 Qed.
 
 Lemma trace_refine_may_converge_ex : forall (E : Type -> Type) (R : Type)
-                         (t : itree E R) (r : R),
+                                            (t : itree E R) (r : R),
     may_converge r t -> exists b, may_converge r b /\ b ⊑ t.
 Proof.
   intros. induction H.
@@ -459,7 +458,7 @@ Proof.
 Qed.
 
 Lemma trace_refine_may_converge : forall (E : Type -> Type) (R : Type)
-                         (t : itree E R) (r : R) (b : itrace E R),
+                                         (t : itree E R) (r : R) (b : itrace E R),
     may_converge r b -> b ⊑ t -> may_converge r t.
 Proof.
   intros. generalize dependent t. induction H; intros.
@@ -477,7 +476,7 @@ Proof.
 Qed.
 
 Lemma trace_refine_must_diverge : forall (E : Type -> Type) (R : Type)
-                       (t : itree E R) (b : itrace E R),
+                                    (t : itree E R) (b : itrace E R),
     must_diverge t -> b ⊑ t -> must_diverge b.
 Proof.
   intros E R. pcofix CIH. intros. punfold H0. red in H0.
@@ -485,9 +484,6 @@ Proof.
   - rewrite <- x in H0. inversion H0.
   - rewrite <- x0. constructor. right. pclearbot. eapply CIH; eauto.
     rewrite <- x in H0. inv H0. pclearbot. auto.
-  - rewrite <- x. constructor. left.  pfold. eapply IHruttF; eauto.
-  - eapply IHruttF; auto. rewrite <- x in H0. inv H0.
-    pclearbot. punfold H2.
   - rewrite <- x0. rewrite <- x in H0. constructor. inv H0.
     ddestruction. subst. intros. right. pclearbot.
     inversion H; subst; ddestruction; try contradiction. destruct b0.
@@ -495,14 +491,17 @@ Proof.
     specialize (H1 tt a). assert (RAnsRef _ _ _ (evans B e2 a) tt e2 a ).
     constructor. apply H1 in H0. unfold id in H0.
     destruct H0; try contradiction. eauto.
+  - rewrite <- x. constructor. left.  pfold. eapply IHruttF; eauto.
+  - eapply IHruttF; auto. rewrite <- x in H0. inv H0.
+    pclearbot. punfold H2.
 Qed.
 
 Lemma trace_refine_converge_bind : forall (E : Type -> Type) (R S : Type)
-            (b : itrace E R) (t : itree E R) (f : R -> itrace E S) (g : R -> itree E S) (r : R),
+                                          (b : itrace E R) (t : itree E R) (f : R -> itrace E S) (g : R -> itree E S) (r : R),
     may_converge r b -> b ⊑ t -> f r ⊑ g r -> ITree.bind b f ⊑ ITree.bind t g.
 Proof.
   intros. generalize dependent t. dependent induction H; intros.
-  - rewrite H. rewrite H in H0. apply trace_refine_ret_inv_r in H0. 
+  - rewrite H. rewrite H in H0. apply trace_refine_ret_inv_r in H0.
     rewrite H0. repeat rewrite bind_ret_l. auto.
   - specialize (IHmay_converge H1).
     rewrite H in H2. apply trace_refine_vis_l in H2 as Ht.
@@ -512,32 +511,32 @@ Proof.
     inversion H5; ddestruction; subst; try contradiction.
     ddestruction. subst. rewrite H. rewrite Ht.
     pfold. red. cbn. constructor; auto.
-    intros. apply H10 in H3. pclearbot. left. 
+    intros. apply H10 in H3. pclearbot. left.
     destruct a0. destruct b. apply IHmay_converge. auto.
 Qed.
 
 Lemma trace_refine_diverge_bind : forall (E : Type -> Type) (R S : Type)
-                  (b : itrace E R) (t : itree E R) (f : R -> itrace E S) (g : R -> itree E S),
+                                         (b : itrace E R) (t : itree E R) (f : R -> itrace E S) (g : R -> itree E S),
     must_diverge b -> b ⊑ t -> ITree.bind b f ⊑ ITree.bind t g.
 Proof.
   intros E R S b t f g. generalize dependent b. generalize dependent t.
   pcofix CIH. intros.
   punfold H0. red in H0.
-  punfold H1. red in H1. pfold. red. cbn. 
+  punfold H1. red in H1. pfold. red. cbn.
   dependent induction H1.
   - rewrite <- x0 in H0. inv H0.
   - unfold observe. cbn. rewrite <- x0. rewrite <- x.
     cbn. constructor. right. pclearbot. apply CIH; auto.
     rewrite <- x0 in H0. inv H0. pclearbot. auto.
-  - unfold observe at 1. cbn. rewrite <- x. cbn. constructor.
-    eapply IHruttF; eauto. rewrite <- x in H0. inv H0. pclearbot. pstep_reverse.
-  - unfold observe at 2. cbn. rewrite <- x. cbn. constructor. 
-    eapply IHruttF; eauto.
   - unfold observe. cbn. rewrite <- x0. rewrite <- x. cbn. constructor; auto.
     intros.
     rewrite <- x0 in H0. inv H0. ddestruction. subst. pclearbot.
     apply H1 in H2. right. eapply CIH; eauto; try apply H4.
     unfold id in H2. pclearbot. auto.
+  - unfold observe at 1. cbn. rewrite <- x. cbn. constructor.
+    eapply IHruttF; eauto. rewrite <- x in H0. inv H0. pclearbot. pstep_reverse.
+  - unfold observe at 2. cbn. rewrite <- x. cbn. constructor.
+    eapply IHruttF; eauto.
 Qed.
 
 Lemma refine_set_eq_to_eutt : forall (E : Type -> Type) (R : Type) (t1 t2 : itree E R),
@@ -547,7 +546,7 @@ Proof.
   pfold. red.
   remember (observe t1) as ot1. remember (observe t2) as ot2.
   destruct (ot1); destruct (ot2).
-    (*Ret Ret*)
+  (*Ret Ret*)
   - specialize (H0 (Ret r0) ) as Hr0.
     specialize (itree_eta t1) as Ht1. rewrite <- Heqot1 in Ht1.
     specialize (itree_eta t2) as Ht2. rewrite <- Heqot2 in Ht2.
@@ -555,7 +554,7 @@ Proof.
     assert (Ret r0 ⊑ t2).
     { rewrite Ht2. apply Hr0. pfold. constructor. auto. }
     rewrite Ht2 in H. pinversion H. subst. constructor. auto.
-    (*Ret Tau *)
+  (*Ret Tau *)
   - specialize (itree_eta t1) as Ht1. rewrite <- Heqot1 in Ht1.
     specialize (itree_eta t2) as Ht2. rewrite <- Heqot2 in Ht2.
     setoid_rewrite Ht2 in H0.
@@ -567,92 +566,92 @@ Proof.
     clear H0 Ht1 Ht2 Heqot1 Heqot2. dependent induction H.
     + rewrite <- x. constructor; auto.
     + rewrite <- x. constructor; auto.
-    (*Ret Vis*)
+  (*Ret Vis*)
   - exfalso.
     specialize (itree_eta t1) as Ht1. rewrite <- Heqot1 in Ht1.
     specialize (itree_eta t2) as Ht2. rewrite <- Heqot2 in Ht2.
     assert (Ret r0 ⊑ t1).
     { rewrite Ht1. pfold. constructor. auto. }
     apply H0 in H. rewrite Ht2 in H. pinversion H.
-    (*Tau Ret*)
+  (*Tau Ret*)
   - specialize (itree_eta t1) as Ht1. rewrite <- Heqot1 in Ht1.
     specialize (itree_eta t2) as Ht2. rewrite <- Heqot2 in Ht2.
     setoid_rewrite Ht1 in H0. setoid_rewrite Ht2 in H0.
     assert (Ret r0 ⊑ t2).
     { rewrite Ht2. pfold. constructor. auto. }
-     rewrite Ht2 in H. apply H0 in H as H1. punfold H1.
+    rewrite Ht2 in H. apply H0 in H as H1. punfold H1.
     clear Heqot1 Heqot2 Ht1 Ht2 H H0. red in H1. cbn in *.
     constructor; auto. inv H1. dependent induction H2; intros; subst.
-    + rewrite <- x. auto.
     + rewrite <- x. constructor; auto.
-    (*Tau Tau*)
-  - constructor. right. eapply CIH. 
-    intros. 
+    + rewrite <- x. auto.
+  (*Tau Tau*)
+  - constructor. right. eapply CIH.
+    intros.
     specialize (itree_eta t1) as Ht1. rewrite <- Heqot1 in Ht1.
     specialize (itree_eta t2) as Ht2. rewrite <- Heqot2 in Ht2.
     assert (t1 ≈ t). { rewrite Ht1. rewrite tau_eutt. reflexivity. }
     assert (t2 ≈ t0). { rewrite Ht2. rewrite tau_eutt. reflexivity. }
     rewrite <- H. rewrite <- H1. auto.
-    (*Tau Vis*)
+  (*Tau Vis*)
   - specialize (itree_eta t1) as Ht1. rewrite <- Heqot1 in Ht1.
-    specialize (itree_eta t2) as Ht2. rewrite <- Heqot2 in Ht2. 
+    specialize (itree_eta t2) as Ht2. rewrite <- Heqot2 in Ht2.
     specialize (itree_refine_nonempty _ _ (t1) ) as [b Hbt1].
     apply H0 in Hbt1 as Hbt2. rewrite Ht1 in Hbt1.
-    rewrite tau_eutt in Hbt1. 
+    rewrite tau_eutt in Hbt1.
     rewrite Ht2 in Hbt2.
     apply trace_refine_vis in Hbt2 as Hb.
     destruct Hb as [Y [e0 [k0 Hb] ] ].
     rewrite Hb in Hbt2.
     rewrite Hb in Hbt1. clear Hb b.
-    constructor; auto. 
+    constructor; auto.
     setoid_rewrite Ht1 in H0. setoid_rewrite tau_eutt in H0.
     clear Heqot1 Heqot2. clear Ht1 t1.
     punfold Hbt1. red in Hbt1. cbn in *.
     dependent induction Hbt1.
-    + rewrite <- x. constructor; auto. eapply IHHbt1; eauto.
-      assert (t0 ≈ t).
-      { 
-        specialize (itree_eta t) as Ht. rewrite <- x in Ht. rewrite Ht.
-        rewrite tau_eutt. reflexivity. 
-      }
-      setoid_rewrite H. auto.
     + rewrite <- x.
       specialize (itree_eta t) as Ht. rewrite <- x in Ht.
       eapply refine_set_eq_to_eutt_vis_aux; eauto.
-    (*Vis Ret*)
+    + rewrite <- x. constructor; auto. eapply IHHbt1; eauto.
+      assert (t0 ≈ t).
+      {
+        specialize (itree_eta t) as Ht. rewrite <- x in Ht. rewrite Ht.
+        rewrite tau_eutt. reflexivity.
+      }
+      setoid_rewrite H. auto.
+  (*Vis Ret*)
   - exfalso.
     specialize (itree_eta t1) as Ht1. rewrite <- Heqot1 in Ht1.
     specialize (itree_eta t2) as Ht2. rewrite <- Heqot2 in Ht2.
     assert (Ret r0 ⊑ t2).
     { rewrite Ht2. pfold. constructor. auto. }
     apply H0 in H. rewrite Ht1 in H. pinversion H.
-    (*Vis Tau*)
+  (*Vis Tau*)
   - specialize (itree_eta t1) as Ht1. rewrite <- Heqot1 in Ht1.
-    specialize (itree_eta t2) as Ht2. rewrite <- Heqot2 in Ht2. 
+    specialize (itree_eta t2) as Ht2. rewrite <- Heqot2 in Ht2.
     specialize (itree_refine_nonempty _ _ (t2) ) as [b Hbt2].
     apply H0 in Hbt2 as Hbt1. rewrite Ht1 in Hbt1.
     rewrite Ht2 in Hbt2.
-    rewrite tau_eutt in Hbt2. 
+    rewrite tau_eutt in Hbt2.
     apply trace_refine_vis in Hbt1 as Hb.
     destruct Hb as [Y [e0 [k0 Hb] ] ].
     rewrite Hb in Hbt2.
     rewrite Hb in Hbt1. clear Hb b.
-    constructor; auto. 
+    constructor; auto.
     setoid_rewrite Ht2 in H0. setoid_rewrite tau_eutt in H0.
     clear Heqot1 Heqot2. clear Ht2 t2.
     punfold Hbt2. red in Hbt2. cbn in *.
     dependent induction Hbt2.
-    + rewrite <- x. constructor; auto. eapply IHHbt2; eauto.
-      assert (t2 ≈ t).
-      { 
-        specialize (itree_eta t) as Ht. rewrite <- x in Ht. rewrite Ht.
-        rewrite tau_eutt. reflexivity. 
-      }
-      setoid_rewrite H. auto.
     + rewrite <- x.
       specialize (itree_eta t) as Ht. rewrite <- x in Ht.
       eapply refine_set_eq_to_eutt_vis_aux; eauto.
-    (*Vis Vis*)
+    + rewrite <- x. constructor; auto. eapply IHHbt2; eauto.
+      assert (t2 ≈ t).
+      {
+        specialize (itree_eta t) as Ht. rewrite <- x in Ht. rewrite Ht.
+        rewrite tau_eutt. reflexivity.
+      }
+      setoid_rewrite H. auto.
+  (*Vis Vis*)
   - specialize (itree_eta t1) as Ht1. rewrite <- Heqot1 in Ht1.
     specialize (itree_eta t2) as Ht2. rewrite <- Heqot2 in Ht2.
     eapply refine_set_eq_to_eutt_vis_aux; eauto.
@@ -665,8 +664,8 @@ Proof.
 Qed.
 
 Lemma trace_refine_bind_cont_inv : forall (E : Type -> Type) (R S : Type)
-         (b : itrace E R) (m : itree E R) (g : R -> itrace E S)
-         (f : R -> itree E S) (r : R),
+                                          (b : itrace E R) (m : itree E R) (g : R -> itrace E S)
+                                          (f : R -> itree E S) (r : R),
     may_converge r b -> b ⊑ m -> ITree.bind b g ⊑ ITree.bind m f -> g r ⊑ f r.
 Proof.
   intros E R S. pcofix CIH. intros b m g f a Hconv Hrefb Hrefbind.
@@ -675,7 +674,7 @@ Proof.
   - rewrite H in Hrefbind. rewrite bind_ret_l in Hrefbind. rewrite H in Hrefb.
     apply trace_refine_ret_inv_r in Hrefb. rewrite Hrefb in Hrefbind.
     rewrite bind_ret_l in Hrefbind. eapply paco2_mon; eauto. intuition.
-  - (*m must be a vis, the continuations must refine then continuation in the m I use in the 
+  - (*m must be a vis, the continuations must refine then continuation in the m I use in the
       inductive hypothesis *)
     destruct e; try contradiction. rewrite H in Hrefb.
     rewrite H in Hrefbind. rewrite bind_vis in Hrefbind.
@@ -692,7 +691,7 @@ Proof.
 Qed.
 
 Lemma may_converge_two_list:
-  forall (E : Type -> Type) (A B : Type) (log : ev_list E) (b : itrace E A) 
+  forall (E : Type -> Type) (A B : Type) (log : ev_list E) (b : itrace E A)
     (a : A) (log' : ev_list E),
     (ev_list_to_stream log) ++ b ≈ (ev_list_to_stream log') ++ Ret a -> may_converge a b.
 Proof.
@@ -712,7 +711,7 @@ Proof.
       eapply IHlog; eauto.
 Qed.
 
-Lemma must_diverge_bind_append: forall (E : Type -> Type) (A : Type) 
+Lemma must_diverge_bind_append: forall (E : Type -> Type) (A : Type)
                                   (log : ev_list E) (b' : itree (EvAns E) A),
     must_diverge (ev_list_to_stream log ++ b') -> must_diverge b'.
 Proof.

--- a/theories/ITrace/ITracePreds.v
+++ b/theories/ITrace/ITracePreds.v
@@ -19,15 +19,15 @@ Local Open Scope monad_scope.
 
 (* Defines some useful predicates over ITraces *)
 
-Variant trace_forallF {E : Type -> Type} {R : Type} (F : itrace E R -> Prop) 
+Variant trace_forallF {E : Type -> Type} {R : Type} (F : itrace E R -> Prop)
         (PE : forall A, EvAns E A -> Prop) (PR : R -> Prop) : itrace' E R -> Prop :=
-| trace_forall_ret (r : R) : PR r -> trace_forallF F PE PR (RetF r)
-| trace_forall_tau (b : itrace E R) : F b -> trace_forallF F PE PR (TauF b)
-| trace_forall_vis {A : Type} (e : EvAns E A) (k : A -> itrace E R) :
+  | trace_forall_ret (r : R) : PR r -> trace_forallF F PE PR (RetF r)
+  | trace_forall_tau (b : itrace E R) : F b -> trace_forallF F PE PR (TauF b)
+  | trace_forall_vis {A : Type} (e : EvAns E A) (k : A -> itrace E R) :
     PE A e -> (forall (a :A), F (k a) ) -> trace_forallF F PE PR (VisF e k)
 .
 
-Hint Constructors trace_forallF.
+#[global] Hint Constructors trace_forallF : core.
 
 Definition trace_forall_ {E R} PE PR F (b : itrace E R) :=
   trace_forallF F PE PR (observe b).
@@ -37,12 +37,12 @@ Proof.
   repeat intro. red in IN. red. induction IN; auto.
 Qed.
 
-Hint Resolve trace_forall_monot : paco.
+#[global] Hint Resolve trace_forall_monot : paco.
 
 Definition trace_forall {E R} PE PR := paco1 (@trace_forall_ E R PE PR) bot1.
 
 Lemma trace_forall_proper_aux: forall (E : Type -> Type) (R : Type) (PE : forall A : Type, EvAns E A -> Prop)
-                                  (PR : R -> Prop) (b1 b2 : itree (EvAns E) R),
+                                 (PR : R -> Prop) (b1 b2 : itree (EvAns E) R),
     (b1 ≈ b2) -> trace_forall PE PR b1 -> trace_forall PE PR b2.
 Proof.
   intros E R PE PR. pcofix CIH. intros b1 b2 Heutt Hforall.
@@ -56,14 +56,12 @@ Proof.
   - constructor. left. pfold. red. apply IHHeutt. auto.
 Qed.
 
-Global Instance trace_forall_proper_eutt {E R PE PR} : Proper (eutt eq ==> iff) (@trace_forall E R PE PR).
+#[global] Instance trace_forall_proper_eutt {E R PE PR} : Proper (eutt eq ==> iff) (@trace_forall E R PE PR).
 Proof.
   intros b1 b2 Heutt. split; intros.
   - eapply trace_forall_proper_aux; eauto.
   - symmetry in Heutt. eapply trace_forall_proper_aux; eauto.
 Qed.
-    
-      
 
 Lemma forall_spin : forall E R PE PR, trace_forall PE PR (@ITree.spin (EvAns E) R).
 Proof.
@@ -72,16 +70,16 @@ Proof.
 Qed.
 
 Inductive trace_inf_oftenF {E : Type -> Type} {R : Type} (PE : forall A, EvAns E A -> Prop)
-        (F : itrace E R -> Prop) : itrace' E R -> Prop :=
-| trace_inf_often_tau (b : itrace E R) : trace_inf_oftenF PE F (observe b) -> 
-                                             trace_inf_oftenF PE F (TauF b)
-| trace_inf_often_vis_neg (e : EvAns E unit) (k : unit -> itrace E R) : 
-    trace_inf_oftenF PE F (observe (k tt)) -> trace_inf_oftenF PE F (VisF e k)
-| trace_inf_often_vis_pos (e : EvAns E unit) (k : unit -> itrace E R) : 
-    F (k tt) -> PE unit e -> trace_inf_oftenF PE F (VisF e k)
+          (F : itrace E R -> Prop) : itrace' E R -> Prop :=
+| trace_inf_often_tau (b : itrace E R) : trace_inf_oftenF PE F (observe b) ->
+                                         trace_inf_oftenF PE F (TauF b)
+| trace_inf_often_vis_neg (e : EvAns E unit) (k : unit -> itrace E R) :
+  trace_inf_oftenF PE F (observe (k tt)) -> trace_inf_oftenF PE F (VisF e k)
+| trace_inf_often_vis_pos (e : EvAns E unit) (k : unit -> itrace E R) :
+  F (k tt) -> PE unit e -> trace_inf_oftenF PE F (VisF e k)
 .
 
-Hint Constructors trace_inf_oftenF.
+#[global] Hint Constructors trace_inf_oftenF : core.
 
 Definition trace_inf_often_ {E R} PE F (b : itrace E R) :=
   trace_inf_oftenF PE F (observe b).
@@ -91,17 +89,17 @@ Proof.
   repeat intro. red in IN. red. induction IN; auto.
 Qed.
 
-Hint Resolve trace_inf_often_monot : paco.
+#[global] Hint Resolve trace_inf_often_monot : paco.
 
 Definition trace_inf_often {E R} PE := paco1 (@trace_inf_often_ E R PE) bot1.
 
 Inductive front_and_last {E : Type -> Type} {R : Type} (PEF : forall A, EvAns E A -> Prop)
           (PEL : forall A, EvAns E A -> Prop) (PR : R -> Prop) : itrace E R -> Prop :=
 | front_and_last_base (e : EvAns E unit) (r : R) (b : itree (EvAns E) R) :
-    b ≈ Vis e (fun u => Ret r) -> PEL unit e -> PR r -> front_and_last PEF PEL PR b
-  | front_and_last_cons (e : EvAns E unit) (k : unit -> itrace E R) (b : itree (EvAns E) R ) :
-      b ≈ Vis e k -> PEF unit e -> front_and_last PEF PEL PR (k tt) -> front_and_last PEF PEL PR b
-      
+  b ≈ Vis e (fun u => Ret r) -> PEL unit e -> PR r -> front_and_last PEF PEL PR b
+| front_and_last_cons (e : EvAns E unit) (k : unit -> itrace E R) (b : itree (EvAns E) R ) :
+  b ≈ Vis e k -> PEF unit e -> front_and_last PEF PEL PR (k tt) -> front_and_last PEF PEL PR b
+
 .
 
 Lemma fal_proper_aux: forall (E : Type -> Type) (R : Type) (PEF PEL : forall A : Type, EvAns E A -> Prop)
@@ -115,62 +113,63 @@ Proof.
   - eapply front_and_last_cons; eauto. rewrite <- Heutt. auto.
 Qed.
 
-Global Instance front_and_last_proper_eutt {E R PEF PEL PR} : Proper (eutt eq ==> iff) (@front_and_last E R PEF PEL PR).
+#[global] Instance front_and_last_proper_eutt {E R PEF PEL PR} :
+  Proper (eutt eq ==> iff) (@front_and_last E R PEF PEL PR).
 Proof.
   intros b1 b2 Heutt. split; intros.
   - eapply fal_proper_aux; eauto.
   - symmetry in Heutt. eapply fal_proper_aux; eauto.
 Qed.
-     
-Section StateMachine.
-(*Note that this state machine definition is not able to deal with empty event parameter types*)
-(*Nor can it encode predicates that can accept silent divergence under certain conditions *)
-(*Pretty sure it could be extended to handle that,but that is a job for another day*)
-Context {E : Type -> Type}.
-Context {R : Type}.
-Context (EvTrans : forall A, E A -> A -> forall B, E B -> B -> Prop).
-Context (RetTrans : forall A, E A -> A -> R -> Prop).
 
-Inductive state_machineF (PEv : forall A, E A -> A -> Prop) (PRet : R -> Prop) 
-          (F : (forall A, E A -> A -> Prop) -> (R -> Prop) -> itrace E R -> Prop) : itrace' E R -> Prop :=
+Section StateMachine.
+  (*Note that this state machine definition is not able to deal with empty event parameter types*)
+  (*Nor can it encode predicates that can accept silent divergence under certain conditions *)
+  (*Pretty sure it could be extended to handle that,but that is a job for another day*)
+  Context {E : Type -> Type}.
+  Context {R : Type}.
+  Context (EvTrans : forall A, E A -> A -> forall B, E B -> B -> Prop).
+  Context (RetTrans : forall A, E A -> A -> R -> Prop).
+
+  Inductive state_machineF (PEv : forall A, E A -> A -> Prop) (PRet : R -> Prop)
+            (F : (forall A, E A -> A -> Prop) -> (R -> Prop) -> itrace E R -> Prop) : itrace' E R -> Prop :=
   | smRet r : PRet r -> state_machineF PEv PRet F (RetF r)
   | smTau t : state_machineF PEv PRet F (observe t) -> state_machineF PEv PRet F (TauF t)
-  | smVis A (e : E A) (a : A) (k : unit -> itrace E R) : 
-      PEv A e a -> F (EvTrans A e a) (RetTrans A e a) (k tt) -> state_machineF PEv PRet F (VisF (evans A e a) k)
-.
+  | smVis A (e : E A) (a : A) (k : unit -> itrace E R) :
+    PEv A e a -> F (EvTrans A e a) (RetTrans A e a) (k tt) -> state_machineF PEv PRet F (VisF (evans A e a) k)
+  .
 
-Hint Constructors state_machineF.
+  Hint Constructors state_machineF : core.
 
-Definition state_machine_ F PEv PRet (tr : itrace E R) :=
-  state_machineF PEv PRet F (observe tr).
+  Definition state_machine_ F PEv PRet (tr : itrace E R) :=
+    state_machineF PEv PRet F (observe tr).
 
-Lemma monotone_state_machine : monotone3 state_machine_.
-Proof.
-  red. intros. red. red in IN. induction IN; auto.
-Qed.
-Hint Resolve trace_inf_often_monot : paco.
-Definition state_machine PEv PRet (tr : itrace E R) :  Prop := paco3 (state_machine_) bot3 PEv PRet tr.
+  Lemma monotone_state_machine : monotone3 state_machine_.
+  Proof.
+    red. intros. red. red in IN. induction IN; auto.
+  Qed.
+  Hint Resolve trace_inf_often_monot : paco.
+  Definition state_machine PEv PRet (tr : itrace E R) :  Prop := paco3 (state_machine_) bot3 PEv PRet tr.
 
-Lemma state_machine_proper_aux : forall PEv PRet (t1 t2 : itrace E R), 
-    (t1 ≈ t2) -> state_machine PEv PRet t1 -> state_machine PEv PRet t2.
-Proof.
-  pcofix CIH. intros PEV PREt t1 t2 Heutt Hsm. pfold. red.
-  punfold Hsm; try apply monotone_state_machine.
-  punfold Heutt. red in Heutt. red in Hsm. 
-  induction Hsm.
-  - remember (RetF r0) as ot1. induction Heutt; subst; auto; try discriminate.
-    injection Heqot1; intros; subst; auto.
-  - apply IHHsm. pstep_reverse. assert (Tau t ≈ t2); auto.
-    rewrite tau_eutt in H. auto.
-  - remember (VisF (evans A e a) k ) as ot1. induction Heutt; subst; auto; try discriminate.
-    injection Heqot1; intros; subst. dependent destruction H1.
-    subst. constructor; auto. right. pclearbot. eapply CIH; eauto.
-    destruct H0; tauto.
-Qed.
+  Lemma state_machine_proper_aux : forall PEv PRet (t1 t2 : itrace E R),
+      (t1 ≈ t2) -> state_machine PEv PRet t1 -> state_machine PEv PRet t2.
+  Proof.
+    pcofix CIH. intros PEV PREt t1 t2 Heutt Hsm. pfold. red.
+    punfold Hsm; try apply monotone_state_machine.
+    punfold Heutt. red in Heutt. red in Hsm.
+    induction Hsm.
+    - remember (RetF r0) as ot1. induction Heutt; subst; auto; try discriminate.
+      injection Heqot1; intros; subst; auto.
+    - apply IHHsm. pstep_reverse. assert (Tau t ≈ t2); auto.
+      rewrite tau_eutt in H. auto.
+    - remember (VisF (evans A e a) k ) as ot1. induction Heutt; subst; auto; try discriminate.
+      injection Heqot1; intros; subst. dependent destruction H1.
+      subst. constructor; auto. right. pclearbot. eapply CIH; eauto.
+      destruct H0; tauto.
+  Qed.
 
-Global Instance state_machine_proper_eutt {PEv PRet} : Proper (eutt eq ==> iff) (@state_machine PEv PRet).
-Proof.
-  intros t1 t2 Heutt. split; intros; try eapply state_machine_proper_aux; eauto; symmetry; auto.
-Qed.
+  #[global] Instance state_machine_proper_eutt {PEv PRet} : Proper (eutt eq ==> iff) (@state_machine PEv PRet).
+  Proof.
+    intros t1 t2 Heutt. split; intros; try eapply state_machine_proper_aux; eauto; symmetry; auto.
+  Qed.
 
 End StateMachine.

--- a/theories/ITrace/ITracePrefix.v
+++ b/theories/ITrace/ITracePrefix.v
@@ -23,33 +23,33 @@ Local Open Scope monad_scope.
 (* Defines and explores a notion of traces being prefixes of other traces *)
 
 Inductive trace_prefixF {E : Type -> Type} {R S : Type} (F : itrace E R -> itrace E S -> Prop) : itrace' E R -> itrace' E S ->  Prop :=
-  | ret_prefix (r : R) (b : itrace E S) : trace_prefixF F (RetF r) (observe b)
-  | tau_prefix (br : itrace E R) (bs : itrace E S) : F br bs -> trace_prefixF F (TauF br) (TauF bs)
-  | tau_r_prefix (br : itrace E R) (obs : itrace' E S) : trace_prefixF F (observe br) obs -> trace_prefixF F (TauF br) obs
-  | tau_l_prefix (obr : itrace' E R) (bs : itrace E S) : trace_prefixF F (obr) (observe bs) -> trace_prefixF F (obr) (TauF bs)
-  | tau_vis_empty {A : Type} (e : E A) (H: A -> void) (kr : void -> itrace E R) (ks : void -> itrace E S) : 
-      trace_prefixF F (VisF (evempty A H e) kr) (VisF (evempty A H e) ks )
-  | tau_vis_ans {A : Type} (e : E A) (ans : A) (kr : unit -> itrace E R) (ks : unit -> itrace E S) :
-      F (kr tt) (ks tt) -> trace_prefixF F (VisF (evans A e ans) kr ) (VisF (evans A e ans) ks)
+| ret_prefix (r : R) (b : itrace E S) : trace_prefixF F (RetF r) (observe b)
+| tau_prefix (br : itrace E R) (bs : itrace E S) : F br bs -> trace_prefixF F (TauF br) (TauF bs)
+| tau_r_prefix (br : itrace E R) (obs : itrace' E S) : trace_prefixF F (observe br) obs -> trace_prefixF F (TauF br) obs
+| tau_l_prefix (obr : itrace' E R) (bs : itrace E S) : trace_prefixF F (obr) (observe bs) -> trace_prefixF F (obr) (TauF bs)
+| tau_vis_empty {A : Type} (e : E A) (H: A -> void) (kr : void -> itrace E R) (ks : void -> itrace E S) :
+  trace_prefixF F (VisF (evempty A H e) kr) (VisF (evempty A H e) ks )
+| tau_vis_ans {A : Type} (e : E A) (ans : A) (kr : unit -> itrace E R) (ks : unit -> itrace E S) :
+  F (kr tt) (ks tt) -> trace_prefixF F (VisF (evans A e ans) kr ) (VisF (evans A e ans) ks)
 .
 
-Hint Constructors trace_prefixF.
+#[global] Hint Constructors trace_prefixF : core.
 
 Definition trace_prefix_ {E R S} F (br : itrace E R) (bs : itrace E S) := trace_prefixF F (observe br) (observe bs).
 
-Hint Unfold trace_prefix_.
+#[global] Hint Unfold trace_prefix_ : core.
 
 Lemma trace_prefix_monot {E R S} : monotone2 (@trace_prefix_ E R S).
 Proof.
   repeat intro. red. red in IN. induction IN; eauto.
 Qed.
 
-Hint Resolve trace_prefix_monot : paco.
+#[global] Hint Resolve trace_prefix_monot : paco.
 
 Definition trace_prefix {E R S} : itrace E R -> itrace E S -> Prop := paco2 trace_prefix_ bot2.
 
-Lemma prefix_vis : forall E R S A (e : E A) (ans : A) (k : unit -> itrace E R) (t : itrace E S), 
-                     trace_prefix (Vis (evans _ e ans) k ) t -> exists k', (t ≈ Vis (evans _ e ans) k' )%itree.
+Lemma prefix_vis : forall E R S A (e : E A) (ans : A) (k : unit -> itrace E R) (t : itrace E S),
+    trace_prefix (Vis (evans _ e ans) k ) t -> exists k', (t ≈ Vis (evans _ e ans) k' )%itree.
 Proof.
   intros E R S A e ans k t Hbp. punfold Hbp. red in Hbp. cbn in *.
   dependent induction Hbp.
@@ -67,7 +67,7 @@ Proof.
 Qed.
 
 Lemma trace_prefix_proper_aux_vis: forall (E : Type -> Type) (S R : Type)
-                                  (t1 : itree (EvAns E) R) (b2 : itrace E R),
+                                     (t1 : itree (EvAns E) R) (b2 : itrace E R),
     eqitF eq true true id
           (upaco2 (eqit_ eq true true id) bot2)
           (observe t1) (observe b2) ->
@@ -75,13 +75,13 @@ Lemma trace_prefix_proper_aux_vis: forall (E : Type -> Type) (S R : Type)
       (X : Type) (e : EvAns E X)
       (k : X -> itree (EvAns E) S),
       trace_prefixF (upaco2 trace_prefix_ bot2)
-                     (observe t1) (VisF e k) ->
+                    (observe t1) (VisF e k) ->
       (forall (b1 b2 : itrace E R)
          (b : itrace E S),
           (b1 ≈ b2) ->
           trace_prefix b1 b -> r b2 b) ->
-        trace_prefixF (upaco2 trace_prefix_ r)
-        (observe b2) (VisF e k).
+      trace_prefixF (upaco2 trace_prefix_ r)
+                    (observe b2) (VisF e k).
 Proof.
   intros E S R t1 b2 Heutt r X e k H0 CIH.
   dependent induction H0.
@@ -103,7 +103,7 @@ Lemma trace_prefix_tau_inv:
   forall (E : Type -> Type) (S R : Type)
     (m1 : itree (EvAns E) R) (t : itree (EvAns E) S),
     trace_prefixF (upaco2 trace_prefix_ bot2)
-                   (TauF m1) (TauF t) -> trace_prefix m1 t.
+                  (TauF m1) (TauF t) -> trace_prefix m1 t.
 Proof.
   intros E S R m1 t Hbp.
   dependent induction  Hbp.
@@ -126,9 +126,9 @@ Proof.
   pfold. red. punfold Heutt. red in Heutt. punfold Hbp. red in Hbp.
   dependent induction Heutt.
   - rewrite <- x. constructor.
-  - rewrite <- x. rewrite <- x0 in Hbp. clear x0 x. pclearbot. 
+  - rewrite <- x. rewrite <- x0 in Hbp. clear x0 x. pclearbot.
     destruct (observe b) eqn : Heqb.
-    + inv Hbp. constructor. dependent induction  H0. 
+    + inv Hbp. constructor. dependent induction  H0.
       * apply simpobs in x0. assert (m1 ≈ m2); auto.
         rewrite x0 in H. clear x x0 Heqb CIH REL.
         punfold H. red in H. cbn in *. dependent induction H.
@@ -138,14 +138,14 @@ Proof.
         apply simpobs in x. assert (m1 ≈ m2); auto.
         rewrite x in H. rewrite tau_eutt in H. auto.
     + constructor. right. eapply CIH; eauto. eapply trace_prefix_tau_inv; eauto.
-    + constructor. clear Heqb. inv Hbp. dependent induction H0. 
+    + constructor. clear Heqb. inv Hbp. dependent induction H0.
       * apply simpobs in x0. assert (m1 ≈ m2); auto.
         rewrite x0 in H. punfold H. red in H. cbn in *.
         dependent induction H.
-       ++ rewrite <- x. apply trace_prefix_ret.
-       ++ rewrite <- x. constructor. eapply IHeqitF; eauto.
-          assert (m1 ≈ m2); auto.
-          apply simpobs in x. rewrite x in H0. rewrite tau_eutt in H0. auto.
+        ++ rewrite <- x. apply trace_prefix_ret.
+        ++ rewrite <- x. constructor. eapply IHeqitF; eauto.
+           assert (m1 ≈ m2); auto.
+           apply simpobs in x. rewrite x in H0. rewrite tau_eutt in H0. auto.
       * eapply IHtrace_prefixF; auto.
         assert (m1 ≈ m2); auto. apply simpobs in x.
         rewrite x in H. rewrite tau_eutt in H. auto.
@@ -161,7 +161,7 @@ Proof.
         rewrite x in H0. punfold H0. red in H0. cbn in *.
         dependent induction H0.
         ++ rewrite <- x. constructor. right. pclearbot. eapply CIH; eauto.
-        ++ rewrite <- x. constructor. eapply IHeqitF; eauto. 
+        ++ rewrite <- x. constructor. eapply IHeqitF; eauto.
            assert (m1 ≈ m2); auto.
            apply simpobs in x. rewrite x in H1. rewrite tau_eutt in H1. auto.
   - rewrite <- x. rewrite <- x0 in Hbp. clear x x0. pclearbot.
@@ -177,9 +177,9 @@ Proof.
         dependent induction  Heutt.
         ++ rewrite <- x. apply trace_prefix_ret.
         ++ rewrite <- x. constructor. eapply IHHeutt; eauto.
-       * eapply IHtrace_prefixF; auto.
-         assert (t1 ≈ b2); auto.
-         apply simpobs in x. rewrite x in H. rewrite tau_eutt in H. punfold H.
+      * eapply IHtrace_prefixF; auto.
+        assert (t1 ≈ b2); auto.
+        apply simpobs in x. rewrite x in H. rewrite tau_eutt in H. punfold H.
     + constructor. eapply IHHeutt; eauto. pstep_reverse. eapply trace_prefix_tau_inv; eauto.
     + clear IHHeutt. inv Hbp. eapply trace_prefix_proper_aux_vis; eauto.
   - rewrite <- x. constructor. eapply IHHeutt; eauto.
@@ -187,11 +187,11 @@ Qed.
 
 Lemma trace_prefixF_tau_inv_r:
   forall (E : Type -> Type) (S R : Type)
-    (t1 : itree (EvAns E) S) (b : itrace E R),
+         (t1 : itree (EvAns E) S) (b : itrace E R),
     trace_prefixF (upaco2 trace_prefix_ bot2)
-                   (observe b) (TauF t1) ->
+                  (observe b) (TauF t1) ->
     trace_prefixF (upaco2 trace_prefix_ bot2)
-                   (observe b) (observe t1).
+                  (observe b) (observe t1).
 Proof.
   intros E S R t1 b Hbp.
   dependent induction  Hbp.
@@ -200,22 +200,22 @@ Proof.
   - rewrite <- x. constructor. eapply IHHbp; eauto.
   - auto.
 Qed.
-  
+
 Lemma trace_prefixF_vis_l:
   forall (E : Type -> Type) (S R : Type)
-    (m1 m2 : itree (EvAns E) S),
+         (m1 m2 : itree (EvAns E) S),
     paco2 (eqit_ eq true true id) bot2 m1 m2 ->
     forall (r : itrace E R -> itrace E S -> Prop)
-      (X : Type) (e : EvAns E X)
-      (k : X -> itree (EvAns E) R),
+           (X : Type) (e : EvAns E X)
+           (k : X -> itree (EvAns E) R),
       trace_prefixF (upaco2 trace_prefix_ bot2)
-                     (VisF e k) (observe m1) ->
+                    (VisF e k) (observe m1) ->
       (forall (b : itrace E R)
-         (b1 b2 : itrace E S),
+              (b1 b2 : itrace E S),
           (b1 ≈ b2) ->
           trace_prefix b b1 -> r b b2 ) ->
-      trace_prefixF (upaco2 trace_prefix_ r) 
-                     (VisF e k) (observe m2).
+      trace_prefixF (upaco2 trace_prefix_ r)
+                    (VisF e k) (observe m2).
 Proof.
   intros E S R m1 m2 REL r X e k H1 CIH.
   punfold REL. red in REL.
@@ -228,7 +228,7 @@ Proof.
     + rewrite <- x. constructor.
     + rewrite <- x. constructor. eapply IHREL; eauto.
   - pclearbot. rewrite <- x in REL. dependent induction REL.
-    + rewrite <- x. constructor. right. pclearbot. eapply CIH; eauto. 
+    + rewrite <- x. constructor. right. pclearbot. eapply CIH; eauto.
     + rewrite <- x. constructor. eapply IHREL; eauto.
 Qed.
 
@@ -254,8 +254,8 @@ Proof.
   - eapply IHHeutt; auto. rewrite <- x in Hbp. eapply trace_prefixF_tau_inv_r; eauto.
   - rewrite <- x. constructor. eapply IHHeutt; eauto.
 Qed.
-  
-Instance trace_prefix_proper {E R S} : Proper (eutt eq ==> eutt eq ==> iff) (@trace_prefix E R S).
+
+#[global] Instance trace_prefix_proper {E R S} : Proper (eutt eq ==> eutt eq ==> iff) (@trace_prefix E R S).
 Proof.
   repeat intro. split; intros.
   - eapply trace_prefix_proper_l; eauto.
@@ -266,9 +266,9 @@ Proof.
 Qed.
 
 Inductive ind_comb {E R S} : itrace E R -> itrace E S -> itrace E S -> Prop :=
-  | left_ret_comb (r : R) b1 b2 b : (b1 ≈ Ret r)%itree -> (b2 ≈ b)%itree -> ind_comb b1 b2 b
-  | left_vis_comb {A : Type} (e : E A) (ans : A) (k1 : unit -> itrace E R) (k2 : unit -> itrace E S) b1 b2 b 
-    : (b1 ≈ Vis (evans _ e ans) k1) -> (b ≈ (Vis (evans _ e ans) k2 ))%itree -> ind_comb (k1 tt) b2 (k2 tt) -> 
+| left_ret_comb (r : R) b1 b2 b : (b1 ≈ Ret r)%itree -> (b2 ≈ b)%itree -> ind_comb b1 b2 b
+| left_vis_comb {A : Type} (e : E A) (ans : A) (k1 : unit -> itrace E R) (k2 : unit -> itrace E S) b1 b2 b
+  : (b1 ≈ Vis (evans _ e ans) k1) -> (b ≈ (Vis (evans _ e ans) k2 ))%itree -> ind_comb (k1 tt) b2 (k2 tt) ->
     ind_comb b1 b2 b.
 
 
@@ -282,14 +282,15 @@ Proof.
 Qed.
 
 Inductive trace_prefix_ind {E R S} : itrace E R -> itrace E S -> Prop :=
-  | left_ret_bp (r : R) b1 b2 : (b1 ≈ Ret r)%itree -> trace_prefix_ind b1 b2
-  | left_vis_bp {A : Type} (e : E A) (ans : A) (k1 : unit -> itrace E R) (k2 : unit -> itrace E S) b1 b2 :
-      (b1 ≈ Vis (evans _ e ans) k1)%itree -> (b2 ≈ Vis (evans _ e ans) k2 )%itree -> trace_prefix_ind (k1 tt) (k2 tt) ->
-      trace_prefix_ind b1 b2
+| left_ret_bp (r : R) b1 b2 : (b1 ≈ Ret r)%itree -> trace_prefix_ind b1 b2
+| left_vis_bp {A : Type} (e : E A) (ans : A) (k1 : unit -> itrace E R) (k2 : unit -> itrace E S) b1 b2 :
+  (b1 ≈ Vis (evans _ e ans) k1)%itree -> (b2 ≈ Vis (evans _ e ans) k2 )%itree -> trace_prefix_ind (k1 tt) (k2 tt) ->
+  trace_prefix_ind b1 b2
 .
 
-Lemma trace_prefix_ind_comb : forall E R S (b1 : itrace E R) (b2 : itrace E S), trace_prefix_ind b1 b2 ->
-                                                                          exists b3, ind_comb b1 b3 b2.
+Lemma trace_prefix_ind_comb : forall E R S (b1 : itrace E R) (b2 : itrace E S),
+    trace_prefix_ind b1 b2 ->
+    exists b3, ind_comb b1 b3 b2.
 Proof.
   intros E R S b1 b2 Hpre. induction Hpre.
   - exists b2. econstructor; eauto. reflexivity.
@@ -297,14 +298,15 @@ Proof.
     exists b3. eapply left_vis_comb; eauto.
 Qed.
 
-Lemma trace_prefix_ind_bind : forall E R S (b1 : itrace E R) (b2 : itrace E S), trace_prefix_ind b1 b2 -> 
-  exists g, (ITree.bind b1 g ≈ b2)%itree.
+Lemma trace_prefix_ind_bind : forall E R S (b1 : itrace E R) (b2 : itrace E S),
+    trace_prefix_ind b1 b2 ->
+    exists g, (ITree.bind b1 g ≈ b2)%itree.
 Proof.
   intros. apply trace_prefix_ind_comb in H. destruct H as [b3 Hb3].
   apply ind_comb_bind in Hb3. exists (fun _ => b3). auto.
 Qed.
 
-Lemma converge_trace_prefix : forall E R S (b1 : itrace E R) (b2 : itrace E S) (r : R), 
+Lemma converge_trace_prefix : forall E R S (b1 : itrace E R) (b2 : itrace E S) (r : R),
     trace_prefix b1 b2 -> may_converge r b1 -> trace_prefix_ind b1 b2.
 Proof.
   intros E R S b1 b2 r Hbp Hconv. generalize dependent b2. induction Hconv; intros.
@@ -325,7 +327,7 @@ Proof.
   - inv Hdiv.
   - constructor. inv Hdiv. pclearbot. right. apply CIH; auto.
   - constructor; auto. apply IHHbf. pstep_reverse. inv Hdiv. pclearbot. auto.
-  - constructor; auto. 
+  - constructor; auto.
   - constructor. intuition.
   - pclearbot. constructor. intros. right. pclearbot. inv Hdiv. ddestruction; subst.
     pclearbot. destruct v. apply CIH; auto. apply H1.
@@ -338,7 +340,7 @@ Proof.
   - destruct H0 as [r Hconv]. eapply converge_trace_prefix in Hconv; eauto.
     apply trace_prefix_ind_bind. auto.
   - eapply trace_prefix_div in H0 as Heuttdiv; eauto.
-    exists (fun _ => ITree.spin). apply eutt_div_subrel. apply eutt_div_sym. 
+    exists (fun _ => ITree.spin). apply eutt_div_subrel. apply eutt_div_sym.
     eapply div_bind_nop with (f := (fun _ => ITree.spin) ) in H0 as H1.
     eapply eutt_div_trans; try apply H1. apply eutt_div_sym. auto.
 Qed.


### PR DESCRIPTION
Minor simplifications to [rutt]:

- Swapped the order of constructors so that they match the definition of [eqit]
- Removed the [vclo] argument: it is introduced in [eqit] exclusively for the definition of [euttG]. If we don't define something similar here, it is completely useless
- Specialized the up-to [eqit] closure. It is only useful to prove up-to [euttge] so no need to carry all these booleans around.

Note: the up-to [eqit] closure is almost a duplicate of the one used to close [eutt] itself, except that this one is heterogeneous in [E]. We could generalize the latter and reuse it here to avoid some duplication.

Also fixed a bunch of warnings against 8.14, hope it doesn't break compatibility with older versions of Coq.