### PR TITLE
More interaction lemmas and inversion principles

### DIFF
--- a/theories/Core/Subevent.v
+++ b/theories/Core/Subevent.v
@@ -114,3 +114,17 @@ Lemma subevent_subevent : forall {E F G :Type -> Type} (SEF: E -< F) (SFG: F -< 
 Proof.
   reflexivity.
 Qed.
+
+#[global] Instance subevent_void1 {E}: void1 -< E := fun T e => match e with end.
+
+Lemma subevent_left {E F R} (e: E R):
+  @subevent E (E +' F) (ReSum_inl _ _ _ _ _) R e = inl1 e.
+Proof.
+  reflexivity.
+Qed.
+
+Lemma subevent_right {E F R} (e: F R):
+  @subevent F (E +' F) (ReSum_inr _ _ _ _ _) R e = inr1 e.
+Proof.
+  reflexivity.
+Qed.

--- a/theories/Interp/InterpFacts.v
+++ b/theories/Interp/InterpFacts.v
@@ -362,6 +362,21 @@ Proof.
   reflexivity.
 Qed.
 
+Lemma interp_iter'_eutt {E F} (f: E ~> itree F) {I A}
+    (t : I -> itree E (I + A))
+    (t': I -> itree F (I + A))
+    (Heq: forall i, interp f (t i) ≈ t' i):
+  forall i, interp f (ITree.iter t i) ≈ ITree.iter t' i.
+Proof.
+  ginit. gcofix CIH; intros i.
+  rewrite 2 unfold_iter.
+  rewrite interp_bind.
+  guclo eqit_clo_bind; econstructor; eauto. apply Heq.
+  intros [] _ []; cbn.
+  - rewrite interp_tau; gstep; constructor; auto with paco.
+  - rewrite interp_ret. gstep; constructor; auto.
+Qed.
+
 Lemma interp_loop {E F} (f : E ~> itree F) {A B C}
       (t : C + A -> itree E (C + B)) a :
   interp f (loop (C := ktree E) t a) ≅ loop (C := ktree F) (fun ca => interp f (t ca)) a.
@@ -386,4 +401,12 @@ Proof.
   - unfold cat, id_, Id_Kleisli, inr_, Inr_Kleisli, lift_ktree, pure; cbn.
     rewrite interp_bind, interp_ret, !bind_ret_l, interp_ret.
     reflexivity.
+Qed.
+
+Lemma translate_iter {E F I R} (b: I -> itree E (I + R)) (h: E ~> F) i:
+  translate h (ITree.iter b i) ≈ ITree.iter (fun x => translate h (b x)) i.
+Proof.
+  rewrite translate_to_interp.
+  rewrite interp_iter'_eutt. reflexivity. clear i.
+  intros i. cbn. rewrite translate_to_interp. reflexivity.
 Qed.

--- a/theories/Interp/TranslateFacts.v
+++ b/theories/Interp/TranslateFacts.v
@@ -237,3 +237,18 @@ Proof.
   intros; unfold trigger; rewrite translate_vis; setoid_rewrite translate_ret; reflexivity.
 Qed.
 
+(** Inversion principles *)
+
+Lemma translate_Vis_inv {E F} {R T} (h: E ~> F) (t: itree E R) (e': F T) k':
+  translate h t ≅ Vis e' k' ->
+  exists (e: E T) k, t ≅ Vis e k /\ e' = h _ e /\ (forall x, k' x ≅ translate h (k x)).
+Proof.
+  intros. rewrite (itree_eta t) in H. setoid_rewrite (itree_eta t).
+  desobs t Ht; clear t Ht; rewrite unfold_translate in H; cbn in H.
+  - punfold H; red in H; inversion H.
+  - punfold H; red in H; inversion H; inversion CHECK.
+  - apply eqitree_inv_Vis_r in H. destruct H as [k'' [H1 H2]].
+    cbn in H1. dependent destruction H1.
+    exists e, k. split. reflexivity. split. reflexivity.
+    intro x. symmetry. eauto.
+Qed.

--- a/theories/Props/Finite.v
+++ b/theories/Props/Finite.v
@@ -5,6 +5,7 @@ From ITree Require Import
      ITree
      Basics.Tacs
      Eq.Eqit
+     Interp.TranslateFacts
      Leaf.
 From ITree.Events Require Import Nondeterminism Exception. (* For counterexamples *)
 
@@ -92,6 +93,13 @@ Proof.
 Qed.
 #[global] Hint Resolve all_finite_Vis : itree.
 
+Lemma all_finite_trigger : forall E R (e: E R),
+  all_finite (ITree.trigger e).
+Proof.
+  intros. apply all_finite_Vis. auto with itree.
+Qed.
+#[global] Hint Extern 1 (all_finite (trigger _)) => apply all_finite_trigger : itree.
+
 (* any_finite *)
 Lemma any_finite_Ret : forall E R a,
   @any_finite E R (Ret a).
@@ -115,6 +123,13 @@ Proof.
   intros; econstructor 3; [reflexivity | eauto].
 Qed.
 #[global] Hint Resolve any_finite_Vis : itree.
+
+Lemma any_finite_trigger : forall E R (e: E R) (r: R),
+  any_finite (ITree.trigger e).
+Proof.
+  intros. apply any_finite_Vis with (x := r). auto with itree.
+Qed.
+#[global] Hint Extern 1 (any_finite (trigger _)) => apply any_finite_trigger : itree.
 
 (** Inversion lemmas *)
 
@@ -435,6 +450,28 @@ Proof.
   - rewrite itree_eta, H in IN'; apply Leaf_Ret_inv in IN'; auto.
   - rewrite itree_eta, H, tau_eutt in IN'; eauto.
   - inv e.
+Qed.
+
+(** [translate] does not affect termination *)
+
+Lemma all_finite_translate {E F R}: forall (f: E ~> F) (t: itree E R),
+  all_finite t ->
+  all_finite (translate f t).
+Proof.
+  intros *; induction 1; rewrite unfold_translate, H; cbn.
+  - apply all_finite_Ret.
+  - apply all_finite_Tau. auto.
+  - apply all_finite_Vis. auto.
+Qed.
+
+Lemma any_finite_translate {E F R}: forall (f: E ~> F) (t: itree E R),
+  any_finite t ->
+  any_finite (translate f t).
+Proof.
+  intros *. induction 1; rewrite unfold_translate, H; cbn.
+  - apply any_finite_Ret.
+  - apply any_finite_Tau. auto.
+  - eapply any_finite_Vis. eauto.
 Qed.
 
 (** [spin] is not finite, in any sense of the term *)


### PR DESCRIPTION
General-purpose lemmas from building abstract interpreters. These are almost all lemmas about how existing constructions interact which each other or inversion principles. Not all are used in my codebase anymore, but I figure they're worth keeping around...

Changes:

- `Props/Leaf.v`:
  * Correspondence with `has_post`: `has_post_Leaf` and `has_post_Leaf_equiv`. These make `Props/Leaf.v` depend on `Props/HasPost.v`; not sure where else to put them to avoid that.
  * Inversion lemmas for iter based based on invariants of body's leaves: `Leaf_iter_inv`, `Leaf_interp_iter_inv`, and `Leaf_interp_state_iter_inv`. The state version is quite juicy because it requires re-phrasing relations.
  * "Neutrality" of `interp` for `Leaf`, ie. `x ∈ interp h t -> x ∈ t`. This needs a special induction on `t`. Two versions: `Leaf_interp_inv`, `Leaf_interp_state_inv`.
  * Same for `translate`: `Leaf_translate_inv`.
- `Props/Finite.v`:
  * `all_finite_trigger` (no hypothesis), `any_finite_trigger` (requires inhabitant).
  * `all_finite_translate`, `any_finite_translate`.
- `Core/Subevent.v`:
  * Global instance `void1 -< E`.
  * Simplification lemmas for `subevent ReSum_inl = inl1` and `subevent ReSum_inr = inr1`. These don't reduce with `cbn` (not sure why) so at least we can rewrite manually.
- `Eq/UpToTaus.v`:
  * Specialization of `eutt_eq_bind` for the equality relation: `eutt_eq_bind'`.
  * A result on swapping `RR` for a super-relation over the diagonal when dealing with `eutt RR t t`: `eutt_sub_self`.
- `Interp/InterpFacts.v`:
  * Variation of `interp_iter'` which uses `eutt` for the body and conclusion: `interp_iter'_eutt`.
  * `translate_iter` (not in `TranslateFacts` because uses the translate/interp correspondence).
- `Interp/StateFacts.v`:
  * Specialization of `eutt_interp_state_iter` for equality (`≈`), in a way that is suitable to rewrite `interp_state (iter ...)`: `eutt_eq_interp_state_iter`.
  * Variation of `interp_state_iter'` which uses `eutt` (instead of `state_eq` which is `eq_itree`): `interp_state_iter'_eutt`.
- `Interp/TranslateFacts.v`:
  * An inversion lemma: `translate_Vis_inv`. There could probably be more.
