### PR TITLE
Updates for Paco v4.2.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ commands:
 defaults: &defaults
   environment:
     OPAMBESTEFFORT: true
-    OPAMJOBS: 4
+    OPAMJOBS: 2
     OPAMVERBOSE: 1
     OPAMWITHTEST: true
     OPAMYES: true

--- a/coq-itree.opam
+++ b/coq-itree.opam
@@ -21,7 +21,7 @@ depends: [
   "dune" {>= "3.14"}
   "coq" {>= "8.13"}
   "coq-ext-lib" {>= "0.11.1"}
-  "coq-paco" {>= "4.0.1"}
+  "coq-paco" {>= "4.2.1"}
   "odoc" {with-doc}
 ]
 build: [

--- a/dune-project
+++ b/dune-project
@@ -12,7 +12,7 @@
   (depends
     (coq (>= 8.13))
     (coq-ext-lib (>= 0.11.1))
-    (coq-paco (>= 4.0.1)))
+    (coq-paco (>= 4.2.1)))
   (tags ("org:deepspec"))
   (authors
     "Li-yao Xia"

--- a/extra/Dijkstra/ITreeDijkstra.v
+++ b/extra/Dijkstra/ITreeDijkstra.v
@@ -260,7 +260,7 @@ Section ITreeDijkstra.
     intros s1 s2 H12 H. pfold. red. punfold H. red in H.
     punfold H12. red in H12. inversion H12; subst; auto.
     - rewrite <- H1 in H. inversion H.
-    - inversion H. subst. pclearbot. destruct H2; [ | contradiction ].
+    - inversion H. subst. pclearbot.
       constructor. right. eapply CIH; eauto.
       rewrite <- H3 in H0. injection H0 as H0 . subst. auto.
   Qed.

--- a/extra/ITrace/ITracePreds.v
+++ b/extra/ITrace/ITracePreds.v
@@ -166,7 +166,6 @@ Section StateMachine.
     - remember (VisF (evans A e a) k ) as ot1. induction Heutt; subst; auto with itree; try discriminate.
       injection Heqot1; intros; subst. dependent destruction H1.
       subst. constructor; auto. right. pclearbot. eapply CIH; eauto with itree.
-      destruct H0; tauto.
   Qed.
 
   #[global] Instance state_machine_proper_eutt {PEv PRet} : Proper (eutt eq ==> iff) (@state_machine PEv PRet).


### PR DESCRIPTION
- Removed workaround code for a bug in `pclearbot`.
- The workaround is no longer necessary as the underlying bug has been fixed in Paco v4.2.1.