### PR TITLE
 Updates for Paco v4.2.3

### DIFF
--- a/extra/ITrace/ITraceBind.v
+++ b/extra/ITrace/ITraceBind.v
@@ -195,7 +195,7 @@ Proof.
         intros. inversion H1. ddestruction.
         apply H0 in H1. pclearbot. unfold id. right. eapply CIH.
         red in x1. cbn in x1. inversion x1. ddestruction.
-        red in H0. specialize (H0 tt a (rar _ _ _)).
+        specialize (H0 tt a (rar _ _ _)).
         specialize (REL0 a). pclearbot.
         change (paco2 ?x ?y ?t ?u) with (eq_itree eq t u) in REL0.
         rewrite REL0. apply H0.

--- a/extra/ITrace/ITraceFacts.v
+++ b/extra/ITrace/ITraceFacts.v
@@ -509,8 +509,7 @@ Proof.
     inversion H; subst; ddestruction; try contradiction. destruct b0.
     eapply CIH; try apply H3.
     specialize (H1 tt a). assert (RAnsRef _ _ _ (evans B e2 a) tt e2 a ).
-    constructor. apply H1 in H0. unfold id in H0.
-    destruct H0; try contradiction. eauto.
+    constructor. apply H1 in H0. eauto.
   - rewrite <- x. constructor. left.  pfold. eapply IHruttF; eauto.
   - eapply IHruttF; auto. rewrite <- x in H0. inv H0.
     pclearbot. punfold H2.
@@ -552,7 +551,6 @@ Proof.
     intros.
     rewrite <- x0 in H0. inv H0. ddestruction. subst. pclearbot.
     apply H1 in H2. right. eapply CIH; eauto; try apply H4.
-    unfold id in H2. pclearbot. auto.
   - unfold observe at 1. cbn. rewrite <- x. cbn. constructor.
     eapply IHruttF; eauto. rewrite <- x in H0. inv H0. pclearbot. pstep_reverse.
   - unfold observe at 2. cbn. rewrite <- x. cbn. constructor.


### PR DESCRIPTION
- Paco v4.2.3 fixes a bug in pclearbot, which now works better under binders
- This is an update for Paco v4.2.3