### PR TITLE
[WIP] Consolidate monad definitions to extlib

### DIFF
--- a/theories/Basics/MonadProp.v
+++ b/theories/Basics/MonadProp.v
@@ -13,7 +13,6 @@ From ITree Require Import
      Basics.CategoryKleisli
      Basics.Monad.
 
-Import ITree.Basics.Basics.Monads.
 Import CatNotations.
 Local Open Scope cat_scope.
 Local Open Scope cat.

--- a/theories/Events/Dependent.v
+++ b/theories/Events/Dependent.v
@@ -14,13 +14,16 @@
  *)
 
 (* begin hide *)
+
+From ExtLib Require Import
+     Data.Monads.IdentityMonad.
+
 From ITree Require Import
      Basics.Basics
      Core.ITreeDefinition
      Indexed.Sum
      Core.Subevent.
 
-Import Basics.Basics.Monads.
 (* end hide *)
 
 Variant depE {I : Type} (F : I -> Type) : Type -> Type :=
@@ -32,8 +35,8 @@ Definition dep {I F E} `{depE F -< E} (i : I) : itree E (F i) :=
   trigger (Dep (F := F) i).
 
 Definition undep {I F} (f : forall i : I, F i) :
-  depE F ~> identity :=
+  depE F ~> ident :=
   fun _ d =>
     match d with
-    | Dep i => f i
+    | Dep i => mkIdent (f i)
     end.

--- a/theories/Events/FailFacts.v
+++ b/theories/Events/FailFacts.v
@@ -25,7 +25,6 @@ From ITree Require Import
      Interp.RecursionFacts.
 
 Import ITreeNotations.
-Import ITree.Basics.Basics.Monads.
 Local Open Scope itree_scope.
 
 Import Monads.

--- a/theories/Events/Map.v
+++ b/theories/Events/Map.v
@@ -9,6 +9,9 @@ Import ListNotations.
 
 From ExtLib.Structures Require Maps.
 
+From ExtLib Require Import
+     Data.Monads.StateMonad.
+
 From ITree Require Import
      Basics.Basics
      Basics.CategoryOps
@@ -19,7 +22,6 @@ From ITree Require Import
      Interp.Interp
      Events.State.
 
-Import ITree.Basics.Basics.Monads.
 (* end hide *)
 
 Section Map.
@@ -50,15 +52,17 @@ Section Map.
   Context {M : Map K V map}.
 
   Definition handle_map {E} : mapE ~> stateT map (itree E) :=
-    fun _ e env =>
+    fun _ e =>
       match e with
-      | Insert k v => Ret (Maps.add k v env, tt)
-      | Lookup k => Ret (env, Maps.lookup k env)
-      | Remove k => Ret (Maps.remove k env, tt)
+      | Insert k v => mkStateT (fun env => Ret (tt, Maps.add k v env))
+      | Lookup k => mkStateT (fun env => Ret (Maps.lookup k env, env))
+      | Remove k => mkStateT (fun env => Ret (tt, Maps.remove k env))
       end.
 
+  (* not sure why case_ requires manual parameters *)
   Definition run_map {E} : itree (mapE +' E) ~> stateT map (itree E) :=
-    interp_state (case_ handle_map pure_state).
+    interp_state (case_ (bif := sum1) (c := stateT map (itree E))
+                        handle_map pure_state).
 
 End Map.
 

--- a/theories/Events/StateFacts.v
+++ b/theories/Events/StateFacts.v
@@ -5,6 +5,8 @@ From Coq Require Import Program.Tactics Morphisms.
 
 From Paco Require Import paco.
 
+From ExtLib Require Import Data.Monads.StateMonad.
+
 From ITree Require Import
      Basics.Basics
      Basics.Category
@@ -27,41 +29,61 @@ Import ITreeNotations.
 
 Local Open Scope itree_scope.
 
-Import Monads.
 (* end hide *)
 
 Definition _interp_state {E F S R}
            (f : E ~> stateT S (itree F)) (ot : itreeF E R _)
-  : stateT S (itree F) R := fun s =>
+  : stateT S (itree F) R := mkStateT (fun s =>
   match ot with
-  | RetF r => Ret (s, r)
-  | TauF t => Tau (interp_state f t s)
-  | VisF e k => f _ e s >>= (fun sx => Tau (interp_state f (k (snd sx)) (fst sx)))
-  end.
+  | RetF r => Ret (r, s)
+  | TauF t => Tau (runStateT (interp_state f t) s)
+  | VisF e k => runStateT (f _ e) s >>= (fun xs => Tau (runStateT (interp_state f (k (fst xs))) (snd xs)))
+  end).
 
-Lemma unfold_interp_state {E F S R} (h : E ~> Monads.stateT S (itree F))
+Lemma unfold_interp_state {E F S R} (h : E ~> stateT S (itree F))
       (t : itree E R) s :
     eq_itree eq
-      (interp_state h t s)
-      (_interp_state h (observe t) s).
+      (runStateT (interp_state h t) s)
+      (runStateT (_interp_state h (observe t)) s).
 Proof.
-  unfold interp_state, interp, Basics.iter, MonadIter_stateT0, Basics.iter, MonadIter_itree; cbn.
+  unfold interp_state, interp, Basics.iter, MonadIter_stateT, Basics.iter, MonadIter_itree; cbn.
   rewrite unfold_iter; cbn.
   destruct observe; cbn.
   - rewrite 2 bind_ret_l. reflexivity.
   - rewrite 2 bind_ret_l.
     reflexivity.
-  - rewrite bind_map, bind_bind; cbn. setoid_rewrite bind_ret_l.
-    apply eqit_bind; reflexivity.
+  - rewrite 2 bind_bind; cbn.
+    apply eqit_bind; [reflexivity|].
+    intros [].
+    rewrite 2 bind_ret_l.
+    reflexivity.
+Qed.
+
+Definition eq_stateT {S M X Y}
+    (RM : forall R1 R2, (R1 -> R2 -> Prop) -> M R1 -> M R2 -> Prop)
+    (RXY : X * S -> Y * S -> Prop)
+  : (stateT S M X) -> (stateT S M Y) -> Prop :=
+  fun t1 t2 => forall s, RM _ _ RXY (runStateT t1 s) (runStateT t2 s).
+
+#[global]
+Instance eq_stateT_runStateT {S M R} 
+    (RM : forall R1 R2, (R1 -> R2 -> Prop) -> M R1 -> M R2 -> Prop) :
+  Proper (eq_stateT RM eq ==> eq ==> (RM _ _ eq)) (@runStateT S _ R).
+Proof.
+  unfold Proper, respectful.
+  intros x y Heq_stateT sx sy Heq.
+  specialize (Heq_stateT sy).
+  rewrite Heq.
+  apply Heq_stateT.
 Qed.
 
 #[global]
-Instance eq_itree_interp_state {E F S R} (h : E ~> Monads.stateT S (itree F)) :
-  Proper (eq_itree eq ==> eq ==> eq_itree eq)
+Instance eq_itree_interp_state {E F S R} (h : E ~> stateT S (itree F)) :
+  Proper (eq_itree eq ==> (eq_stateT (@eq_itree _) eq))
          (@interp_state _ _ _ _ _ _ h R).
 Proof.
   revert_until R.
-  ginit. pcofix CIH. intros h x y H0 x2 _ [].
+  ginit. pcofix CIH. intros h x y H0 s.
   rewrite !unfold_interp_state.
   punfold H0; repeat red in H0.
   destruct H0; subst; pclearbot; try discriminate; cbn.
@@ -73,31 +95,31 @@ Proof.
 Qed.
 
 Lemma interp_state_ret {E F : Type -> Type} {R S : Type}
-      (f : forall T, E T -> S -> itree F (S * T)%type)
+      (f : forall T, E T -> stateT S (itree F) T)
       (s : S) (r : R) :
-  (interp_state f (Ret r) s) ≅ (Ret (s, r)).
+  (runStateT (interp_state f (Ret r)) s) ≅ (Ret (r, s)).
 Proof.
   rewrite itree_eta. reflexivity.
 Qed.
 
 Lemma interp_state_vis {E F : Type -> Type} {S T U : Type}
-      (e : E T) (k : T -> itree E U) (h : E ~> Monads.stateT S (itree F)) (s : S)
-  : interp_state h (Vis e k) s
-  ≅ h T e s >>= fun sx => Tau (interp_state h (k (snd sx)) (fst sx)).
+      (e : E T) (k : T -> itree E U) (h : E ~> stateT S (itree F)) (s : S)
+  : runStateT (interp_state h (Vis e k)) s
+  ≅ runStateT (h T e) s >>= fun xs => Tau (runStateT (interp_state h (k (fst xs))) (snd xs)).
 Proof.
   rewrite unfold_interp_state; reflexivity.
 Qed.
 
 Lemma interp_state_tau {E F : Type -> Type} S {T : Type}
-      (t : itree E T) (h : E ~> Monads.stateT S (itree F)) (s : S)
-  : interp_state h (Tau t) s ≅ Tau (interp_state h t s).
+      (t : itree E T) (h : E ~> stateT S (itree F)) (s : S)
+  : runStateT (interp_state h (Tau t)) s ≅ Tau (runStateT (interp_state h t) s).
 Proof.
   rewrite unfold_interp_state; reflexivity.
 Qed.
 
 Lemma interp_state_trigger_eqit {E F : Type -> Type} {R S : Type}
-      (e : E R) (f : E ~> Monads.stateT S (itree F)) (s : S)
-  : (interp_state f (ITree.trigger e) s) ≅ (f _ e s >>= fun x => Tau (Ret x)).
+      (e : E R) (f : E ~> stateT S (itree F)) (s : S)
+  : (runStateT (interp_state f (ITree.trigger e)) s) ≅ (runStateT (f _ e) s >>= fun x => Tau (Ret x)).
 Proof.
   unfold ITree.trigger. rewrite interp_state_vis.
   eapply eqit_bind; try reflexivity.
@@ -105,8 +127,8 @@ Proof.
 Qed.
 
 Lemma interp_state_trigger {E F : Type -> Type} {R S : Type}
-      (e : E R) (f : E ~> Monads.stateT S (itree F)) (s : S)
-  : interp_state f (ITree.trigger e) s ≈ f _ e s.
+      (e : E R) (f : E ~> stateT S (itree F)) (s : S)
+  : runStateT (interp_state f (ITree.trigger e)) s ≈ runStateT (f _ e) s.
 Proof.
   unfold ITree.trigger. rewrite interp_state_vis.
   match goal with
@@ -118,12 +140,12 @@ Proof.
 Qed.
 
 Lemma interp_state_bind {E F : Type -> Type} {A B S : Type}
-      (f : forall T, E T -> S -> itree F (S * T)%type)
+      (f : forall T, E T -> stateT S (itree F) T)
       (t : itree E A) (k : A -> itree E B)
       (s : S) :
-  (interp_state f (t >>= k) s)
+  (runStateT (interp_state f (t >>= k)) s)
     ≅
-  (interp_state f t s >>= fun st => interp_state f (k (snd st)) (fst st)).
+  (runStateT (interp_state f t) s >>= fun ts => runStateT (interp_state f (k (fst ts))) (snd ts)).
 Proof.
   revert t k s.
   ginit. pcofix CIH.
@@ -131,11 +153,11 @@ Proof.
   rewrite unfold_bind.
   rewrite (unfold_interp_state f t).
   destruct (observe t).
-  - cbn. rewrite !bind_ret_l. cbn.
+  - cbn. rewrite bind_ret_l. cbn.
     apply reflexivity.
-  - cbn. rewrite !bind_tau, interp_state_tau.
+  - rewrite interp_state_tau. cbn. rewrite bind_tau.
     gstep. econstructor. gbase. apply CIH.
-  - cbn. rewrite interp_state_vis, bind_bind.
+  - rewrite interp_state_vis. cbn. rewrite bind_bind.
     guclo eqit_clo_bind. econstructor.
     + reflexivity.
     + intros u2 ? [].
@@ -147,14 +169,14 @@ Qed.
 
 #[global]
 Instance eutt_interp_state {E F: Type -> Type} {S : Type}
-         (h : E ~> Monads.stateT S (itree F)) R RR :
-  Proper (eutt RR ==> eq ==> eutt (prod_rel eq RR)) (@interp_state E (itree F) S _ _ _ h R).
+         (h : E ~> stateT S (itree F)) R RR :
+  Proper (eutt RR ==> eq_stateT (@eutt _) (prod_rel RR eq)) (@interp_state E (itree F) S _ _ _ h R).
 Proof.
   repeat intro. subst. revert_until RR.
   einit. ecofix CIH. intros.
 
   rewrite !unfold_interp_state. punfold H0. red in H0.
-  induction H0; intros; subst; simpl; pclearbot.
+  induction H0; intros; subst; pclearbot; cbn.
   - eret.
   - etau.
   - ebind. econstructor; [reflexivity|].
@@ -166,14 +188,14 @@ Qed.
 
 #[global]
 Instance eutt_interp_state_eq {E F: Type -> Type} {S : Type}
-         (h : E ~> Monads.stateT S (itree F)) R :
-  Proper (eutt eq ==> eq ==> eutt eq) (@interp_state E (itree F) S _ _ _ h R).
+         (h : E ~> stateT S (itree F)) R :
+  Proper (eutt eq ==> eq_stateT (@eutt _) eq) (@interp_state E (itree F) S _ _ _ h R).
 Proof.
   repeat intro. subst. revert_until R.
   einit. ecofix CIH. intros.
 
   rewrite !unfold_interp_state. punfold H0. red in H0.
-  induction H0; intros; subst; simpl; pclearbot.
+  induction H0; intros; subst; cbn; pclearbot.
   - eret.
   - etau.
   - ebind. econstructor; [reflexivity|].
@@ -187,17 +209,17 @@ Qed.
 Lemma eutt_interp_state_aloop {E F S I I' A A'}
       (RA : A -> A' -> Prop) (RI : I -> I' -> Prop)
       (RS : S -> S -> Prop)
-      (h : E ~> Monads.stateT S (itree F))
+      (h : E ~> stateT S (itree F))
       (t1 : I -> itree E (I + A))
       (t2 : I' -> itree E (I' + A')):
   (forall i i' s1 s2, RS s1 s2 -> RI i i' ->
-     eutt (prod_rel RS (sum_rel RI RA))
-                     (interp_state h (t1 i) s1)
-                     (interp_state h (t2 i') s2)) ->
+     eutt (prod_rel (sum_rel RI RA) RS)
+          (runStateT (interp_state h (t1 i)) s1)
+          (runStateT (interp_state h (t2 i')) s2)) ->
   (forall i i' s1 s2, RS s1 s2 -> RI i i' ->
-     eutt (fun a b => RS (fst a) (fst b) /\ RA (snd a) (snd b))
-          (interp_state h (ITree.iter t1 i) s1)
-          (interp_state h (ITree.iter t2 i') s2)).
+     eutt (fun a b => RA (fst a) (fst b) /\ RS (snd a) (snd b))
+          (runStateT (interp_state h (ITree.iter t1 i)) s1)
+          (runStateT (interp_state h (ITree.iter t2 i')) s2)).
 Proof.
   intro Ht.
   einit. ecofix CIH. intros.
@@ -205,43 +227,43 @@ Proof.
   rewrite 2 interp_state_bind.
   ebind; econstructor.
   - eapply Ht; auto.
-  - intros [s1' i1'] [s2' i2'] [? []]; cbn.
-    + rewrite 2 interp_state_tau. auto with paco.
-    + rewrite 2 interp_state_ret. auto with paco.
+  - intros [i1' s1'] [i2' s2'] [[] ?].
+    + rewrite 2 interp_state_tau. cbn. auto with paco.
+    + rewrite 2 interp_state_ret. cbn. auto with paco.
 Qed.
 
 Lemma eutt_interp_state_iter {E F S A A' B B'}
       (RA : A -> A' -> Prop) (RB : B -> B' -> Prop)
       (RS : S -> S -> Prop)
-      (h : E ~> Monads.stateT S (itree F))
+      (h : E ~> stateT S (itree F))
       (t1 : A -> itree E (A + B))
       (t2 : A' -> itree E (A' + B')) :
   (forall ca ca' s1 s2, RS s1 s2 ->
                         RA ca ca' ->
-     eutt (prod_rel RS (sum_rel RA RB))
-          (interp_state h (t1 ca) s1)
-          (interp_state h (t2 ca') s2)) ->
+     eutt (prod_rel (sum_rel RA RB) RS)
+          (runStateT (interp_state h (t1 ca)) s1)
+          (runStateT (interp_state h (t2 ca')) s2)) ->
   (forall a a' s1 s2, RS s1 s2 -> RA a a' ->
-     eutt (fun a b => RS (fst a) (fst b) /\ RB (snd a) (snd b))
-          (interp_state h (iter (C := ktree _) t1 a) s1)
-          (interp_state h (iter (C := ktree _) t2 a') s2)).
+     eutt (fun a b => RB (fst a) (fst b) /\ RS (snd a) (snd b))
+          (runStateT (interp_state h (iter (C := ktree _) t1 a)) s1)
+          (runStateT (interp_state h (iter (C := ktree _) t2 a')) s2)).
 Proof.
   apply eutt_interp_state_aloop.
 Qed.
 
 Lemma eutt_eq_interp_state_iter {E F S} (f: E ~> stateT S (itree F)) {I A}
     (t : I -> itree E (I + A)):
-  forall i s, interp_state f (ITree.iter t i) s ≈
-    Basics.iter (fun i => interp_state f (t i)) i s.
+  forall i s, runStateT (interp_state f (ITree.iter t i)) s ≈
+    runStateT (Basics.iter (fun i => interp_state f (t i)) i) s.
 Proof.
-  unfold Basics.iter, MonadIter_stateT0, Basics.iter, MonadIter_itree in *; cbn.
+  unfold Basics.iter, MonadIter_stateT, Basics.iter, MonadIter_itree in *. cbn.
   ginit. gcofix CIH; intros i s.
   rewrite 2 unfold_iter; cbn.
   rewrite !bind_bind.
   setoid_rewrite bind_ret_l.
   rewrite interp_state_bind.
   guclo eqit_clo_bind; econstructor; eauto. reflexivity.
-  intros [s' []] _ []; cbn.
+  intros [[] s'] _ []; cbn.
   - rewrite interp_state_tau.
     gstep; constructor.
     auto with paco.
@@ -249,16 +271,16 @@ Proof.
 Qed.
 
 Lemma eutt_interp_state_loop {E F S A B C} (RS : S -> S -> Prop)
-      (h : E ~> Monads.stateT S (itree F))
+      (h : E ~> stateT S (itree F))
       (t1 t2 : C + A -> itree E (C + B)) :
   (forall ca s1 s2, RS s1 s2 ->
-     eutt (fun a b => RS (fst a) (fst b) /\ snd a = snd b)
-          (interp_state h (t1 ca) s1)
-          (interp_state h (t2 ca) s2)) ->
+     eutt (fun a b => fst a = fst b /\ RS (snd a) (snd b))
+          (runStateT (interp_state h (t1 ca)) s1)
+          (runStateT (interp_state h (t2 ca)) s2)) ->
   (forall a s1 s2, RS s1 s2 ->
-     eutt (fun a b => RS (fst a) (fst b) /\ snd a = snd b)
-          (interp_state h (loop (C := ktree E) t1 a) s1)
-          (interp_state h (loop (C := ktree E) t2 a) s2)).
+     eutt (fun a b => fst a = fst b /\ RS (snd a) (snd b))
+          (runStateT (interp_state h (loop (C := ktree E) t1 a)) s1)
+          (runStateT (interp_state h (loop (C := ktree E) t2 a)) s2)).
 Proof.
   intros.
   unfold loop, bimap, Bimap_Coproduct, case_, Case_Kleisli, Function.case_sum, id_, Id_Kleisli, cat, Cat_Kleisli, inr_, Inr_Kleisli, inl_, Inl_Kleisli, lift_ktree_; cbn.
@@ -268,36 +290,31 @@ Proof.
   subst.
   eapply eutt_clo_bind; eauto.
   intros.
-  cbn in H2; destruct (snd u1); rewrite <- (proj2 H2).
+  cbn in H2; destruct (fst u1); rewrite <- (proj1 H2).
   - rewrite bind_ret_l, 2 interp_state_ret.
     pstep.
     constructor.
-    split; cbn; auto using (proj1 H2).
+    split; cbn; auto using (proj2 H2).
   - rewrite bind_ret_l, 2 interp_state_ret. pstep. constructor.
-    split; cbn; auto using (proj1 H2).
+    split; cbn; auto using (proj2 H2).
 Qed.
-
-(* SAZ: These are probably too specialized. *)
-Definition state_eq {E S X}
-  : (stateT S (itree E) X) -> (stateT S (itree E) X) -> Prop :=
-  fun t1 t2 => forall s, eq_itree eq (t1 s) (t2 s).
 
 Lemma interp_state_iter {E F } S (f : E ~> stateT S (itree F)) {I A}
       (t  : I -> itree E (I + A))
       (t' : I -> stateT S (itree F) (I + A))
-      (EQ_t : forall i, state_eq (State.interp_state f (t i)) (t' i))
-  : forall i, state_eq (State.interp_state f (ITree.iter t i))
+      (EQ_t : forall i, eq_stateT (@eq_itree _) eq (State.interp_state f (t i)) (t' i))
+  : forall i, eq_stateT (@eq_itree _) eq (State.interp_state f (ITree.iter t i))
                   (Basics.iter t' i).
 Proof.
-  unfold Basics.iter, MonadIter_stateT0, Basics.iter, MonadIter_itree in *; cbn.
-  ginit. pcofix CIH; intros i s.
+  unfold Basics.iter, MonadIter_stateT, Basics.iter, MonadIter_itree in *.
+  ginit. pcofix CIH; intros i s. cbn.
   rewrite 2 unfold_iter; cbn.
   rewrite !bind_bind.
   setoid_rewrite bind_ret_l.
   rewrite interp_state_bind.
   guclo eqit_clo_bind; econstructor; eauto.
   - apply EQ_t.
-  - intros [s' []] _ []; cbn.
+  - intros [[] s'] _ []; cbn.
     + rewrite interp_state_tau.
       gstep; constructor.
       auto with paco.
@@ -306,7 +323,7 @@ Qed.
 
 Lemma interp_state_iter' {E F } S (f : E ~> stateT S (itree F)) {I A}
       (t  : I -> itree E (I + A))
-  : forall i, state_eq (State.interp_state f (ITree.iter t i))
+  : forall i, eq_stateT (@eq_itree _) eq (State.interp_state f (ITree.iter t i))
                        (Basics.iter (fun i => State.interp_state f (t i)) i).
 Proof.
   eapply interp_state_iter.
@@ -317,10 +334,10 @@ Qed.
 Lemma interp_state_iter'_eutt {E F S} (f: E ~> stateT S (itree F)) {I A}
     (t : I -> itree E (I + A))
     (t': I -> stateT S (itree F) (I + A))
-    (Heq: forall i s, interp_state f (t i) s ≈ (t' i) s):
-  forall i s, interp_state f (ITree.iter t i) s ≈ Basics.iter t' i s.
+    (Heq: forall i s, runStateT (interp_state f (t i)) s ≈ runStateT (t' i) s):
+  forall i s, runStateT (interp_state f (ITree.iter t i)) s ≈ runStateT (Basics.iter t' i) s.
 Proof.
-  unfold Basics.iter, MonadIter_stateT0, Basics.iter, MonadIter_itree in *; cbn.
+  unfold Basics.iter, MonadIter_stateT, Basics.iter, MonadIter_itree in *; cbn.
   ginit. gcofix CIH; intros i s.
   rewrite 2 unfold_iter; cbn.
   rewrite !bind_bind.
@@ -328,7 +345,7 @@ Proof.
   rewrite interp_state_bind.
   guclo eqit_clo_bind; econstructor; eauto.
   - apply Heq.
-  - intros [s' []] _ []; cbn.
+  - intros [[] s'] _ []; cbn.
     + rewrite interp_state_tau.
       gstep; constructor.
       auto with paco.

--- a/theories/Interp/Handler.v
+++ b/theories/Interp/Handler.v
@@ -18,8 +18,6 @@ From ITree Require Import
      Interp.Interp
      Interp.Recursion.
 
-Import ITree.Basics.Basics.Monads.
-
 Local Open Scope itree_scope.
 
 (* end hide *)

--- a/theories/Interp/HandlerFacts.v
+++ b/theories/Interp/HandlerFacts.v
@@ -22,7 +22,6 @@ From ITree Require Import
      Interp.RecursionFacts.
 
 Import ITreeNotations.
-Import ITree.Basics.Basics.Monads.
 
 Local Open Scope itree_scope.
 


### PR DESCRIPTION
Removes the monad definitions in `theories/Basics/Basics.v`, and adapts all uses of `stateT` and `writerT` to instead use the ones defined in the extlib.

## TODO:
* update `theories/Events/FailFacts.v` to use `optionT` from the extlib.
* update `extra/`
* update `tests/`
* update `examples/`
* update `tutorial/`

The changes are currently very not-backwards-compatible. I'm not entirely sure if it is possible to make them backwards compatible without copying every single lemma that uses the monads.

Closes #258 